### PR TITLE
hvsock: don't fail even if the error is unexpected

### DIFF
--- a/src/com.docker.slirp.exe/src/main.ml
+++ b/src/com.docker.slirp.exe/src/main.ml
@@ -77,7 +77,7 @@ let hvsock_connect_forever url sockaddr callback =
           Lwt_unix.sleep 1.
         | e ->
           Log.err (fun f -> f "hvsock connect raised %s" (Printexc.to_string e));
-          Lwt.fail e
+          Lwt_unix.sleep 1.
       )
     >>= fun () ->
     aux () in


### PR DESCRIPTION
The ocaml-hvsock bindings are returning an error like

 Failure("Unix.Unix_error(Unix.ECONNABORTED..."

which is obviously a bug in the bindings, but we shouldn't let this take
down the whole server.

Signed-off-by: David Scott dave.scott@docker.com
