### PR TITLE
DNS: don't attempt to look up localhost.local

### DIFF
--- a/src/hostnet/host_lwt_unix.ml
+++ b/src/hostnet/host_lwt_unix.ml
@@ -812,9 +812,14 @@ module Dns = struct
       | _ -> acc
     ) [] x
 
+  let localhost_local = Dns.Name.of_string "localhost.local"
+
   let resolve question =
     let open Dns.Packet in
     begin match question with
+      | { q_class = Q_IN; q_name; _ } when q_name = localhost_local ->
+        Log.debug (fun f -> f "DNS lookup of localhost.local: return NXDomain");
+        Lwt.return (q_name, [])
       | { q_class = Q_IN; q_type = Q_A; q_name; _ } ->
         getaddrinfo (Dns.Name.to_string q_name) Unix.PF_INET
         >>= fun ips ->

--- a/src/hostnet/hostnet_dns.mli
+++ b/src/hostnet/hostnet_dns.mli
@@ -8,6 +8,7 @@ module Config: sig
     | `Host (** use the host's resolver *)
   ]
   val to_string: t -> string
+  val compare: t -> t -> int
 end
 
 module Make

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -613,6 +613,10 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
 
   module Debug = struct
     let get_nat_table_size t = Udp_nat.get_nat_table_size t.udp_nat
+
+    let update_dns () =
+      let local_address = { Dns_forward.Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 0 } in
+      dns := Dns_forwarder.create ~local_address (Dns_policy.config ());
   end
 
   (* If no traffic is received for 5 minutes, delete the endpoint and

--- a/src/hostnet/slirp.mli
+++ b/src/hostnet/slirp.mli
@@ -52,6 +52,9 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
   module Debug: sig
     val get_nat_table_size: t -> int
     (** Return the number of active NAT table entries *)
+
+    val update_dns: unit -> unit
+    (** Update the DNS forwarder following a configuration change *)
   end
 end
 

--- a/src/hostnet_test/suite.ml
+++ b/src/hostnet_test/suite.ml
@@ -13,6 +13,7 @@ let run ?(timeout=60.) t =
   let timeout = Host.Time.sleep timeout >>= fun () -> Lwt.fail (Failure "timeout") in
   Host.Main.run @@ Lwt.pick [ timeout; t ]
 
+module Dns_policy = Slirp_stack.Dns_policy
 module Slirp_stack = Slirp_stack.Make(Host)
 open Slirp_stack
 
@@ -26,7 +27,13 @@ let test_dhcp_query () =
       ) in
   run t
 
-let test_dns_query server () =
+let set_dns_policy use_host =
+  Dns_policy.remove ~priority:3;
+  Dns_policy.add ~priority:3 ~config:(if use_host then `Host else Dns_policy.google_dns);
+  Slirp_stack.Debug.update_dns ()
+
+let test_dns_query server use_host () =
+  set_dns_policy use_host;
   let t =
     with_stack
       (fun _ stack ->
@@ -45,7 +52,8 @@ let test_dns_query server () =
 (* `docker push` will attempt to resolve `localhost.local` if the host has
    domain set to `local` which is common on Macs. We don't want this query to
    take 5s to fail. *)
-let test_localhost_local_query server () =
+let test_localhost_local_query server use_host () =
+  set_dns_policy use_host;
   let t =
     with_stack
       (fun _ stack ->
@@ -67,7 +75,8 @@ let test_localhost_local_query server () =
       ) in
   run t
 
-let test_etc_hosts_query server () =
+let test_etc_hosts_query server use_host () =
+  set_dns_policy use_host;
   let test_name = "vpnkit.is.cool.yes.really" in
   let t =
     with_stack
@@ -306,12 +315,13 @@ let test_dhcp = [
   "Simple query", `Quick, test_dhcp_query;
 ]
 
-let test_dns = [
-  "Use 8.8.8.8 to lookup www.google.com", `Quick, test_dns_query primary_dns_ip;
-  "Service a query from /etc/hosts cache", `Quick, test_etc_hosts_query primary_dns_ip;
-  "Check that localhost.local fails fast", `Quick, test_localhost_local_query primary_dns_ip;
+let test_dns use_host =
+  let descr = if use_host then "local Host resolver" else "Google via 8.8.8.8" in [
+  "Use " ^ descr ^ " to lookup www.google.com", `Quick, test_dns_query primary_dns_ip use_host;
+  "Service a query from /etc/hosts cache", `Quick, test_etc_hosts_query primary_dns_ip use_host;
+  "Check that localhost.local fails fast via " ^ descr, `Quick, test_localhost_local_query primary_dns_ip use_host;
 ] @ (List.map (fun ip ->
-  "Use 8.8.8.8 to lookup www.google.com via " ^ (Ipaddr.V4.to_string ip), `Quick, test_dns_query ip;
+  "Use " ^ descr ^ " to lookup www.google.com via " ^ (Ipaddr.V4.to_string ip), `Quick, test_dns_query ip use_host;
   ) extra_dns_ip
 )
 
@@ -335,7 +345,8 @@ module N = Test_nat.Make(Host)
 let suite = Hosts_test.suite @ [
   "Forwarding", F.test;
   "DHCP", test_dhcp;
-  "DNS UDP", test_dns;
+  "DNS UDP via Host", test_dns true;
+  "DNS UDP via Google", test_dns false;
   "TCP", test_tcp;
   "UDP", N.suite;
 ]


### PR DESCRIPTION
When performing a `docker push` to `localhost`, `docker` will look up both `localhost` and `localhost.local`. Unfortunately the Mac will seriously attempt to look up `localhost.local` using mDNS which takes several seconds to timeout.

This patch special-cases `localhost.local`, making it always return a failure. This allows lookups of other .local names to continue working.

Related to docker/for-mac#1536

Signed-off-by: David Scott <dave.scott@docker.com>