### PR TITLE
DNS: don't use mDNS at all

### DIFF
--- a/src/hostnet/host_uwt.ml
+++ b/src/hostnet/host_uwt.ml
@@ -950,13 +950,16 @@ module Dns = struct
         | _ -> acc
       ) [] x
 
-  let localhost_local = Dns.Name.of_string "localhost.local"
+  let is_mdns name =
+    match List.rev @@ Dns.Name.to_string_list name with
+    | [] -> false
+    | n :: _ -> n = "local"
 
   let resolve_getaddrinfo question =
     let open Dns.Packet in
     begin match question with
-      | { q_class = Q_IN; q_name; _ } when q_name = localhost_local ->
-        Log.debug (fun f -> f "DNS lookup of localhost.local: return NXDomain");
+      | { q_class = Q_IN; q_name; _ } when is_mdns q_name ->
+        Log.debug (fun f -> f "DNS lookup of %s: return NXDomain" (Dns.Name.to_string q_name));
         Lwt.return (q_name, [])
       | { q_class = Q_IN; q_type = Q_A; q_name; _ } ->
         getaddrinfo (Dns.Name.to_string q_name) Unix.PF_INET
@@ -1007,8 +1010,8 @@ module Dns = struct
           ) (Ok rrs) cnames in
 
     begin match question with
-      | { q_class = Q_IN; q_name; _ } when q_name = localhost_local ->
-        Log.debug (fun f -> f "DNS lookup of localhost.local: return NXDomain");
+      | { q_class = Q_IN; q_name; _ } when is_mdns q_name ->
+        Log.debug (fun f -> f "DNS lookup of %s: return NXDomain" (Dns.Name.to_string q_name));
         Lwt.return []
       | { q_class = Q_IN; q_type; q_name; _ } ->
         begin


### PR DESCRIPTION
Currently a query for `foo.local` can use the host resolver and this may involve real mDNS, which can be very slow. At the moment our current client (linuxkit, previously known as Moby) has a domain name set to `local` which causes lots of lookups of `foo.local` names which don't exist, which each incur a ~5s timeout.

This patch returns `NXDomain` for all lookups of `*.local` for now.

Signed-off-by: David Scott <dave.scott@docker.com>