### PR TITLE
Improve the error handling in port forwarding

### DIFF
--- a/repo/darwin/packages/local/slirp.local/opam
+++ b/repo/darwin/packages/local/slirp.local/opam
@@ -8,7 +8,7 @@ depends: [
   "result"
   "tar-format" {= "0.6.1"}
   "ipaddr"
-  "lwt"
+  "lwt" { < "3.0.0" }
   "uwt" {>= "0.0.4"}
   "tcpip" { = "999" }
   "pcap-format"

--- a/src/bin/jbuild
+++ b/src/bin/jbuild
@@ -6,4 +6,3 @@
    ))
    (preprocess  no_preprocessing)
 ))
-

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -224,6 +224,8 @@ let main_t socket_url port_control_url introspection_url diagnostics_url max_con
   Log.info (fun f -> f "vpnkit version %s with hostnet version %s %s uwt version %s hvsock version %s %s"
     Depends.version Depends.hostnet_version Depends.hostnet_pinned Depends.uwt_version Depends.hvsock_version Depends.hvsock_pinned
   );
+  Log.info (fun f -> f "System SOMAXCONN is %d" Utils.somaxconn);
+
   Printexc.record_backtrace true;
 
   ( match dns with

--- a/src/hostnet/host_lwt_unix.ml
+++ b/src/hostnet/host_lwt_unix.ml
@@ -556,7 +556,7 @@ module Stream = struct
                 (fun () ->
                   Lwt.finalize
                     (fun () ->
-                      Lwt_unix.listen fd 32;
+                      Lwt_unix.listen fd Utils.somaxconn;
                       loop fd
                     ) (fun () ->
                       shutdown server

--- a/src/hostnet/host_lwt_unix.ml
+++ b/src/hostnet/host_lwt_unix.ml
@@ -35,15 +35,9 @@ let next_connection_idx =
 exception Too_many_connections
 
 let connection_table = Hashtbl.create 511
-let connections =
-  Vfs.Dir.of_list
-    (fun () ->
-      Vfs.ok (
-        Hashtbl.fold
-          (fun _ c acc -> Vfs.Inode.dir c Vfs.Dir.empty :: acc)
-          connection_table []
-      )
-    )
+let connections () =
+  let xs = Hashtbl.fold (fun _ c acc -> c :: acc) connection_table [] in
+  Vfs.File.ro_of_string @@ String.concat "\n" xs
 let register_connection_no_limit description =
   let idx = next_connection_idx () in
   Hashtbl.replace connection_table idx description;

--- a/src/hostnet/host_uwt.ml
+++ b/src/hostnet/host_uwt.ml
@@ -150,7 +150,8 @@ module Sockets = struct
           )
           (fun e ->
              deregister_connection idx;
-             Uwt.Udp.close_wait fd
+             log_exception_continue "Udp.connect Uwt.Udp.close_wait"
+               (fun () -> Uwt.Udp.close_wait fd)
              >>= fun () ->
              errorf "Socket.%s.connect %s: caught %s" label description (Printexc.to_string e)
           )
@@ -206,7 +207,8 @@ module Sockets = struct
         | Some fd ->
           t.fd <- None;
           Log.debug (fun f -> f "Socket.%s.close: %s" t.label (string_of_flow t));
-          Uwt.Udp.close_wait fd
+          log_exception_continue "Udp.close Uwt.Udp.close_wait"
+            (fun () -> Uwt.Udp.close_wait fd)
           >>= fun () ->
           (match t.idx with Some idx -> deregister_connection idx | None -> ());
           Lwt.return_unit
@@ -275,7 +277,8 @@ module Sockets = struct
       let shutdown server =
         if not server.closed then begin
           server.closed <- true;
-          Uwt.Udp.close_wait server.fd
+          log_exception_continue "Udp.shutdown Uwt.Udp.close_wait"
+            (fun () -> Uwt.Udp.close_wait server.fd)
           >>= fun () ->
           deregister_connection server.idx;
           Lwt.return_unit
@@ -383,7 +386,8 @@ module Sockets = struct
           )
           (fun e ->
              deregister_connection idx;
-             Uwt.Tcp.close_wait fd
+             log_exception_continue "Tcp.connect Uwt.Tcp.close_wait"
+               (fun () -> Uwt.Tcp.close_wait fd)
              >>= fun () ->
              errorf "Socket.%s.connect %s: caught %s" label description (Printexc.to_string e)
           )
@@ -472,7 +476,8 @@ module Sockets = struct
       let close t =
         if not t.closed then begin
           t.closed <- true;
-          Uwt.Tcp.close_wait t.fd
+          log_exception_continue "Tcp.close Uwt.Tcp.close_wait"
+            (fun () -> Uwt.Tcp.close_wait t.fd)
           >>= fun () ->
           deregister_connection t.idx;
           Lwt.return ()
@@ -562,7 +567,8 @@ module Sockets = struct
         let fds = server.listening_fds in
         server.listening_fds <- [];
         Lwt_list.iter_s (fun (idx, fd) ->
-          Uwt.Tcp.close_wait fd
+          log_exception_continue "Tcp.shutdown: Uwt.Tcp.close_wait"
+            (fun () -> Uwt.Tcp.close_wait fd)
           >>= fun () ->
           deregister_connection idx;
           Lwt.return_unit
@@ -612,7 +618,8 @@ module Sockets = struct
                              >>= fun idx ->
                              Lwt.return (Some (of_fd ~idx ~label ~description client))
                            ) (fun _e ->
-                             Uwt.Tcp.close_wait client
+                             log_exception_continue "Tcp.listen Uwt.Tcp.close_wait"
+                               (fun () -> Uwt.Tcp.close_wait client)
                              >>= fun () ->
                              Lwt.return_none
                            )
@@ -752,7 +759,8 @@ module Sockets = struct
       let close t =
         if not t.closed then begin
           t.closed <- true;
-          Uwt.Pipe.close_wait t.fd
+          log_exception_continue "Unix.close Uwt.Pipe.close_wait"
+            (fun () -> Uwt.Pipe.close_wait t.fd)
           >>= fun () ->
           deregister_connection t.idx;
           Lwt.return ()
@@ -813,7 +821,8 @@ module Sockets = struct
                         >>= fun idx ->
                         Lwt.return (Some (of_fd ~idx ~description client))
                       ) (fun _e ->
-                        Uwt.Pipe.close_wait client
+                        log_exception_continue "Unix.listen Uwt.Pipe.close_wait"
+                          (fun () -> Uwt.Pipe.close_wait client)
                         >>= fun () ->
                         Lwt.return_none
                       )
@@ -849,7 +858,8 @@ module Sockets = struct
       let shutdown server =
         if not server.closed then begin
           server.closed <- true;
-          Uwt.Pipe.close_wait server.fd
+          log_exception_continue "Unix.shutdown Uwt.Pipe.close_wait"
+            (fun () -> Uwt.Pipe.close_wait server.fd)
           >>= fun () ->
           deregister_connection server.idx;
           Lwt.return_unit

--- a/src/hostnet/host_uwt.ml
+++ b/src/hostnet/host_uwt.ml
@@ -69,15 +69,9 @@ module Sockets = struct
   exception Too_many_connections
 
   let connection_table = Hashtbl.create 511
-  let connections =
-    Vfs.Dir.of_list
-      (fun () ->
-        Vfs.ok (
-          Hashtbl.fold
-            (fun _ c acc -> Vfs.Inode.dir c Vfs.Dir.empty :: acc)
-            connection_table []
-        )
-      )
+  let connections () =
+    let xs = Hashtbl.fold (fun _ c acc -> c :: acc) connection_table [] in
+    Vfs.File.ro_of_string @@ String.concat "\n" xs
   let register_connection_no_limit description =
     let idx = next_connection_idx () in
     Hashtbl.replace connection_table idx description;

--- a/src/hostnet/host_uwt.ml
+++ b/src/hostnet/host_uwt.ml
@@ -586,7 +586,7 @@ module Sockets = struct
       let listen server' cb =
         List.iter
           (fun (_, fd) ->
-             let listen_result = Uwt.Tcp.listen fd ~max:32 ~cb:(fun server x ->
+             let listen_result = Uwt.Tcp.listen fd ~max:Utils.somaxconn ~cb:(fun server x ->
                  if Uwt.Int_result.is_error x then
                    Log.err (fun f -> f "Uwt.Tcp.listen callback failed with: %s" (Uwt.strerror @@ Uwt.Int_result.to_error x))
                  else
@@ -801,7 +801,7 @@ module Sockets = struct
         server.disable_connection_tracking <- true
 
       let listen ({ fd; _ } as server') cb =
-        let listen_result = Uwt.Pipe.listen fd ~max:5 ~cb:(fun server x ->
+        let listen_result = Uwt.Pipe.listen fd ~max:Utils.somaxconn ~cb:(fun server x ->
           if Uwt.Int_result.is_error x then
             Log.err (fun f -> f "Uwt.Pipe.listen callback failed with: %s" (Uwt.strerror @@ Uwt.Int_result.to_error x))
           else

--- a/src/hostnet/jbuild
+++ b/src/hostnet/jbuild
@@ -9,6 +9,6 @@
     lwt.preemptive threads astring datakit-server.vfs dns-forward tar mirage-vnetif
     dnssd uuidm
    ))
+   (c_names (stubs_utils))
    (wrapped false)
 ))
-

--- a/src/hostnet/mux.ml
+++ b/src/hostnet/mux.ml
@@ -62,16 +62,12 @@ module Make(Netif: V1_LWT.NETWORK) = struct
   }
 
   let filesystem t =
-    Vfs.Dir.of_list
-      (fun () ->
-        Vfs.ok (
-          RuleMap.fold
-            (fun ip t acc ->
-              let txt = Printf.sprintf "%s last_active_time = %.1f" (Ipaddr.V4.to_string ip) t.last_active_time in
-               Vfs.Inode.dir txt Vfs.Dir.empty :: acc)
-            t.rules []
-        )
-      )
+    let xs =
+      RuleMap.fold
+        (fun ip t acc ->
+          Printf.sprintf "%s last_active_time = %.1f" (Ipaddr.V4.to_string ip) t.last_active_time :: acc
+        ) t.rules [] in
+    Vfs.File.ro_of_string @@ String.concat "\n" xs
 
   let remove t rule =
     Log.debug (fun f -> f "removing switch port for %s" (Ipaddr.V4.to_string rule));

--- a/src/hostnet/mux.mli
+++ b/src/hostnet/mux.mli
@@ -31,6 +31,6 @@ module Make(Netif: V1_LWT.NETWORK) : sig
   val remove: t -> rule -> unit
   (** Given a rule, remove the associated port if one exists *)
 
-  val filesystem: t -> Vfs.Dir.t
+  val filesystem: t -> Vfs.File.t
   (** A virtual filesystem for debugging *)
 end

--- a/src/hostnet/sig.ml
+++ b/src/hostnet/sig.ml
@@ -67,7 +67,7 @@ module type SOCKETS = sig
   (** TODO: hide these by refactoring Hyper-V sockets stuff *)
   val register_connection: string -> int Lwt.t
   val deregister_connection: int -> unit
-  val connections: Vfs.Dir.t
+  val connections: unit -> Vfs.File.t
   (** A filesystem which allows the connections to be introspected *)
 
   module Datagram: sig

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -557,6 +557,7 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
         Lwt.return_unit in
 
     let rec tar pwd dir =
+      let mod_time = Int64.of_float @@ Host.Clock.time () in
       Vfs.Dir.ls dir
       >>?= fun inodes ->
       Lwt_list.iter_s
@@ -588,7 +589,7 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
             copy ()
             >>= fun fragments ->
             let length = List.fold_left (+) 0 (List.map Cstruct.len fragments) in
-            let header = Tar.Header.make (Filename.concat pwd @@ Vfs.Inode.basename inode) (Int64.of_int length) in
+            let header = Tar.Header.make ~file_mode:0o0644 ~mod_time (Filename.concat pwd @@ Vfs.Inode.basename inode) (Int64.of_int length) in
             Writer.write header c
             >>= fun () ->
             List.iter (C.write_buffer c) fragments;

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -540,7 +540,7 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
       (fun () ->
          Vfs.ok [
            (* could replace "connections" with "flows" *)
-           Vfs.Inode.dir "connections" Host.Sockets.connections;
+           Vfs.Inode.file "connections" (Host.Sockets.connections ());
            Vfs.Inode.dir "capture" @@ Netif.filesystem t.interface;
            Vfs.Inode.dir "flows" Tcp.Flow.filesystem;
            Vfs.Inode.dir "endpoints" endpoints;

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -534,7 +534,7 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
            Vfs.Inode.dir "capture" @@ Netif.filesystem t.interface;
            Vfs.Inode.file "flows" (Tcp.Flow.filesystem ());
            Vfs.Inode.file "endpoints" endpoints;
-           Vfs.Inode.dir "ports" @@ Switch.filesystem t.switch;
+           Vfs.Inode.file "ports" @@ Switch.filesystem t.switch;
          ]
       )
 

--- a/src/hostnet/stubs_utils.c
+++ b/src/hostnet/stubs_utils.c
@@ -1,0 +1,20 @@
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/custom.h>
+#include <caml/callback.h>
+#include <caml/alloc.h>
+
+#include <stdio.h>
+
+#ifdef WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <sys/socket.h>
+#endif
+
+CAMLprim value stub_get_SOMAXCONN(){
+  fprintf(stderr, "SOMAXCONN = %d\n", SOMAXCONN);
+  return (Val_int (SOMAXCONN));
+}

--- a/src/hostnet/utils.ml
+++ b/src/hostnet/utils.ml
@@ -1,0 +1,4 @@
+
+external get_SOMAXCONN: unit -> int = "stub_get_SOMAXCONN"
+
+let somaxconn = get_SOMAXCONN ()

--- a/src/hostnet/utils.mli
+++ b/src/hostnet/utils.mli
@@ -1,0 +1,2 @@
+
+val somaxconn: int


### PR DESCRIPTION
- Previously we would close `Uwt` connections asynchronously. Switch from `close` to `close_wait` to clean up as much stuff as possible between connections.
- In some error cases we printed to stdout. Switch to using the logging system.
- Catch and log any stray exceptions in the `listen` callbacks, just in case
- Discover and use `SOMAXCONN` rather than the hardcoded values `32` and `5`
- Re-add missing diagnostic data to the `.tar` and tidy up the file modes and times.