### PR TITLE
Add `value` parameter to SOMAXCONN binding

### DIFF
--- a/src/hostnet/stubs_utils.c
+++ b/src/hostnet/stubs_utils.c
@@ -14,7 +14,7 @@
 #include <sys/socket.h>
 #endif
 
-CAMLprim value stub_get_SOMAXCONN(){
+CAMLprim value stub_get_SOMAXCONN(value unit){
   fprintf(stderr, "SOMAXCONN = %d\n", SOMAXCONN);
   return (Val_int (SOMAXCONN));
 }


### PR DESCRIPTION
Problem spotted by yallop in
https://github.com/moby/vpnkit/commit/8d718125a66fbe746ba17ad3e85b7924ac0ed9a4#commitcomment-21930309

Signed-off-by: David Scott <dave.scott@docker.com>