### PR TITLE
Update the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,4 @@ Design
 ------
 
 - [Using vpnkit as a default gateway](docs/ethernet.md): describes the flow of ethernet traffic to/from the VM
-- [DNS](docs/DNS.md): describes the DNS forwarder implementation
+- [Port forwarding](docs/ports.md): describes how ports are forwarded from the host into the VM

--- a/README.md
+++ b/README.md
@@ -61,5 +61,5 @@ traffic without requiring low-level Ethernet bridging support.
 Design
 ------
 
-- [ethernet](docs/ethernet.md): describes the flow of ethernet traffic to/from the VM
+- [Using vpnkit as a default gateway](docs/ethernet.md): describes the flow of ethernet traffic to/from the VM
 - [DNS](docs/DNS.md): describes the DNS forwarder implementation

--- a/docs/ethernet.md
+++ b/docs/ethernet.md
@@ -15,12 +15,24 @@ interface inside the VM. The virtual hardware implementation connects to
 `vpnkit` on the host over a Unix domain socket and encapsulates frames using a
 simple custom protocol.
 
+![Mac plumbing diagram](http://moby.github.io/vpnkit/mac.png)
+
 ## Inside Docker for Windows
 
 The Docker for Windows VM is running on top of Hyper-V. `vpnkit` on the host
 uses Hyper-V sockets to connect to a process inside the VM which accepts the
 connection and configures a `tap` device. Frames are encapsulated using the
 same custom protocol as on the Mac.
+
+![Windows plumbing diagram](http://moby.github.io/vpnkit/win.png)
+
+Note: the connection is currently made from the Host to the VM to work around
+a bug in older versions of Windows 10. At some point this should change to be
+a connection from the VM to the host.
+
+Note: the userspace process in the VM which configures a `tap` device could be
+replaced with a custom Linux kernel driver which knows how to encapsulate the
+frames and communicate over Hyper-V sockets.
 
 ## When a frame arrives in vpnkit
 

--- a/docs/ethernet.md
+++ b/docs/ethernet.md
@@ -1,11 +1,9 @@
 # Ethernet traffic flow
 
-The following diagram shows the flow of ethernet traffic from the VM:
+This page describes how `vpnkit` works by using Docker for Mac and Docker
+for Windows as concrete examples.
 
-![ethernet diagram](http://moby.github.io/vpnkit/ethernet.png)
-
-The following sections describe the flow in more detail, using Docker for Mac
-and Docker for Windows as concrete examples.
+First, how do ethernet frames leave the VM and arrive in `vpnkit`?
 
 ## Inside Docker for Mac
 
@@ -58,6 +56,10 @@ If the VM is communicating with 10 remote IP addresses, then there will be 10
 instances of a Mirage TCP/IP stack, one per IP address. The TCP/IP stack
 instances act as proxies for the remote hosts.
 
+The following diagram shows the flow of ethernet traffic within `vpnkit`:
+
+![ethernet diagram](http://moby.github.io/vpnkit/ethernet.png)
+
 Each switch port has an associated `last_active_time` and if there is no traffic
 flow for a configured time interval, the port is deactivated and the TCP/IP
 endpoint is shutdown.
@@ -65,6 +67,7 @@ endpoint is shutdown.
 The active ports may be queried by connecting to a Unix domain socket on the Mac
 or a named pipe on Windows and receiving diagnostic data in a Unix tar formatted
 stream.
+
 
 ## Example: connection setup
 

--- a/docs/ethernet.md
+++ b/docs/ethernet.md
@@ -49,7 +49,7 @@ Frames arriving on the default port are examined and
   same destination address is processed by the new endpoint.
 
 Each virtual TCP/IP endpoint terminates TCP and UDP flows using the
-[Mirage](https://openmirage.io/) [TCP/IP stack](https://github.com/mirage/mirage-tcpip).
+[Mirage](https://mirage.io/) [TCP/IP stack](https://github.com/mirage/mirage-tcpip).
 The data from the flows is proxied to and from regular BSD-style sockets on
 both Windows and Mac.
 

--- a/docs/ethernet.md
+++ b/docs/ethernet.md
@@ -2,7 +2,7 @@
 
 The following diagram shows the flow of ethernet traffic from the VM:
 
-![ethernet diagram](http://docker.github.io/vpnkit/ethernet.png)
+![ethernet diagram](http://moby.github.io/vpnkit/ethernet.png)
 
 Frames arriving from the VM interface are processed by a simple ethernet switch.
 The switch demultiplexes traffic onto output ports by matching against rules.

--- a/docs/ethernet.md
+++ b/docs/ethernet.md
@@ -10,8 +10,9 @@ and Docker for Windows as concrete examples.
 ## Inside Docker for Mac
 
 The Docker for Mac VM is running on top of the [hyperkit](https://github.com/moby/hyperkit)
-hypervisor. The VM has a `virtio-vpnkit` PCI device which appears as a network
-interface inside the VM. The virtual hardware implementation connects to
+hypervisor. The VM has a `virtio-vpnkit` PCI device which appears as a `virtio-net`
+network interface inside the VM. The
+[virtual hardware implementation](https://github.com/moby/hyperkit/blob/master/src/lib/pci_virtio_net_vpnkit.c) connects to
 `vpnkit` on the host over a Unix domain socket and encapsulates frames using a
 simple custom protocol.
 
@@ -20,7 +21,7 @@ simple custom protocol.
 ## Inside Docker for Windows
 
 The Docker for Windows VM is running on top of Hyper-V. `vpnkit` on the host
-uses Hyper-V sockets to connect to a process inside the VM which accepts the
+uses Hyper-V sockets to connect to a process (`tap-vsockd`) inside the VM which accepts the
 connection and configures a `tap` device. Frames are encapsulated using the
 same custom protocol as on the Mac.
 
@@ -30,7 +31,7 @@ Note: the connection is currently made from the Host to the VM to work around
 a bug in older versions of Windows 10. At some point this should change to be
 a connection from the VM to the host.
 
-Note: the userspace process in the VM which configures a `tap` device could be
+Note: the userspace `tap-vsockd` process in the VM which configures a `tap` device could be
 replaced with a custom Linux kernel driver which knows how to encapsulate the
 frames and communicate over Hyper-V sockets.
 

--- a/docs/ethernet.md
+++ b/docs/ethernet.md
@@ -4,25 +4,91 @@ The following diagram shows the flow of ethernet traffic from the VM:
 
 ![ethernet diagram](http://moby.github.io/vpnkit/ethernet.png)
 
-Frames arriving from the VM interface are processed by a simple ethernet switch.
-The switch demultiplexes traffic onto output ports by matching against rules.
-The current rules match only on the destination IPv4 address. Frames which
-don't match any rule are forwarded to a default port.
+The following sections describe the flow in more detail, using Docker for Mac
+and Docker for Windows as concrete examples.
+
+## Inside Docker for Mac
+
+The Docker for Mac VM is running on top of the [hyperkit](https://github.com/moby/hyperkit)
+hypervisor. The VM has a `virtio-vpnkit` PCI device which appears as a network
+interface inside the VM. The virtual hardware implementation connects to
+`vpnkit` on the host over a Unix domain socket and encapsulates frames using a
+simple custom protocol.
+
+## Inside Docker for Windows
+
+The Docker for Windows VM is running on top of Hyper-V. `vpnkit` on the host
+uses Hyper-V sockets to connect to a process inside the VM which accepts the
+connection and configures a `tap` device. Frames are encapsulated using the
+same custom protocol as on the Mac.
+
+## When a frame arrives in vpnkit
+
+Frames arriving from the VM are processed by a simple internal ethernet switch.
+The switch demultiplexes traffic onto output ports by matching on the destination
+IPv4 address. Frames which don't match any rule are forwarded to a default port.
 
 Frames arriving on the default port are examined and
 
 - if they contain ARP requests, we send a response using a static global ARP
-  tabl
-- if they contain IPv4 datagrams then we create a fresh TCP/IP stack, a fresh
+  table
+- if they contain IPv4 datagrams then we create a fresh virtual TCP/IP endpoint, a fresh
   switch port and connect them together so that all future IPv4 traffic to the
-  same destination address is processed by the new stack.
+  same destination address is processed by the new endpoint.
+
+Each virtual TCP/IP endpoint terminates TCP and UDP flows using the
+[Mirage](https://openmirage.io/) [TCP/IP stack](https://github.com/mirage/mirage-tcpip).
+The data from the flows is proxied to and from regular BSD-style sockets on
+both Windows and Mac.
 
 If the VM is communicating with 10 remote IP addresses, then there will be 10
 instances of a Mirage TCP/IP stack, one per IP address. The TCP/IP stack
 instances act as proxies for the remote hosts.
 
 Each switch port has an associated `last_active_time` and if there is no traffic
-flow for a configured time interval, the port is deactivated.
+flow for a configured time interval, the port is deactivated and the TCP/IP
+endpoint is shutdown.
 
-The active ports may be queried over the 9P debug interface via the `ports`
-subdirectory.
+The active ports may be queried by connecting to a Unix domain socket on the Mac
+or a named pipe on Windows and receiving diagnostic data in a Unix tar formatted
+stream.
+
+## Example: connection setup
+
+Consider what happens when an application inside a container in the Linux VM
+tries to make a TCP connection:
+
+- the application calls `connect`
+- the Linux kernel emits a `TCP` packet with the `SYN` flag set
+- the Linux kernel applies the `iptables` rules (created by `docker`) and consults
+  the routing table to select the outgoing interface and then transmits the frame
+- the frame is relayed to the host
+  - on windows: the interface was a `tap` device created by the `tap-vsockd`
+    process. This process reads the frame from the associated file descriptor,
+    encapsulates it and writes it to the Hyper-V socket connected to `vpnkit`.
+  - on Mac: the interface was a `virtio` NIC. The network driver in the VM pushes
+    the packet to a queue in memory shared with the hypervisor, the `virtio-vpnkit`
+    virtual hardware pops the packet from the queue and then writes it down a
+    Unix domain socket connected to `vpnkit`.
+- the frame is received by `vpnkit` and input into the ethernet switch.
+  - if the destination IP is not recognised: `vpnkit` creates a TCP/IP endpoint
+    with the destination IP address and configures the switch to send future
+    packets with this destination IP to this endpoint
+  - if the destination IP is recognised: the internal switch inputs the frame
+    into the TCP/IP endpoint
+- the TCP/IP endpoint observes the `SYN` flag is set and so it calls the regular
+  `connect` API to establish a regular `SOCK_STREAM` connection to that destination.
+  - if the `connect` succeeds: the TCP/IP endpoint sends back a packet with the
+    `SYN` and `ACK` flags set and the handshake continues
+  - if the `connect` fails: the TCP/IP endpoint sends back a packet with the
+    `RST` flag set to reject the connection.
+
+If all has gone well, the VM now has a TCP connection over a virtual point-to-point
+ethernet link connected to `vpnkit`, and `vpnkit` has a socket connection to
+the true destination. `vpnkit` will now proxy the data in both directions.
+
+Note that from the host kernel's point of view, there is no network connection
+to the VM and no set of associated firewall rules or routing tables. All outgoing
+connections originate from the `vpnkit` process. If the user installs some
+advanced networking or VPN software which reconfigures the routing table or
+firewall rules, it will not break the connection between `vpnkit` and the VM.

--- a/docs/ethernet.svg
+++ b/docs/ethernet.svg
@@ -9,12 +9,12 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="151.6311mm"
-   height="105.86524mm"
-   viewBox="0 0 537.27556 375.11303"
+   width="202.78575mm"
+   height="138.53989mm"
+   viewBox="0 0 718.53218 490.88932"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
+   inkscape:version="0.92.1 r"
    sodipodi:docname="ethernet.svg">
   <defs
      id="defs4">
@@ -23,13 +23,45 @@
        orient="auto"
        refY="0"
        refX="0"
-       id="marker5338"
+       id="marker7897"
        style="overflow:visible"
        inkscape:isstock="true">
       <path
+         id="path7895"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker7839"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path7837" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5338"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
          id="path5340"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -44,8 +76,8 @@
        inkscape:collect="always">
       <path
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
          id="path5300"
          inkscape:connector-curvature="0" />
     </marker>
@@ -59,8 +91,8 @@
        inkscape:isstock="true">
       <path
          id="path4990"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
          transform="matrix(0.8,0,0,0.8,10,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -75,8 +107,8 @@
        inkscape:collect="always">
       <path
          id="path4993"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -90,8 +122,39 @@
        inkscape:isstock="true">
       <path
          id="path5340-5"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker7839-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path7837-6" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7897-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7895-6"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -104,16 +167,16 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="0.98994949"
-     inkscape:cx="257.3869"
-     inkscape:cy="245.43766"
+     inkscape:cx="272.60068"
+     inkscape:cy="279.27271"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
-     inkscape:window-width="1440"
-     inkscape:window-height="797"
+     inkscape:window-width="1920"
+     inkscape:window-height="1087"
      inkscape:window-x="0"
-     inkscape:window-y="1"
-     inkscape:window-maximized="1"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
      fit-margin-top="0"
      fit-margin-left="0"
      fit-margin-right="0"
@@ -134,49 +197,29 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(-201.08157,-89.98452)">
-    <rect
-       id="rect3342"
-       width="78.571434"
-       height="49.999996"
-       x="659.28571"
-       y="204.93364"
-       style="fill:none;fill-opacity:1;stroke:#000000;stroke-opacity:1" />
+     transform="translate(8.2670479,-5.9285717)">
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="568.57147"
        y="216.36221"
-       id="text4165"
-       sodipodi:linespacing="125%"><tspan
+       id="text4165"><tspan
          sodipodi:role="line"
          id="tspan4167"
          x="568.57147"
          y="216.36221"
-         style="font-size:17.5px">ethernet</tspan></text>
+         style="font-size:17.5px;line-height:1.25">ethernet</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="682.14282"
-       y="235.64793"
-       id="text4169"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan4171"
-         x="682.14282"
-         y="235.64793"
-         style="font-size:17.5px">VM</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:17.5px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="453.98984"
        y="235.17152"
-       id="text4229"
-       sodipodi:linespacing="125%"><tspan
+       id="text4229"><tspan
          sodipodi:role="line"
          id="tspan4231"
          x="453.98984"
-         y="235.17152">switch</tspan></text>
+         y="235.17152"
+         style="font-size:17.5px;line-height:1.25">switch</tspan></text>
     <rect
        style="fill:none;fill-opacity:1;stroke:#000000;stroke-opacity:1"
        id="rect4233"
@@ -186,30 +229,31 @@
        y="204.6001" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:17.5px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="500.97681"
        y="297.60873"
-       id="text4259"
-       sodipodi:linespacing="125%"><tspan
+       id="text4259"><tspan
          sodipodi:role="line"
          id="tspan4261"
          x="500.97681"
-         y="297.60873">default</tspan></text>
+         y="297.60873"
+         style="font-size:17.5px;line-height:1.25">default</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:17.5px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="435.42859"
        y="358.07648"
-       id="text4263"
-       sodipodi:linespacing="125%"><tspan
+       id="text4263"><tspan
          sodipodi:role="line"
          x="435.42859"
          y="358.07648"
-         id="tspan4269">ARP</tspan><tspan
+         id="tspan4269"
+         style="font-size:17.5px;line-height:1.25">- ARP</tspan><tspan
          sodipodi:role="line"
          x="435.42859"
          y="379.95148"
-         id="tspan3524">new flows</tspan></text>
+         id="tspan3524"
+         style="font-size:17.5px;line-height:1.25">- new flows</tspan></text>
     <rect
        style="fill:none;fill-opacity:1;stroke:#000000;stroke-opacity:1"
        id="rect4271"
@@ -219,9 +263,10 @@
        y="329.76901" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker5338)"
-       d="m 659.12454,229.75285 -107.58125,0.50507"
+       d="m 710.26351,229.75285 -158.72022,0.50507"
        id="path4980"
-       inkscape:connector-curvature="0" />
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker5298)"
        d="m 417.69808,214.44067 -41.41626,0.50507 -0.50507,-87.37819 -74.24622,0.50508"
@@ -229,62 +274,60 @@
        inkscape:connector-curvature="0" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Lend)"
-       d="m 417.69808,235.65387 -41.41626,0 0,96.97465 -75.25636,0.50507"
+       d="m 417.69808,235.65387 h -41.41626 v 96.97465 l -75.25636,0.50507"
        id="path4984"
        inkscape:connector-curvature="0" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:17.5px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="418.70822"
        y="414.95596"
-       id="text5378"
-       sodipodi:linespacing="125%"><tspan
+       id="text5378"><tspan
          sodipodi:role="line"
          x="418.70822"
          y="414.95596"
-         style="font-size:10px"
+         style="font-size:10px;line-height:1.25"
          id="tspan5406">traffic which doesn't match</tspan><tspan
          sodipodi:role="line"
          x="418.70822"
          y="427.45596"
-         style="font-size:10px"
+         style="font-size:10px;line-height:1.25"
          id="tspan3552">an existing destination IP</tspan><tspan
          sodipodi:role="line"
          x="418.70822"
          y="439.95596"
-         style="font-size:10px"
+         style="font-size:10px;line-height:1.25"
          id="tspan3554">match rule either handled</tspan><tspan
          sodipodi:role="line"
          x="418.70822"
          y="452.45596"
-         style="font-size:10px"
+         style="font-size:10px;line-height:1.25"
          id="tspan3677">directly or used to set up</tspan><tspan
          sodipodi:role="line"
          x="418.70822"
          y="464.95596"
-         style="font-size:10px"
+         style="font-size:10px;line-height:1.25"
          id="tspan3679">new rules</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:17.5px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="202.53558"
        y="384.65137"
-       id="text5384"
-       sodipodi:linespacing="125%"><tspan
+       id="text5384"><tspan
          sodipodi:role="line"
          x="202.53558"
          y="384.65137"
-         style="font-size:10px"
+         style="font-size:10px;line-height:1.25"
          id="tspan5396">Mirage TCP/IP</tspan><tspan
          sodipodi:role="line"
          x="202.53558"
          y="397.15137"
-         style="font-size:10px"
+         style="font-size:10px;line-height:1.25"
          id="tspan3613">acting as a proxy</tspan><tspan
          sodipodi:role="line"
          x="202.53558"
          y="409.65137"
-         style="font-size:10px"
+         style="font-size:10px;line-height:1.25"
          id="tspan3615">for a remote host</tspan></text>
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker5338-6)"
@@ -294,19 +337,20 @@
        sodipodi:nodetypes="cc" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:17.5px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="228.51999"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="215.26173"
        y="119.80212"
-       id="text4263-7"
-       sodipodi:linespacing="125%"><tspan
+       id="text4263-7"><tspan
          sodipodi:role="line"
-         x="228.51999"
+         x="215.26173"
          y="119.80212"
-         id="tspan4269-6">TCP</tspan><tspan
+         id="tspan3524-9"
+         style="font-size:17.5px;line-height:1.25">TCP/IP</tspan><tspan
          sodipodi:role="line"
-         x="228.51999"
+         x="215.26173"
          y="141.67712"
-         id="tspan3524-9">UDP</tspan></text>
+         style="font-size:17.5px;line-height:1.25"
+         id="tspan7770">endpoint</tspan></text>
     <rect
        style="fill:none;fill-opacity:1;stroke:#000000;stroke-opacity:1"
        id="rect4271-4"
@@ -314,21 +358,6 @@
        height="70.747581"
        x="203.60188"
        y="90.484505" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:17.5px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="226.49969"
-       y="325.87323"
-       id="text4263-7-2"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         x="226.49969"
-         y="325.87323"
-         id="tspan4269-6-5">TCP</tspan><tspan
-         sodipodi:role="line"
-         x="226.49969"
-         y="347.74823"
-         id="tspan3524-9-6">UDP</tspan></text>
     <rect
        style="fill:none;fill-opacity:1;stroke:#000000;stroke-opacity:1"
        id="rect4271-4-8"
@@ -338,47 +367,164 @@
        y="296.55563" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:17.5px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="203.79375"
        y="177.69547"
-       id="text5384-8"
-       sodipodi:linespacing="125%"><tspan
+       id="text5384-8"><tspan
          sodipodi:role="line"
          x="203.79375"
          y="177.69547"
-         style="font-size:10px"
+         style="font-size:10px;line-height:1.25"
          id="tspan5396-5">Mirage TCP/IP</tspan><tspan
          sodipodi:role="line"
          x="203.79375"
          y="190.19547"
-         style="font-size:10px"
+         style="font-size:10px;line-height:1.25"
          id="tspan3613-0">acting as a proxy</tspan><tspan
          sodipodi:role="line"
          x="203.79375"
          y="202.69547"
-         style="font-size:10px"
+         style="font-size:10px;line-height:1.25"
          id="tspan3615-2">for the local host</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:17.5px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="344.50928"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="325.75928"
        y="115.20975"
-       id="text4259-2"
-       sodipodi:linespacing="125%"><tspan
+       id="text4259-2"><tspan
          sodipodi:role="line"
          id="tspan4261-4"
-         x="344.50928"
-         y="115.20975">IP.dst=x</tspan></text>
+         x="325.75928"
+         y="115.20975"
+         style="font-size:17.5px;line-height:1.25">IP.dst=x</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:17.5px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="336.64664"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="317.89664"
        y="358.65652"
-       id="text4259-2-4"
-       sodipodi:linespacing="125%"><tspan
+       id="text4259-2-4"><tspan
          sodipodi:role="line"
          id="tspan4261-4-1"
-         x="336.64664"
-         y="358.65652">IP.dst=y</tspan></text>
+         x="317.89664"
+         y="358.65652"
+         style="font-size:17.5px;line-height:1.25">IP.dst=y</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="211.1965"
+       y="324.5712"
+       id="text4263-7-0"><tspan
+         sodipodi:role="line"
+         x="211.1965"
+         y="324.5712"
+         id="tspan3524-9-8"
+         style="font-size:17.5px;line-height:1.25;stroke-width:1px">TCP/IP</tspan><tspan
+         sodipodi:role="line"
+         x="211.1965"
+         y="346.4462"
+         style="font-size:17.5px;line-height:1.25;stroke-width:1px"
+         id="tspan7770-2">endpoint</tspan></text>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.93749994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker7839)"
+       d="M 202.97561,113.7539 H 142.36646 V 46.515622"
+       id="path7821"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.93749994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker7897)"
+       d="M 201.08157,139.32338 H 80.810292"
+       id="path7823"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:16.40625px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.93749994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="-9.1081886"
+       y="18.105085"
+       id="text7955"><tspan
+         sodipodi:role="line"
+         id="tspan7953"
+         x="-9.1081886"
+         y="18.105085"
+         style="stroke-width:0.93749994px">SOCK_STREAM</tspan><tspan
+         sodipodi:role="line"
+         x="-9.1081886"
+         y="38.6129"
+         style="stroke-width:0.93749994px"
+         id="tspan7957">connections from host</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:16.40625px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.93749988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="-9.1081886"
+       y="168.17918"
+       id="text7955-0"><tspan
+         sodipodi:role="line"
+         id="tspan7953-7"
+         x="-9.1081886"
+         y="168.17918"
+         style="stroke-width:0.93749988px">SOCK_DGRAM</tspan><tspan
+         sodipodi:role="line"
+         x="-9.1081886"
+         y="188.687"
+         style="stroke-width:0.93749988px"
+         id="tspan7957-4">connections from host</tspan></text>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.93749988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker7839-7)"
+       d="m 201.56796,346.51818 h -60.60915 v 67.23828"
+       id="path7821-0"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.93749988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker7897-2)"
+       d="M 202.46509,317.36276 H 82.193819"
+       id="path7823-8"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:16.40625px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.93749982px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="-9.1081886"
+       y="278.98029"
+       id="text7955-0-3"><tspan
+         sodipodi:role="line"
+         id="tspan7953-7-0"
+         x="-9.1081886"
+         y="278.98029"
+         style="stroke-width:0.93749982px">SOCK_DGRAM</tspan><tspan
+         sodipodi:role="line"
+         x="-9.1081886"
+         y="299.4881"
+         style="stroke-width:0.93749982px"
+         id="tspan7957-4-2">connections from host</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:16.40625px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.93749988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="-9.1081886"
+       y="433.34424"
+       id="text7955-7"><tspan
+         sodipodi:role="line"
+         id="tspan7953-1"
+         x="-9.1081886"
+         y="433.34424"
+         style="stroke-width:0.93749988px">SOCK_STREAM</tspan><tspan
+         sodipodi:role="line"
+         x="-9.1081886"
+         y="453.85205"
+         style="stroke-width:0.93749988px"
+         id="tspan7957-9">connections from host</tspan></text>
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.93749988;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect8704"
+       width="501.91953"
+       height="430.89319"
+       x="180.24718"
+       y="65.455978" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:16.40625px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.93749994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="602.61719"
+       y="95.760551"
+       id="text8864"><tspan
+         sodipodi:role="line"
+         id="tspan8862"
+         x="602.61719"
+         y="95.760551"
+         style="stroke-width:0.93749994px">vpnkit</tspan></text>
   </g>
 </svg>

--- a/docs/mac.svg
+++ b/docs/mac.svg
@@ -1,0 +1,397 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="305.27692mm"
+   height="95.25mm"
+   viewBox="0 0 305.27692 95.25"
+   version="1.1"
+   id="svg4670"
+   inkscape:version="0.92.1 r"
+   sodipodi:docname="mac.svg">
+  <defs
+     id="defs4664">
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mend"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5308"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mend-1"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5308-8"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mend-5"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5308-7"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mend-9"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5308-84"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="618.22132"
+     inkscape:cy="148.86019"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     objecttolerance="10000"
+     inkscape:window-width="1920"
+     inkscape:window-height="1087"
+     inkscape:window-x="0"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5215"
+       dotted="true"
+       originx="8.8110733"
+       originy="-95.25" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata4667">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(8.811073,-106.5)">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.63020849px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="252.48808"
+       y="159.79465"
+       id="text5219"><tspan
+         sodipodi:role="line"
+         id="tspan5217"
+         x="252.48808"
+         y="159.79465"
+         style="stroke-width:0.26458332px">eth0</tspan><tspan
+         sodipodi:role="line"
+         x="252.48808"
+         y="165.58241"
+         style="stroke-width:0.26458332px"
+         id="tspan5283">(192.168.65.2)</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.63020849px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="191.27225"
+       y="121.65705"
+       id="text5227"><tspan
+         sodipodi:role="line"
+         id="tspan5225"
+         x="191.27225"
+         y="121.65705"
+         style="stroke-width:0.26458332px">VM</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.63020849px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="168.34293"
+       y="121.38978"
+       id="text5231"><tspan
+         sodipodi:role="line"
+         id="tspan5229"
+         x="168.34293"
+         y="121.38978"
+         style="stroke-width:0.26458332px">Host</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.63020849px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="216.58035"
+       y="161.30655"
+       id="text5235"><tspan
+         sodipodi:role="line"
+         id="tspan5233"
+         x="216.58035"
+         y="161.30655"
+         style="stroke-width:0.26458332px">virtio-net</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.63020849px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="126.62202"
+       y="161.30655"
+       id="text5239"><tspan
+         sodipodi:role="line"
+         id="tspan5237"
+         x="126.62202"
+         y="161.30655"
+         style="stroke-width:0.26458332px">virtio-vpnkit</tspan></text>
+    <g
+       id="g5672">
+      <rect
+         y="154.125"
+         x="174.625"
+         height="15.875"
+         width="5.2916679"
+         id="rect5241"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         y="154.125"
+         x="179.91667"
+         height="15.875002"
+         width="5.2916632"
+         id="rect5241-5"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         y="154.125"
+         x="185.20833"
+         height="15.875002"
+         width="5.291666"
+         id="rect5241-8"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         y="154.125"
+         x="190.5"
+         height="15.875002"
+         width="5.2916646"
+         id="rect5241-87"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.63020849px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="211.66666"
+       y="143.54167"
+       id="text5293"><tspan
+         sodipodi:role="line"
+         id="tspan5291"
+         x="211.66666"
+         y="143.54167"
+         style="stroke-width:0.26458332px">Linux kernel</tspan></text>
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect5295"
+       width="89.958344"
+       height="42.333332"
+       x="206.375"
+       y="132.95834" />
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect5631"
+       width="31.749994"
+       height="15.875005"
+       x="211.66667"
+       y="154.125" />
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect5631-0"
+       width="42.333324"
+       height="15.875005"
+       x="248.70834"
+       y="154.125" />
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect5631-2"
+       width="37.041668"
+       height="15.875005"
+       x="121.70834"
+       y="154.125" />
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect5674"
+       width="47.625"
+       height="42.333332"
+       x="116.41666"
+       y="132.95834" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.63020849px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="121.70832"
+       y="143.54167"
+       id="text5293-8"><tspan
+         sodipodi:role="line"
+         id="tspan5291-5"
+         x="121.70832"
+         y="143.54167"
+         style="stroke-width:0.26458332px">hyperkit</tspan></text>
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect5674-5"
+       width="47.625"
+       height="42.333332"
+       x="31.75"
+       y="132.95834" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.63020849px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="37.041668"
+       y="143.54167"
+       id="text5293-8-6"><tspan
+         sodipodi:role="line"
+         id="tspan5291-5-0"
+         x="37.041668"
+         y="143.54167"
+         style="stroke-width:0.26458332px">vpnkit</tspan></text>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 248.70833,162.06251 h -5.29167"
+       id="path5738"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 206.375,162.06251 H 195.79166"
+       id="path5740"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 174.625,162.06251 H 158.75"
+       id="path5742"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 116.41667,162.06251 79.375,162.0625"
+       id="path5744"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.63020849px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="167.14145"
+       y="177.40295"
+       id="text5748"><tspan
+         sodipodi:role="line"
+         id="tspan5746"
+         x="167.14145"
+         y="177.40295"
+         style="stroke-width:0.26458332px">shared memory</tspan><tspan
+         sodipodi:role="line"
+         x="167.14145"
+         y="183.19072"
+         style="stroke-width:0.26458332px"
+         id="tspan5750">queues</tspan></text>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79374995, 0.26458332;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 185.20833,148.83334 V 106.5"
+       id="path5752"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.52916663, 0.26458332;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 185.20833,185.875 V 201.75"
+       id="path5754"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.63020849px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="83.570724"
+       y="177.3761"
+       id="text5777"><tspan
+         sodipodi:role="line"
+         id="tspan5775"
+         x="83.570724"
+         y="177.3761"
+         style="stroke-width:0.26458332px">Unix domain</tspan><tspan
+         sodipodi:role="line"
+         x="83.570724"
+         y="183.16386"
+         style="stroke-width:0.26458332px"
+         id="tspan5779">socket</tspan></text>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend)"
+       d="M 31.75,138.25001 H 18.520833"
+       id="path5781"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend-1)"
+       d="M 31.75,148.83334 H 18.520833"
+       id="path5781-4"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend-5)"
+       d="M 31.75,159.41667 H 18.520832"
+       id="path5781-0"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend-9)"
+       d="M 31.75,170.00001 H 18.520833"
+       id="path5781-5"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.63020849px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="-9.1140261"
+       y="177.48491"
+       id="text6342"><tspan
+         sodipodi:role="line"
+         id="tspan6340"
+         x="-9.1140261"
+         y="177.48491"
+         style="stroke-width:0.26458332px">SOCK_STREAM</tspan><tspan
+         sodipodi:role="line"
+         x="-9.1140261"
+         y="183.27267"
+         style="stroke-width:0.26458332px"
+         id="tspan6344">SOCK_DGRAM</tspan></text>
+  </g>
+</svg>

--- a/docs/ports.md
+++ b/docs/ports.md
@@ -1,0 +1,128 @@
+# Port-forwarding
+
+This page describes how `vpnkit` is used by Docker for Mac and Docker for Windows to
+open ports on host interfaces and to forward traffic to containers.
+
+Note: this is completely separate from [using vpnkit as a default gateway](ethernet.md).
+This implementation could be factored out into a separate executable.
+
+## Background
+
+On a regular installation of `docker` on Linux the command:
+
+```
+docker run -p 8080:80 nginx
+```
+starts an `nginx` container and forwards connections from `0.0.0.0:8080` on
+the host to the container's port `80`.
+
+The command:
+
+```
+docker run -p 1.2.3.4:8080:80 nginx
+```
+starts an `nginx` container but only forwards connections from `1.2.3.4:8080` on
+the host to the container's port `80`.
+
+On Linux port forwarding can be achieved either through `iptables` or by
+running a simple user-space proxy. On Docker for Mac and Docker for Windows
+
+- the `docker` daemon does not run on the host (except on Windows when running
+  Windows containers-- this is out of scope of this document) and so cannot run
+  anything on the host
+- the container network within the VM is separated from the host's network
+  by `vpnkit` (ignoring the internal network used on Windows for volume sharing):
+  see [using vpnkit as default gateway](ethernet.md).
+
+Therefore `vpnkit` includes a port forwarding service which allows the `docker` daemon
+in the VM to open ports on the host and which forwards connections transparently
+to the container port inside the VM.
+
+## Docker daemon interface
+
+The `docker` daemon can either use `iptables` or a userspace proxy to open ports
+on a regular Linux system. In Docker for Mac and Docker for Windows we configure
+the `docker` daemon to use a userspace proxy, and we provide our own custom
+implementation. This acts as a very basic "plugin".
+
+For example, after running `docker run -p 8080:80 nginx` on the host, inside the
+VM we can see a process:
+
+```
+/usr/bin/slirp-proxy -proto tcp -host-ip 0.0.0.0 -host-port 8080 -container-ip 172.17.0.2 -container-port 80
+```
+This shows a single port forward from `0.0.0.0:8080` on the host to the internal
+IP `172.17.0.2:80` inside the VM.
+
+This custom proxy uses a custom signaling protocol to communicate the port forwarding
+request to the host, and to receive back success or error (e.g. `EADDRINUSE`
+or `EADDRNOTAVAIL`).
+
+## Signalling from the VM to the host
+
+The control interface takes the form of a virtual 9P filesystem served by
+`vpnkit` and mounted in the Linux VM. New port forwards are requested by
+creating directories, and status (including error messages) read by reading
+files.
+
+For example, after running `docker run -p 8080:80 nginx` on the host, inside
+the VM we can see:
+```
+/ # ls /port
+README                              tcp:0.0.0.0:8080:tcp:172.17.0.2:80
+```
+This shows a single active port forward from `0.0.0.0:8080` on the host to the internal
+IP `172.17.0.2:80` inside the VM.
+
+The initial filesystem mount is slightly different between Docker for Mac
+and Docker for Windows.
+
+The [hyperkit](https://github.com/moby/hyperkit) hypervisor on the Mac has a
+[virtio-9p](https://github.com/moby/hyperkit/blob/master/src/lib/pci_virtio_9p.c)
+device which connects to a Unix domain socket whenever the VM issues a `mount`
+command.
+
+On Windows we run a process `9p-mount` which calls `listen` on a Hyper-V socket for
+connections from the host. `vpnkit` calls `connect`, and then `9p-mount` calls
+`accept` and then passes
+the file descriptor to the `mount` command via the `rfdno` and `wfdno`
+arguments.
+
+When it has opened a new host port forward, the custom proxy retains an open
+file descriptor referencing a control file on the filesystem. If the proxy
+is killed or crashes the Linux kernel will close the file descriptor and emit
+a 9P `clunk` message which is used by `vpnkit` to shut down the port forward.
+This ensures that the port forwards in `vpnkit` do not leak.
+
+Note: the use of a mounted filesystem is not ideal, for if the `vpnkit` process
+is restarted then the filesystem becomes broken. It would be better in future
+to use a reconnectable protocol.
+
+Note: the use of `clunk` like this is quite fragile; if another process were
+to `open` and `close` the file it would prematurly call `clunk` and shutdown
+the port forward.
+
+## Forwarding connections
+
+When a client connects to the port on the host, `vpnkit` accepts the connection.
+
+On Windows, `vpnkit` calls `connect` on a Hyper-V socket to connect to the VM
+on a well-known port.
+
+On the Mac, `vpnkit` calls `connect` on a Unix domain socket to connect to the
+[hyperkit](https://github.com/moby/hyperkit) hypervisor's `virtio-vsock` control
+socket. `vpnkit` writes a short header including the well-known `AF_VSOCK`
+port number and is connected to the VM.
+
+Inside
+the VM there is a connection demultiplexer which calls `listen` on this well-known port.
+This process calls `accept` and then reads a simple header which includes the
+ultimate destination IP and port (`172.17.0.2:80` in the example above).
+The demultiplexer calls `connect` to the container port and starts proxying data.
+
+Note: since early versions of Windows 10 do not support `shutdown` (i.e. the
+ability to signal that `write` calls have finished but while allowing `read` calls to continue
+c.f. TCP half-close) there is a simple protocol layered over the Hyper-V socket
+stream which implements this behaviour, not described here.
+
+Note: the code also transports UDP with a simple framing protocol, not described here.

--- a/docs/win.svg
+++ b/docs/win.svg
@@ -1,0 +1,395 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="241.7769mm"
+   height="106.09812mm"
+   viewBox="0 0 241.7769 106.09812"
+   version="1.1"
+   id="svg4670"
+   inkscape:version="0.92.1 r"
+   sodipodi:docname="win.svg"
+   inkscape:export-filename="/Users/djs/djs55/vpnkit/docs/mac.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96">
+  <defs
+     id="defs4664">
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mend"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5308"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mend-1"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5308-8"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mend-5"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5308-7"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mend-9"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5308-84"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="352.56655"
+     inkscape:cy="-12.263431"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     objecttolerance="10000"
+     inkscape:window-width="1920"
+     inkscape:window-height="1087"
+     inkscape:window-x="0"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5215"
+       dotted="true"
+       originx="-70.563914"
+       originy="-95.117501" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata4667">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-70.563917,-95.784375)">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.63020849px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="191.27225"
+       y="121.65705"
+       id="text5227"><tspan
+         sodipodi:role="line"
+         id="tspan5225"
+         x="191.27225"
+         y="121.65705"
+         style="stroke-width:0.26458332px">VM</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.63020849px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="168.34293"
+       y="121.38978"
+       id="text5231"><tspan
+         sodipodi:role="line"
+         id="tspan5229"
+         x="168.34293"
+         y="121.38978"
+         style="stroke-width:0.26458332px">Host</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.63020849px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="215.244"
+       y="161.03928"
+       id="text5235"><tspan
+         sodipodi:role="line"
+         id="tspan5233"
+         x="215.244"
+         y="161.03928"
+         style="stroke-width:0.26458332px">AF_HVSOCK</tspan></text>
+    <g
+       id="g5672">
+      <rect
+         y="154.125"
+         x="174.625"
+         height="15.875"
+         width="5.2916679"
+         id="rect5241"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         y="154.125"
+         x="179.91667"
+         height="15.875002"
+         width="5.2916632"
+         id="rect5241-5"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         y="154.125"
+         x="185.20833"
+         height="15.875002"
+         width="5.291666"
+         id="rect5241-8"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         y="154.125"
+         x="190.5"
+         height="15.875002"
+         width="5.2916646"
+         id="rect5241-87"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.63020849px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="211.66666"
+       y="143.54167"
+       id="text5293"><tspan
+         sodipodi:role="line"
+         id="tspan5291"
+         x="211.66666"
+         y="143.54167"
+         style="stroke-width:0.26458332px">Linux kernel</tspan></text>
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect5295"
+       width="52.916668"
+       height="68.791656"
+       x="206.375"
+       y="132.95834" />
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect5631"
+       width="37.04166"
+       height="15.875"
+       x="211.66667"
+       y="154.125" />
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect5674-5"
+       width="47.625"
+       height="42.333332"
+       x="111.12499"
+       y="132.95834" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.63020849px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="116.41666"
+       y="143.54167"
+       id="text5293-8-6"><tspan
+         sodipodi:role="line"
+         id="tspan5291-5-0"
+         x="116.41666"
+         y="143.54167"
+         style="stroke-width:0.26458332px">vpnkit</tspan></text>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 248.70833,95.916667 h -5.29167"
+       id="path5738"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 211.66667,162.0625 -15.87501,1e-5"
+       id="path5740"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 174.625,162.06251 -15.875,-1e-5"
+       id="path5744"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.63020849px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="167.14145"
+       y="177.40295"
+       id="text5748"><tspan
+         sodipodi:role="line"
+         x="167.14145"
+         y="177.40295"
+         style="stroke-width:0.26458332px"
+         id="tspan5750">Hyper-V sockets</tspan><tspan
+         sodipodi:role="line"
+         x="167.14145"
+         y="183.19072"
+         style="stroke-width:0.26458332px"
+         id="tspan7027" /></text>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79374995, 0.26458332;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 185.20833,148.83334 V 106.5"
+       id="path5752"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.52916663, 0.26458332;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 185.20833,185.875 V 201.75"
+       id="path5754"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend)"
+       d="M 111.12499,138.25 H 97.895824"
+       id="path5781"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend-1)"
+       d="M 111.12499,148.83333 H 97.895824"
+       id="path5781-4"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend-5)"
+       d="M 111.12499,159.41666 H 97.895823"
+       id="path5781-0"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Mend-9)"
+       d="M 111.12499,170 H 97.895824"
+       id="path5781-5"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.63020849px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="70.260963"
+       y="177.48491"
+       id="text6342"><tspan
+         sodipodi:role="line"
+         id="tspan6340"
+         x="70.260963"
+         y="177.48491"
+         style="stroke-width:0.26458332px">SOCK_STREAM</tspan><tspan
+         sodipodi:role="line"
+         x="70.260963"
+         y="183.27267"
+         style="stroke-width:0.26458332px"
+         id="tspan6344">SOCK_DGRAM</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.63020849px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="215.44641"
+       y="183.60715"
+       id="text5219-8"><tspan
+         sodipodi:role="line"
+         x="215.44641"
+         y="183.60715"
+         style="stroke-width:0.26458332px"
+         id="tspan7053">eth0 (TUN/TAP)</tspan><tspan
+         sodipodi:role="line"
+         x="215.44641"
+         y="189.39491"
+         style="stroke-width:0.26458332px"
+         id="tspan7057">(192.168.65.2)</tspan><tspan
+         sodipodi:role="line"
+         x="215.44641"
+         y="195.18266"
+         style="stroke-width:0.26458332px"
+         id="tspan5283-0" /></text>
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect5631-0-4"
+       width="42.333324"
+       height="15.875005"
+       x="211.66667"
+       y="177.9375" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.63020849px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="270.80649"
+       y="171.6226"
+       id="text5235-8"><tspan
+         sodipodi:role="line"
+         id="tspan5233-4"
+         x="270.80649"
+         y="171.6226"
+         style="stroke-width:0.26458332px">tap-vsockd</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.63020849px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="264.58331"
+       y="143.54166"
+       id="text5293-1"><tspan
+         sodipodi:role="line"
+         id="tspan5291-4"
+         x="264.58331"
+         y="143.54166"
+         style="stroke-width:0.26458332px">Linux userspace</tspan></text>
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect5295-2"
+       width="52.916668"
+       height="68.791656"
+       x="259.29166"
+       y="132.95833" />
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect5631-1"
+       width="37.041664"
+       height="15.875"
+       x="267.22916"
+       y="164.70833" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 267.22916,170 -18.52083,-7.9375"
+       id="path7104"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 267.22916,175.29167 254,185.875"
+       id="path7106"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/docs/win.svg
+++ b/docs/win.svg
@@ -90,7 +90,7 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="0.98994949"
-     inkscape:cx="352.56655"
+     inkscape:cx="831.37886"
      inkscape:cy="-12.263431"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
@@ -120,7 +120,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -236,11 +236,6 @@
          x="116.41666"
          y="143.54167"
          style="stroke-width:0.26458332px">vpnkit</tspan></text>
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 248.70833,95.916667 h -5.29167"
-       id="path5738"
-       inkscape:connector-curvature="0" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m 211.66667,162.0625 -15.87501,1e-5"

--- a/src/hostnet/stubs_utils.c
+++ b/src/hostnet/stubs_utils.c
@@ -14,7 +14,7 @@
 #include <sys/socket.h>
 #endif
 
-CAMLprim value stub_get_SOMAXCONN(){
+CAMLprim value stub_get_SOMAXCONN(value unit){
   fprintf(stderr, "SOMAXCONN = %d\n", SOMAXCONN);
   return (Val_int (SOMAXCONN));
 }


### PR DESCRIPTION
- add a Windows and Mac example plumbing diagram
- add `SOCK_STREAM` and `SOCK_DGRAM` to the main `vpnkit` diagram
- link to hyperkit and Mirage TCP/IP
- add a high-level walk-through describing what happens when a process in a Linux VM connected to `vpnkit` attempts to establish a TCP connection