### PR TITLE
Add optional builtin DNS names

### DIFF
--- a/src/hostnet/hostnet_dns.mli
+++ b/src/hostnet/hostnet_dns.mli
@@ -16,7 +16,7 @@ module Make
     (Udp: V1_LWT.UDPV4)
     (Tcp:V1_LWT.TCPV4)
     (Socket: Sig.SOCKETS)
-    (Dns: Sig.DNS)
+    (Dns_resolver: Sig.DNS)
     (Time: V1_LWT.TIME)
     (Clock: V1.CLOCK)
     (Recorder: Sig.RECORDER) : sig
@@ -24,7 +24,7 @@ module Make
   type t
   (** A DNS proxy instance with a fixed configuration *)
 
-  val create: local_address:Dns_forward.Config.Address.t -> Config.t -> t Lwt.t
+  val create: local_address:Dns_forward.Config.Address.t -> host_names:Dns.Name.t list -> Config.t -> t Lwt.t
   (** Create a DNS forwarding instance based on the given configuration, either
       [`Upstream config]: send DNS requests to the given upstream servers
       [`Host]: use the Host's resolver.

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -92,6 +92,7 @@ type config = {
   client_uuids: uuid_table;
   bridge_connections: bool;
   mtu: int;
+  host_names: Dns.Name.t list;
 }
 
 module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLICY)(Host: Sig.HOST)(Vnet : Vnetif.BACKEND with type macaddr = Macaddr.t) = struct
@@ -131,7 +132,7 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
   let dns =
     let ip = Ipaddr.V4 (Ipaddr.V4.of_string_exn default_host) in
     let local_address = { Dns_forward.Config.Address.ip; port = 0 } in
-    ref (Dns_forwarder.create ~local_address @@ Dns_policy.config ())
+    ref (Dns_forwarder.create ~local_address ~host_names:[] @@ Dns_policy.config ())
 
   let is_dns = let open Frame in function
     | Ethernet { payload = Ipv4 { payload = Udp { src = 53; _ }; _ }; _ }
@@ -607,7 +608,7 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
 
     let update_dns () =
       let local_address = { Dns_forward.Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 0 } in
-      dns := Dns_forwarder.create ~local_address (Dns_policy.config ());
+      dns := Dns_forwarder.create ~local_address ~host_names:[] (Dns_policy.config ());
   end
 
   (* If no traffic is received for 5 minutes, delete the endpoint and
@@ -806,7 +807,7 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
     Log.info (fun f -> f "TCP/IP ready");
     Lwt.return t
 
-  let create config =
+  let create ?(host_names = [ Dns.Name.of_string "vpnkit.host" ]) config =
     let driver = [ "com.docker.driver.amd64-linux" ] in
 
     let max_connections_path = driver @ [ "slirp"; "max-connections" ] in
@@ -968,7 +969,7 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
       Dns_policy.remove ~priority:3;
       Dns_policy.add ~priority:3 ~config;
       let local_address = { Dns_forward.Config.Address.ip = Ipaddr.V4 local_ip; port = 0 } in
-      dns := Dns_forwarder.create ~local_address (Dns_policy.config ());
+      dns := Dns_forwarder.create ~local_address ~host_names (Dns_policy.config ());
       Lwt.return_unit in
 
     let rec monitor_dns_settings settings =
@@ -1029,6 +1030,7 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
       client_uuids;
       bridge_connections;
       mtu;
+      host_names;
     } in
     Lwt.return t
 

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -606,9 +606,9 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
   module Debug = struct
     let get_nat_table_size t = Udp_nat.get_nat_table_size t.udp_nat
 
-    let update_dns () =
-      let local_address = { Dns_forward.Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 0 } in
-      dns := Dns_forwarder.create ~local_address ~host_names:[] (Dns_policy.config ());
+    let update_dns ?(local_ip = Ipaddr.V4 Ipaddr.V4.localhost) ?(host_names = []) () =
+      let local_address = { Dns_forward.Config.Address.ip = local_ip; port = 0 } in
+      dns := Dns_forwarder.create ~local_address ~host_names (Dns_policy.config ());
   end
 
   (* If no traffic is received for 5 minutes, delete the endpoint and

--- a/src/hostnet/slirp.mli
+++ b/src/hostnet/slirp.mli
@@ -26,13 +26,14 @@ type config = {
   client_uuids: uuid_table;
   bridge_connections: bool;
   mtu: int;
+  host_names: Dns.Name.t list;
 }
 
 (** A slirp TCP/IP stack ready to accept connections *)
 
 module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLICY)(Host: Sig.HOST)(Vnet : Vnetif.BACKEND) : sig
 
-  val create: Config.t -> config Lwt.t
+  val create: ?host_names:Dns.Name.t list -> Config.t -> config Lwt.t
   (** Initialise a TCP/IP stack, taking configuration from the Config.t *)
 
   type t

--- a/src/hostnet/slirp.mli
+++ b/src/hostnet/slirp.mli
@@ -54,7 +54,7 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
     val get_nat_table_size: t -> int
     (** Return the number of active NAT table entries *)
 
-    val update_dns: unit -> unit
+    val update_dns: ?local_ip:Ipaddr.t -> ?host_names:Dns.Name.t list -> unit -> unit
     (** Update the DNS forwarder following a configuration change *)
   end
 end

--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -136,6 +136,7 @@ let config_without_bridge =
     bridge_connections = false;
     global_arp_table;
     mtu = 1500;
+    host_names = [];
   }
 
 (* This is a hacky way to get a hancle to the server side of the stack. *)


### PR DESCRIPTION
Previously the only way to access ports exposed on the Host from the VM was to know and hardcode the virtual IP `192.168.65.1` (although this can be changed via the database).
    
This patch adds a command-line argument `--host-names` which accepts a comma-separated list of DNS names which will be mapped to the current host virtual IP.

The default name is `vpnkit.host` but this can be overriden or extended.
    
Signed-off-by: David Scott <dave.scott@docker.com>
