### PR TITLE
Fix warnings, selectively re-enable -warn-error

### DIFF
--- a/opam
+++ b/opam
@@ -33,7 +33,7 @@ depends: [
   "result"
   "tar-format" {= "0.6.1"}
   "ipaddr"
-  "lwt" { < "3.0.0" }
+  "lwt" { >= "2.7.0" }
   "uwt" { >= "0.0.4" }
   "tcpip" { >= "2.8.0" & < "3.0.0" }
   "pcap-format"

--- a/repo/darwin/packages/local/slirp.local/opam
+++ b/repo/darwin/packages/local/slirp.local/opam
@@ -8,7 +8,7 @@ depends: [
   "result"
   "tar-format" {= "0.6.1"}
   "ipaddr"
-  "lwt" { < "3.0.0" }
+  "lwt" { >= "2.7.0" }
   "uwt" {>= "0.0.4"}
   "tcpip" { = "999" }
   "pcap-format"

--- a/src/bin/connect.ml
+++ b/src/bin/connect.ml
@@ -76,7 +76,6 @@ module Make_hvsock(Host: Sig.HOST) = struct
       let flow = F.connect fd in
       Lwt.return { idx; flow }
 
-  let getclientname _ = failwith "Hyper-V socket implementation lacks getsockname"
   let read_into t = F.read_into t.flow
   let read t = F.read t.flow
   let write t = F.write t.flow

--- a/src/bin/jbuild
+++ b/src/bin/jbuild
@@ -5,4 +5,5 @@
      datakit-server.fs9p win-eventlog asl fd-send-recv
    ))
    (preprocess  no_preprocessing)
+   (flags (:standard -warn-error "+1..49-3" -w "A-4-41-42-44"))
 ))

--- a/src/hostnet/capture.ml
+++ b/src/hostnet/capture.ml
@@ -175,7 +175,7 @@ module Make(Input: Sig.VMNET) = struct
   let record t bufs =
     try
       Hashtbl.iter
-        (fun name rule ->
+        (fun _ rule ->
           match Frame.parse bufs with
           | Result.Ok f -> if rule.predicate f then push rule bufs
           | Result.Error (`Msg m) -> failwith m
@@ -232,9 +232,9 @@ module Make(Input: Sig.VMNET) = struct
   let stop_capture _ =
     failwith "Capture.stop_capture unimplemented"
 
-  let get_client_uuid t =
+  let get_client_uuid _ =
     failwith "Capture.get_client_uuid unimplemented"
 
-  let get_client_macaddr t =
+  let get_client_macaddr _ =
     failwith "Capture.get_client_macaddr unimplemented"
 end

--- a/src/hostnet/cstructs.ml
+++ b/src/hostnet/cstructs.ml
@@ -33,7 +33,7 @@ let sub t off len =
   (* trim the length *)
   let rec trim acc ts remaining = match remaining, ts with
     | 0, _ -> List.rev acc
-    | n, [] -> err "invalid bounds in Cstructs.sub %a off=%d len=%d" pp_t t off len
+    | _, [] -> err "invalid bounds in Cstructs.sub %a off=%d len=%d" pp_t t off len
     | n, t :: ts ->
       let to_take = min (Cstruct.len t) n in
       (* either t is consumed and we only need ts, or t has data remaining in which

--- a/src/hostnet/dhcp.ml
+++ b/src/hostnet/dhcp.ml
@@ -30,7 +30,7 @@ module Make(Netif: V1_LWT.NETWORK) = struct
     | hd::tl -> List.fold_left (fun acc x -> if compare acc x > 0 then acc else x) hd tl
 
   (* given some MACs and IPs, construct a usable DHCP configuration *)
-  let make ~client_macaddr ~server_macaddr ~peer_ip ~highest_peer_ip ~local_ip ~extra_dns_ip
+  let make ~server_macaddr ~peer_ip ~highest_peer_ip ~local_ip ~extra_dns_ip
     ~get_domain_search ~get_domain_name netif =
     let open Dhcp_server.Config in
     (* FIXME: We need a DHCP range to make the DHCP server happy, even though we

--- a/src/hostnet/dhcp.mli
+++ b/src/hostnet/dhcp.mli
@@ -4,7 +4,7 @@
 module Make(Netif: V1_LWT.NETWORK): sig
   type t
 
-  val make: client_macaddr:Macaddr.t -> server_macaddr:Macaddr.t
+  val make: server_macaddr:Macaddr.t
     -> peer_ip: Ipaddr.V4.t -> highest_peer_ip: Ipaddr.V4.t option -> local_ip:Ipaddr.V4.t
     -> extra_dns_ip:Ipaddr.V4.t list -> get_domain_search:(unit -> string list)
     -> get_domain_name:(unit -> string)

--- a/src/hostnet/error.ml
+++ b/src/hostnet/error.ml
@@ -1,14 +1,3 @@
-open Lwt.Infix
-
 type 'a t = ('a, [ `Msg of string ]) Hostnet_lwt_result.t
-
-module FromFlowError(Flow: V1_LWT.FLOW) = struct
-  let (>>=) m f = m >>= function
-    | `Eof -> Lwt.return (Result.Error (`Msg "Unexpected end of file"))
-    | `Error e -> Lwt.return (Result.Error (`Msg (Flow.error_message e)))
-    | `Ok x -> f x
-end
-
-let errorf fmt = Printf.ksprintf (fun s -> Lwt.return (Result.Error (`Msg s))) fmt
 
 module Infix = Hostnet_lwt_result.Infix

--- a/src/hostnet/filter.ml
+++ b/src/hostnet/filter.ml
@@ -107,10 +107,10 @@ module Make(Input: Sig.VMNET) = struct
   let of_fd ~client_macaddr_of_uuid:_ ~server_macaddr:_ ~mtu:_ =
     failwith "Filter.of_fd unimplemented"
 
-  let get_client_uuid t =
+  let get_client_uuid _ =
     failwith "Filter.get_client_uuid unimplemented"
 
-  let get_client_macaddr t =
+  let get_client_macaddr _ =
     failwith "Filter.get_client_macaddr unimplemented"
 
   let start_capture _ ?size_limit:_ _ =

--- a/src/hostnet/forward.ml
+++ b/src/hostnet/forward.ml
@@ -31,26 +31,14 @@ module Result = struct
 end
 
 module Int16 = struct
-  module M = struct
-    type t = int
-    let compare (a: t) (b: t) = Pervasives.compare a b
-  end
-  include M
-  module Map = Map.Make(M)
-  module Set = Set.Make(M)
+  type t = int
 end
 
 module Port = struct
-  module M = struct
-    type t = [
-      | `Tcp of Ipaddr.t * Int16.t
-      | `Udp of Ipaddr.t * Int16.t
-    ]
-    let compare = compare
-  end
-  include M
-  module Map = Map.Make(M)
-  module Set = Set.Make(M)
+  type t = [
+    | `Tcp of Ipaddr.t * Int16.t
+    | `Udp of Ipaddr.t * Int16.t
+  ]
 
   let to_string = function
     | `Tcp (addr, port) -> Printf.sprintf "tcp:%s:%d" (Ipaddr.to_string addr) port
@@ -84,8 +72,6 @@ type t = {
 type key = Port.t
 
 let get_key t = t.local
-
-module Map = Port.Map
 
 type context = string
 

--- a/src/hostnet/host_lwt_unix.ml
+++ b/src/hostnet/host_lwt_unix.ml
@@ -37,7 +37,7 @@ exception Too_many_connections
 let connection_table = Hashtbl.create 511
 let connections () =
   let xs = Hashtbl.fold (fun _ c acc -> c :: acc) connection_table [] in
-  Vfs.File.ro_of_string @@ String.concat "\n" xs
+  Vfs.File.ro_of_string (String.concat "\n" xs)
 let register_connection_no_limit description =
   let idx = next_connection_idx () in
   Hashtbl.replace connection_table idx description;

--- a/src/hostnet/host_uwt.ml
+++ b/src/hostnet/host_uwt.ml
@@ -71,7 +71,7 @@ module Sockets = struct
   let connection_table = Hashtbl.create 511
   let connections () =
     let xs = Hashtbl.fold (fun _ c acc -> c :: acc) connection_table [] in
-    Vfs.File.ro_of_string @@ String.concat "\n" xs
+    Vfs.File.ro_of_string (String.concat "\n" xs)
   let register_connection_no_limit description =
     let idx = next_connection_idx () in
     Hashtbl.replace connection_table idx description;

--- a/src/hostnet/hosts.ml
+++ b/src/hostnet/hosts.ml
@@ -24,7 +24,7 @@ let of_string txt =
         if line = "" then acc else begin
           let line = match String.cut ~sep:"#" line with
             | None -> line
-            | Some (important, comment) -> important in
+            | Some (important, _) -> important in
           let whitespace = function
             | ' ' | '\n' | '\011' | '\012' | '\r' | '\t' -> true
             | _ -> false in

--- a/src/hostnet/jbuild
+++ b/src/hostnet/jbuild
@@ -11,4 +11,5 @@
    ))
    (c_names (stubs_utils))
    (wrapped false)
+   (flags (:standard -warn-error "+1..49-3" -w "A-4-41-42-44"))
 ))

--- a/src/hostnet/mux.ml
+++ b/src/hostnet/mux.ml
@@ -67,7 +67,7 @@ module Make(Netif: V1_LWT.NETWORK) = struct
         (fun ip t acc ->
           Printf.sprintf "%s last_active_time = %.1f" (Ipaddr.V4.to_string ip) t.last_active_time :: acc
         ) t.rules [] in
-    Vfs.File.ro_of_string @@ String.concat "\n" xs
+    Vfs.File.ro_of_string (String.concat "\n" xs)
 
   let remove t rule =
     Log.debug (fun f -> f "removing switch port for %s" (Ipaddr.V4.to_string rule));
@@ -77,7 +77,7 @@ module Make(Netif: V1_LWT.NETWORK) = struct
     (* Does the packet match any of our rules? *)
     let open Frame in
     match parse [ buf ] with
-    | Ok (Ethernet { payload = Ipv4 { dst } }) ->
+    | Ok (Ethernet { payload = Ipv4 { dst; _ }; _ }) ->
       if RuleMap.mem dst t.rules then begin
         let port = RuleMap.find dst t.rules in
         port.last_active_time <- Unix.gettimeofday ();

--- a/src/hostnet_test/forwarding.ml
+++ b/src/hostnet_test/forwarding.ml
@@ -67,8 +67,6 @@ module ForwardServer = struct
 end
 
 module Forward = Forward.Make(struct
-  type port = Forward.Port.t
-
   include Host.Sockets.Stream.Tcp
 
   open Lwt.Infix
@@ -226,7 +224,7 @@ module ForwardControl = struct
         Lwt.return { t; fid; ip; port }
       | _ -> failwith ("failed to parse response: " ^ line)
     end else failwith response
-  let destroy { t; fid } =
+  let destroy { t; fid; _ } =
     Client.LowLevel.clunk t.ninep fid
     >>*= fun _clunk ->
     Lwt.return ()

--- a/src/hostnet_test/jbuild
+++ b/src/hostnet_test/jbuild
@@ -5,4 +5,5 @@
      dns.mirage lwt.preemptive uwt.preemptive
    ))
    (preprocess  no_preprocessing)
+   (flags (:standard -warn-error "+1..49-3" -w "A-4-41-42-44"))
 ))

--- a/src/hostnet_test/main_lwt.ml
+++ b/src/hostnet_test/main_lwt.ml
@@ -1,5 +1,3 @@
-open Lwt.Infix
-
 let src =
   let src = Logs.Src.create "test" ~doc:"Test the slirp stack" in
   Logs.Src.set_level src (Some Logs.Debug);

--- a/src/hostnet_test/main_uwt.ml
+++ b/src/hostnet_test/main_uwt.ml
@@ -1,5 +1,3 @@
-open Lwt.Infix
-
 let src =
   let src = Logs.Src.create "test" ~doc:"Test the slirp stack" in
   Logs.Src.set_level src (Some Logs.Debug);

--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -11,7 +11,7 @@ module Dns_policy = struct
   let config_of_ips ips =
     let open Dns_forward.Config in
     let servers = Server.Set.of_list (
-      List.map (fun (ip, port) ->
+      List.map (fun (ip, _) ->
         {
           Server.address = { Address.ip; port = 53 }; zones = Domain.Set.empty;
           timeout_ms = Some 2000; order = 0;
@@ -113,18 +113,17 @@ let peer_ip = Ipaddr.V4.of_string_exn "192.168.65.2"
 let local_ip = Ipaddr.V4.of_string_exn "192.168.65.1"
 let server_macaddr = Slirp.default_server_macaddr
 
-let global_arp_table : Slirp.arp_table = 
-  { mutex = Lwt_mutex.create (); 
-    table = [(local_ip, Slirp.default_server_macaddr)] 
+let global_arp_table : Slirp.arp_table =
+  { Slirp.mutex = Lwt_mutex.create ();
+    table = [(local_ip, Slirp.default_server_macaddr)]
   }
 
-let client_uuids : Slirp.uuid_table = 
-  { mutex = Lwt_mutex.create ();
+let client_uuids : Slirp.uuid_table =
+  { Slirp.mutex = Lwt_mutex.create ();
     table = Hashtbl.create 50;
   }
 
 let config_without_bridge =
-  let never, _ = Lwt.task () in
   {
     Slirp.peer_ip;
     local_ip;
@@ -182,7 +181,6 @@ let with_stack f =
   | Result.Ok flow ->
   Log.info (fun f -> f "Made a loopback connection");
   let client_macaddr = Slirp.default_client_macaddr in
-  let server_macaddr = Slirp.default_server_macaddr in
   let uuid = (match Uuidm.of_string "d1d9cd61-d0dc-4715-9bb3-4c11da7ad7a5" with
   | Some x -> x
   | None -> failwith "unable to parse test uuid") in

--- a/src/hostnet_test/suite.ml
+++ b/src/hostnet_test/suite.ml
@@ -77,11 +77,11 @@ let test_localhost_local_query server use_host () =
       (fun _ stack ->
         let resolver = DNS.create stack in
         Lwt_list.iter_s
-          (fun name ->
+          (fun _ ->
             let request =
               DNS.gethostbyname ~server resolver "localhost.local"
               >>= function
-              | (_ :: _) as ips ->
+              | _ :: _ ->
                 Log.err (fun f -> f "successfully resolved localhost.local: this shouldn't happen");
                 failwith "Successfully resolved localhost.local"
               | _ ->
@@ -139,7 +139,7 @@ let test_max_connections () =
               Host.Sockets.set_max_connections (Some 0);
               begin Client.TCPV4.create_connection (Client.tcpv4 stack) (ip, 80)
               >>= function
-              | `Ok flow ->
+              | `Ok _ ->
                 Log.err (fun f -> f "Connected to www.google.com, max_connections exceeded");
                 failwith "too many connections"
               | `Error _ ->
@@ -264,7 +264,7 @@ let rec count = function 0 -> [] | n -> () :: (count (n - 1))
 let test_stream_data connections length () =
   let t =
     DevNullServer.with_server
-      (fun { DevNullServer.local_port } ->
+      (fun { DevNullServer.local_port; _ } ->
         with_stack
           (fun _ stack ->
             Lwt_list.iter_p

--- a/src/ofs/jbuild
+++ b/src/ofs/jbuild
@@ -6,5 +6,6 @@
     mirage-types.lwt astring named-pipe.lwt
    ))
    (wrapped false)
+   (flags (:standard -warn-error "+1..49-3" -w "A-4-41-42-44"))
 ))
 


### PR DESCRIPTION
Previously the `-w` and `-warn-error` compiler arguments were lost with the switch to `jbuilder`. This PR

- fixes all the warnings including
  - the `Lwt_unix.bind` deprecation warning by using the new `Lwt_unix.Versioned.bind_2`
  - avoiding pattern matching on a `Failure <string>`
- re-enables `-w` and selective `-warn-error`