### PR TITLE
Add command-line argument `--listen-backlog <n>`

### DIFF
--- a/src/hostnet/host_lwt_unix.ml
+++ b/src/hostnet/host_lwt_unix.ml
@@ -552,7 +552,7 @@ module Stream = struct
                 (fun () ->
                   Lwt.finalize
                     (fun () ->
-                      Lwt_unix.listen fd Utils.somaxconn;
+                      Lwt_unix.listen fd (!Utils.somaxconn);
                       loop fd
                     ) (fun () ->
                       shutdown server

--- a/src/hostnet/host_uwt.ml
+++ b/src/hostnet/host_uwt.ml
@@ -580,7 +580,7 @@ module Sockets = struct
       let listen server' cb =
         List.iter
           (fun (_, fd) ->
-             let listen_result = Uwt.Tcp.listen fd ~max:Utils.somaxconn ~cb:(fun server x ->
+             let listen_result = Uwt.Tcp.listen fd ~max:(!Utils.somaxconn) ~cb:(fun server x ->
                try
                  if Uwt.Int_result.is_error x then
                    Log.err (fun f -> f "Uwt.Tcp.listen callback failed with: %s" (Uwt.strerror @@ Uwt.Int_result.to_error x))
@@ -798,7 +798,7 @@ module Sockets = struct
         server.disable_connection_tracking <- true
 
       let listen ({ fd; _ } as server') cb =
-        let listen_result = Uwt.Pipe.listen fd ~max:Utils.somaxconn ~cb:(fun server x ->
+        let listen_result = Uwt.Pipe.listen fd ~max:(!Utils.somaxconn) ~cb:(fun server x ->
           try
             if Uwt.Int_result.is_error x then
               Log.err (fun f -> f "Uwt.Pipe.listen callback failed with: %s" (Uwt.strerror @@ Uwt.Int_result.to_error x))

--- a/src/hostnet/utils.ml
+++ b/src/hostnet/utils.ml
@@ -1,4 +1,4 @@
 
 external get_SOMAXCONN: unit -> int = "stub_get_SOMAXCONN"
 
-let somaxconn = get_SOMAXCONN ()
+let somaxconn = ref (get_SOMAXCONN ())

--- a/src/hostnet/utils.mli
+++ b/src/hostnet/utils.mli
@@ -1,2 +1,2 @@
 
-val somaxconn: int
+val somaxconn: int ref (* can be overriden by the command-line *)


### PR DESCRIPTION
Previously we always used `SOMAXCONN` for the `listen(2)` backlog. This patch allows the backlog to be overriden.

Signed-off-by: David Scott <dave.scott@docker.com>