### PR TITLE
test: check that we can consume more than 1024 file descriptors

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -33,6 +33,8 @@ opam install $(ls -1 ${OPAM_REPO}/packages/upstream) -y
 OPAMVERBOSE=1 opam install --deps-only slirp -y
 
 OPAMVERBOSE=1 make
+# One test requires 1026 file descriptors
+ulimit -n 1500
 OPAMVERBOSE=1 make test
 OPAMVERBOSE=1 make artefacts
 OPAMVERBOSE=1 make OSS-LICENSES

--- a/src/bin/bind.ml
+++ b/src/bin/bind.ml
@@ -26,6 +26,7 @@ module Make(Socket: Sig.SOCKETS) = struct
   let register_connection = Socket.register_connection
   let deregister_connection = Socket.deregister_connection
   let set_max_connections = Socket.set_max_connections
+  let get_num_connections = Socket.get_num_connections
   let connections = Socket.connections
   exception Too_many_connections = Socket.Too_many_connections
 

--- a/src/hostnet/host_lwt_unix.ml
+++ b/src/hostnet/host_lwt_unix.ml
@@ -35,6 +35,7 @@ let next_connection_idx =
 exception Too_many_connections
 
 let connection_table = Hashtbl.create 511
+let get_num_connections () = Hashtbl.length connection_table
 let connections () =
   let xs = Hashtbl.fold (fun _ c acc -> c :: acc) connection_table [] in
   Vfs.File.ro_of_string (String.concat "\n" xs)

--- a/src/hostnet/host_uwt.ml
+++ b/src/hostnet/host_uwt.ml
@@ -69,6 +69,7 @@ module Sockets = struct
   exception Too_many_connections
 
   let connection_table = Hashtbl.create 511
+  let get_num_connections () = Hashtbl.length connection_table
   let connections () =
     let xs = Hashtbl.fold (fun _ c acc -> c :: acc) connection_table [] in
     Vfs.File.ro_of_string (String.concat "\n" xs)

--- a/src/hostnet/sig.ml
+++ b/src/hostnet/sig.ml
@@ -67,6 +67,8 @@ module type SOCKETS = sig
   (** TODO: hide these by refactoring Hyper-V sockets stuff *)
   val register_connection: string -> int Lwt.t
   val deregister_connection: int -> unit
+  val get_num_connections: unit -> int
+  (** Fetch the number of tracked connections *)
   val connections: unit -> Vfs.File.t
   (** A filesystem which allows the connections to be introspected *)
 

--- a/src/hostnet_test/main_uwt.ml
+++ b/src/hostnet_test/main_uwt.ml
@@ -23,4 +23,4 @@ let () =
         Printf.fprintf stderr "Starting test case %s\n%!" case;
         fn ()
       ) cases
-    ) Tests.tests
+    ) (Tests.tests @ Tests.scalability)


### PR DESCRIPTION
This is a basic sanity check of the underlying I/O engine.

Note that Lwt_unix calls `select` which fails with `EINVAL` so we skip this test. This is part of the reason we switched the default to `Uwt`/`libuv` anyway.

Signed-off-by: David Scott <dave.scott@docker.com>