### PR TITLE
test: check what happens after we hit the connection limit

### DIFF
--- a/src/hostnet_test/suite.ml
+++ b/src/hostnet_test/suite.ml
@@ -146,6 +146,18 @@ let test_max_connections () =
                 Log.debug (fun f -> f "Expected failure to connect to www.google.com");
                 Lwt.return ()
               end
+              >>= fun () ->
+              Host.Sockets.set_max_connections None;
+              (* Check that connections work again *)
+              begin Client.TCPV4.create_connection (Client.tcpv4 stack) (ip, 80)
+              >>= function
+              | `Ok _ ->
+                Log.debug (fun f -> f "Connected to www.google.com");
+                Lwt.return ()
+              | `Error _ ->
+                Log.debug (fun f -> f "Failure to connect to www.google.com: removing max_connections limit didn't work");
+                failwith "wrong max connections limit"
+              end
             | _ ->
               Log.err (fun f -> f "Failed to look up an IPv4 address for www.google.com");
               failwith "http_fetch dns"


### PR DESCRIPTION
We impose a connection limit to avoid hitting the system limits (particularly the global limits on Mac). Previously the test would check that we couldn't exceed the connection limit. This patch extends the test to check that, when the limit is raised, we can still make outgoing connections. This verifies that the act of hitting the limit does not break the stack i.e. we should be able to recover afterwards.

Signed-off-by: David Scott <dave.scott@docker.com>