### PR TITLE
Improve logging and make the tests easier to debug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,7 @@ vpnkit.exe: src/bin/depends.ml
 
 .PHONY: test
 test:
-	jbuilder build src/hostnet_test/main_lwt.exe
 	jbuilder build src/hostnet_test/main_uwt.exe
-	./_build/default/src/hostnet_test/main_lwt.exe
 	./_build/default/src/hostnet_test/main_uwt.exe
 
 .PHONY: OSS-LICENSES

--- a/src/bin/bind.ml
+++ b/src/bin/bind.ml
@@ -27,6 +27,7 @@ module Make(Socket: Sig.SOCKETS) = struct
   let deregister_connection = Socket.deregister_connection
   let set_max_connections = Socket.set_max_connections
   let connections = Socket.connections
+  exception Too_many_connections = Socket.Too_many_connections
 
   let of_fd fd =
     let buf = Cstruct.create Init.sizeof in

--- a/src/hostnet/host_uwt.ml
+++ b/src/hostnet/host_uwt.ml
@@ -83,7 +83,7 @@ module Sockets = struct
       let now = Unix.gettimeofday () in
       if (now -. !last_error_log) > 30. then begin
         (* Avoid hammering the logging system *)
-        Log.err (fun f -> f "exceeded maximum number of forwarded connections (%d)" m);
+        Log.warn (fun f -> f "exceeded maximum number of forwarded connections (%d)" m);
         last_error_log := now;
       end;
       Lwt.fail Too_many_connections

--- a/src/hostnet/sig.ml
+++ b/src/hostnet/sig.ml
@@ -70,6 +70,8 @@ module type SOCKETS = sig
   val connections: unit -> Vfs.File.t
   (** A filesystem which allows the connections to be introspected *)
 
+  exception Too_many_connections
+
   module Datagram: sig
 
     type address = Ipaddr.t * int

--- a/src/hostnet_test/forwarding.ml
+++ b/src/hostnet_test/forwarding.ml
@@ -308,8 +308,8 @@ let test_10_connections () =
       ) in
   run t
 
-let test = [
-  "Test one port forward", `Quick, test_one_forward;
-  "Check speed of 10 forwarded connections", `Quick, test_10_connections;
+let tests = [
+  "Ports: 1 port forward", [ "Perform an HTTP GET through a port forward", `Quick, test_one_forward ];
+  "Ports: 10 port forwards", [ "Perform 10 HTTP GETs through a port forward", `Quick, test_10_connections ];
 ]
 end

--- a/src/hostnet_test/hosts_test.ml
+++ b/src/hostnet_test/hosts_test.ml
@@ -40,9 +40,5 @@ let test_one txt expected () =
   ) (List.combine expected x)
 
 let tests = List.map (fun (name, txt, expected) ->
-  "hosts " ^ name, `Quick, test_one txt expected
+  "hosts " ^ name, [ "", `Quick, test_one txt expected ]
 ) examples
-
-let suite = [
-  "hosts", tests;
-]

--- a/src/hostnet_test/main_lwt.ml
+++ b/src/hostnet_test/main_lwt.ml
@@ -7,10 +7,6 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 module Tests = Suite.Make(Host_lwt_unix)
 
-let tests =
-  (List.map (fun (name, test) -> name ^ "_with_Lwt", test) Tests.suite) @
-  Hosts_test.suite
-
 (* Run it *)
 let () =
   Logs.set_reporter (Logs_fmt.reporter ());
@@ -20,4 +16,4 @@ let () =
       (Printexc.get_backtrace ())
     )
   );
-  Alcotest.run "Hostnet" tests
+  Alcotest.run "Hostnet" Tests.tests

--- a/src/hostnet_test/main_uwt.ml
+++ b/src/hostnet_test/main_uwt.ml
@@ -16,4 +16,11 @@ let () =
       (Printexc.get_backtrace ())
     )
   );
-  Alcotest.run "Hostnet" Tests.tests
+  List.iter
+    (fun (test, cases) ->
+      Printf.fprintf stderr "\n**** Starting test %s\n%!" test;
+      List.iter (fun (case, _, fn) ->
+        Printf.fprintf stderr "Starting test case %s\n%!" case;
+        fn ()
+      ) cases
+    ) Tests.tests

--- a/src/hostnet_test/main_uwt.ml
+++ b/src/hostnet_test/main_uwt.ml
@@ -7,10 +7,6 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 module Tests = Suite.Make(Host_uwt)
 
-let tests =
-  (List.map (fun (name, test) -> name ^ "_with_Uwt", test) Tests.suite) @
-  Hosts_test.suite
-
 (* Run it *)
 let () =
   Logs.set_reporter (Logs_fmt.reporter ());
@@ -20,4 +16,4 @@ let () =
       (Printexc.get_backtrace ())
     )
   );
-  Alcotest.run "Hostnet" tests
+  Alcotest.run "Hostnet" Tests.tests

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -197,12 +197,12 @@ module Make(Host: Sig.HOST) = struct
         )
     end
 
-  let suite = [
-    "interception", `Quick, test_interception;
-    "URI", `Quick, test_uri_absolute;
-    "custom_header", `Quick, test_x_header_preserved;
-    "user_agent", `Quick, test_user_agent_preserved;
-    "CONNECT", `Quick, test_http_connect;
+  let tests = [
+    "HTTP: interception", [ "", `Quick, test_interception ];
+    "HTTP: URI", [ "check that URIs are rewritten", `Quick, test_uri_absolute ];
+    "HTTP: custom header", [ "check that custom headers are preserved", `Quick, test_x_header_preserved ];
+    "HTTP: user-agent", [ "check that user-agent is preserved", `Quick, test_user_agent_preserved ];
+    "HTTP: CONNECT", [ "check that HTTP CONNECT works for HTTPS", `Quick, test_http_connect ];
   ]
 
 end

--- a/src/hostnet_test/test_nat.ml
+++ b/src/hostnet_test/test_nat.ml
@@ -321,11 +321,11 @@ module Make(Host: Sig.HOST) = struct
         ) in
     Host.Main.run t
 
-  let suite = [
-    "Shared NAT rule", `Quick, test_shared_nat_rule;
-    "1 UDP connection", `Quick, test_udp;
-    "2 UDP connections", `Quick, test_udp_2;
-    "NAT punch", `Quick, test_nat_punch;
-    "Source ports", `Quick, test_source_ports;
+  let tests = [
+    "NAT: shared rule", [ "", `Quick, test_shared_nat_rule ];
+    "NAT: 1 UDP connection", [ "", `Quick, test_udp ];
+    "NAT: 2 UDP connections", [ "", `Quick, test_udp_2 ];
+    "NAT: punch", [ "", `Quick, test_nat_punch ];
+    "NAT: source ports", [ "", `Quick, test_source_ports ];
   ]
 end


### PR DESCRIPTION
- remove unnecessary error logs (triggered by the tests)
- only test the `Uwt` backend since the `Lwt_unix` one is known broken
- run the tests with `List.iter` so we can associate the log output with the test that generated it