### PR TITLE
DNS: respond to AAAA queries with NXDomain

### DIFF
--- a/src/hostnet/host_uwt.ml
+++ b/src/hostnet/host_uwt.ml
@@ -1006,6 +1006,9 @@ module Dns = struct
       | { q_class = Q_IN; q_name; _ } when is_mdns q_name ->
         Log.debug (fun f -> f "DNS lookup of %s: return NXDomain" (Dns.Name.to_string q_name));
         Lwt.return []
+      | { q_class = Q_IN; q_type = Q_AAAA; q_name; _ } ->
+        Log.debug (fun f -> f "DNS lookup of AAAA %s: return NXDomain" (Dns.Name.to_string q_name));
+        Lwt.return []
       | { q_class = Q_IN; q_type; q_name; _ } ->
         begin
           query q_name q_type


### PR DESCRIPTION
Currently we don't have a working IPv6 stack so clients can't really use the IPv6 addresses they discover. They may cause confusion and possible request timeouts. This is an experiment to see if a network timeout bug is fixed in an IPv6 environment.

Possibly related to [docker/for-mac#1629]

Signed-off-by: David Scott <dave.scott@docker.com>