### PR TITLE
[DO NOT MERGE]: time out connections after 50 minutes

### DIFF
--- a/src/hostnet/mux.ml
+++ b/src/hostnet/mux.ml
@@ -70,7 +70,7 @@ module Make(Netif: V1_LWT.NETWORK) = struct
     Vfs.File.ro_of_string (String.concat "\n" xs)
 
   let remove t rule =
-    Log.debug (fun f -> f "removing switch port for %s" (Ipaddr.V4.to_string rule));
+    Log.warn (fun f -> f "removing switch port for %s" (Ipaddr.V4.to_string rule));
     t.rules <- RuleMap.remove rule t.rules
 
   let callback t buf =

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -642,7 +642,7 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
         Lwt.return (Ok ())
   end
 
-  (* If no traffic is received for 5 minutes, delete the endpoint and
+  (* If no traffic is received for 50 minutes, delete the endpoint and
      the switch port. *)
   let rec delete_unused_endpoints t () =
     Host.Time.sleep 30.
@@ -652,7 +652,7 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
          let now = Unix.gettimeofday () in
          let old_ips = IPMap.fold (fun ip endpoint acc ->
              let age = now -. endpoint.Endpoint.last_active_time in
-             if age > 300.0 then ip :: acc else acc
+             if age > 3000.0 then ip :: acc else acc
            ) t.endpoints [] in
          List.iter (fun ip ->
              Switch.remove t.switch ip;


### PR DESCRIPTION
Previously we would time out connections after 5 minutes; this patch
increases the timeout to 50 minutes as a test.

This patch also logs the `Switch.remove` event as "info" so the failure
should be more obvious.

Related to #234

Signed-off-by: David Scott <dave.scott@docker.com>