### PR TITLE
proxy: make sure we build static binary

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -12,7 +12,7 @@ build-in-container: $(DEPS)
 
 build/vpnkit-forwarder.linux: $(DEPS)
 	GOOS=linux GOARCH=amd64 \
-	go build -o $@ --ldflags -s --buildmode pie \
+	go build -o $@ --ldflags '-s -w -extldflags "-static"' --buildmode pie \
 	$(DEPS)
 
 build/vpnkit-expose-port.linux: build/vpnkit-forwarder.linux


### PR DESCRIPTION
linuxkit/virtsock currently needs cgo for the HVSOCK bindings. Pass
-static so we can run the code in a scratch container.

Signed-off-by: Magnus Skjegstad <magnus@skjegstad.com>