### PR TITLE
Respect the 'excludes' in the transparent http proxy

### DIFF
--- a/src/hostnet/hostnet_http.ml
+++ b/src/hostnet/hostnet_http.ml
@@ -68,7 +68,7 @@ module Exclude = struct
   let of_string s =
     let open Astring in
     (* Accept either space or comma-separated ignoring whitespace *)
-    let parts = String.fields ~is_sep:(fun c -> c = ',' || Char.Ascii.is_white c) s in
+    let parts = String.fields ~empty:false ~is_sep:(fun c -> c = ',' || Char.Ascii.is_white c) s in
     List.map One.of_string parts
 
   let to_string t = String.concat " " @@ (List.map One.to_string t)

--- a/src/hostnet/hostnet_http.ml
+++ b/src/hostnet/hostnet_http.ml
@@ -185,9 +185,7 @@ module Make
     module Response = Cohttp.Response.Make(IO)
   end
 
-  let choose_proxy_for ~t _uri = t.http
-
-  let http ~dst ~t =
+  let http ~dst ~t h =
     let open Lwt.Infix in
     let listeners _port =
       Log.debug (fun f -> f "HTTP TCP handshake complete");
@@ -206,10 +204,10 @@ module Make
                 (* The scheme from cohttp is missing. If we send to an HTTP proxy
                    then we need it. *)
                 let uri = Uri.with_scheme (Cohttp.Request.uri req) (Some "http") in
-                let address = match Exclude.matches dst (Some req) t.exclude, choose_proxy_for ~t uri with
-                  | true, _
-                  | false, None -> Ipaddr.V4 dst, 80 (* direct connection *)
-                  | false, Some (ip, port) -> ip, port in
+                let address =
+                  if Exclude.matches dst (Some req) t.exclude
+                  then Ipaddr.V4 dst, 80 (* direct connection *)
+                  else h in
                 (* Log the request to the console *)
                 Log.info (fun f -> f "%s:80 --> %s:%d %s %s %s\n%!"
                   (Ipaddr.V4.to_string dst)
@@ -302,104 +300,98 @@ module Make
       ) in
     Lwt.return listeners
 
-  let https ~dst ~t =
+  let https ~dst ((ip, port) as address) =
     let open Lwt.Infix in
     let listeners _port =
       Log.debug (fun f -> f "HTTPS TCP handshake complete");
       Some (fun flow ->
         Lwt.finalize
           (fun () ->
-            match Exclude.matches dst None t.exclude, t.https with
-            | true, _
-            | false, None ->
-              Log.warn (fun f -> f "Failed to proxy https: no proxy defined");
+            let host = Ipaddr.V4.to_string dst in
+            Log.info (fun f -> f "%s:443 --> %s:%d\n%!" host (Ipaddr.to_string ip) port);
+            let connect = Cohttp.Request.make ~meth:`CONNECT (Uri.make ()) in
+            let connect = { connect with Cohttp.Request.resource = Printf.sprintf "%s:%d" (Ipaddr.V4.to_string dst) 443 } in
+            Socket.Stream.Tcp.connect address
+            >>= function
+            | Error _ ->
+              Log.err (fun f -> f "Failed to connect to %s" (string_of_address address));
               Lwt.return_unit
-            | false, Some ((ip, port) as address) ->
-              let host = Ipaddr.V4.to_string dst in
-              Log.info (fun f -> f "%s:443 --> %s:%d\n%!" host (Ipaddr.to_string ip) port);
-              let connect = Cohttp.Request.make ~meth:`CONNECT (Uri.make ()) in
-              let connect = { connect with Cohttp.Request.resource = Printf.sprintf "%s:%d" (Ipaddr.V4.to_string dst) 443 } in
-              Socket.Stream.Tcp.connect address
-              >>= function
-              | Error _ ->
-                Log.err (fun f -> f "Failed to connect to %s" (string_of_address address));
-                Lwt.return_unit
-              | Ok remote ->
-                let outgoing = Outgoing.C.create remote in
-                Lwt.finalize
-                  (fun () ->
-                    Outgoing.Request.write ~flush:true (fun _ -> Lwt.return_unit) connect outgoing
-                    >>= fun () ->
-                    Outgoing.Response.read outgoing
-                    >>= function
-                    | `Eof ->
-                      Log.warn (fun f -> f "EOF from %s" (string_of_address address));
-                      Lwt.return_unit
-                    | `Invalid x ->
-                      Log.warn (fun f -> f "Failed to parse HTTP response on port %s: %s" (string_of_address address) x);
-                      Lwt.return_unit
-                    | `Ok res ->
-                      begin
-                        Log.info (fun f -> f "<-- %s %s %s\n%!"
-                          (Cohttp.Code.string_of_status res.Cohttp.Response.status)
-                          (Cohttp.Code.string_of_version res.Cohttp.Response.version)
-                          (Sexplib.Sexp.to_string_hum (Cohttp.Response.sexp_of_t res)));
-                        (* Since we've already layered a channel on top, we can't
-                           use the Mirage_flow.proxy since it would miss the contents
-                           already buffered. Therefore we write out own channel-level
-                           proxy here: *)
-                        let incoming = Incoming.C.create flow in
-                        let a_t =
-                          let rec loop () =
-                            Lwt.catch
-                              (fun () ->
-                                Outgoing.C.read_some outgoing
-                                >>= fun buf ->
-                                Incoming.C.write_buffer incoming buf;
-                                Incoming.C.flush incoming
-                                >>= fun () ->
-                                Lwt.return true
-                              ) (function
-                                | End_of_file -> Lwt.return false
-                                | e ->
-                                  Log.warn (fun f -> f "Possibly unexpected exeption %s in proxy" (Printexc.to_string e));
-                                  Lwt.return false)
-                            >>= fun continue ->
-                            if continue then loop () else begin
-                              Tcp.shutdown_write flow
+            | Ok remote ->
+              let outgoing = Outgoing.C.create remote in
+              Lwt.finalize
+                (fun () ->
+                  Outgoing.Request.write ~flush:true (fun _ -> Lwt.return_unit) connect outgoing
+                  >>= fun () ->
+                  Outgoing.Response.read outgoing
+                  >>= function
+                  | `Eof ->
+                    Log.warn (fun f -> f "EOF from %s" (string_of_address address));
+                    Lwt.return_unit
+                  | `Invalid x ->
+                    Log.warn (fun f -> f "Failed to parse HTTP response on port %s: %s" (string_of_address address) x);
+                    Lwt.return_unit
+                  | `Ok res ->
+                    begin
+                      Log.info (fun f -> f "<-- %s %s %s\n%!"
+                        (Cohttp.Code.string_of_status res.Cohttp.Response.status)
+                        (Cohttp.Code.string_of_version res.Cohttp.Response.version)
+                        (Sexplib.Sexp.to_string_hum (Cohttp.Response.sexp_of_t res)));
+                      (* Since we've already layered a channel on top, we can't
+                         use the Mirage_flow.proxy since it would miss the contents
+                         already buffered. Therefore we write out own channel-level
+                         proxy here: *)
+                      let incoming = Incoming.C.create flow in
+                      let a_t =
+                        let rec loop () =
+                          Lwt.catch
+                            (fun () ->
+                              Outgoing.C.read_some outgoing
+                              >>= fun buf ->
+                              Incoming.C.write_buffer incoming buf;
+                              Incoming.C.flush incoming
                               >>= fun () ->
-                              Lwt.return_unit
-                            end in
-                          loop () in
-                        let b_t =
-                          let rec loop () =
-                            Lwt.catch
-                              (fun () ->
-                                Incoming.C.read_some incoming
-                                >>= fun buf ->
-                                Outgoing.C.write_buffer outgoing buf;
-                                Outgoing.C.flush outgoing
-                                >>= fun () ->
-                                Lwt.return true
-                              ) (function
-                                | End_of_file -> Lwt.return false
-                                | e ->
-                                  Log.warn (fun f -> f "Possibly unexpected exeption %s in proxy" (Printexc.to_string e));
-                                  Lwt.return false)
-                            >>= fun continue ->
-                            if continue then loop () else begin
-                              Socket.Stream.Tcp.shutdown_write remote
+                              Lwt.return true
+                            ) (function
+                              | End_of_file -> Lwt.return false
+                              | e ->
+                                Log.warn (fun f -> f "Possibly unexpected exeption %s in proxy" (Printexc.to_string e));
+                                Lwt.return false)
+                          >>= fun continue ->
+                          if continue then loop () else begin
+                            Tcp.shutdown_write flow
+                            >>= fun () ->
+                            Lwt.return_unit
+                          end in
+                        loop () in
+                      let b_t =
+                        let rec loop () =
+                          Lwt.catch
+                            (fun () ->
+                              Incoming.C.read_some incoming
+                              >>= fun buf ->
+                              Outgoing.C.write_buffer outgoing buf;
+                              Outgoing.C.flush outgoing
                               >>= fun () ->
-                              Lwt.return_unit
-                            end in
-                          loop () in
-                        Lwt.join [ a_t; b_t ]
-                        >>= fun () ->
-                        Lwt.return_unit
-                      end
-                ) (fun () ->
-                  Socket.Stream.Tcp.close remote
-                )
+                              Lwt.return true
+                            ) (function
+                              | End_of_file -> Lwt.return false
+                              | e ->
+                                Log.warn (fun f -> f "Possibly unexpected exeption %s in proxy" (Printexc.to_string e));
+                                Lwt.return false)
+                          >>= fun continue ->
+                          if continue then loop () else begin
+                            Socket.Stream.Tcp.shutdown_write remote
+                            >>= fun () ->
+                            Lwt.return_unit
+                          end in
+                        loop () in
+                      Lwt.join [ a_t; b_t ]
+                      >>= fun () ->
+                      Lwt.return_unit
+                    end
+              ) (fun () ->
+                Socket.Stream.Tcp.close remote
+              )
           ) (fun () ->
             Tcp.close flow
           )
@@ -407,9 +399,11 @@ module Make
     Lwt.return listeners
 
   let handle ~dst:(ip, port) ~t =
-    if port = 80 && t.http <> None
-    then Some (http ~dst:ip ~t)
-    else if port = 443 && t.https <> None
-    then Some (https ~dst:ip ~t)
-    else None
+    match port, t.http, t.https with
+    | 80, Some h, _ -> Some (http ~dst:ip ~t h)
+    | 443, _, Some h ->
+      if Exclude.matches ip None t.exclude
+      then None
+      else Some (https ~dst:ip h)
+    | _, _, _ -> None
 end

--- a/src/hostnet/hostnet_http.mli
+++ b/src/hostnet/hostnet_http.mli
@@ -5,7 +5,7 @@ module Exclude: sig
   val of_string: string -> t
   val to_string: t -> string
 
-  val matches: Ipaddr.V4.t -> Cohttp.Request.t -> t -> bool
+  val matches: Ipaddr.V4.t -> Cohttp.Request.t option -> t -> bool
   (** If true, the given request should bypass the proxy *)
 end
 

--- a/src/hostnet/hostnet_http.mli
+++ b/src/hostnet/hostnet_http.mli
@@ -1,3 +1,14 @@
+module Exclude: sig
+  type t
+  (** A request destination which should bypass the proxy *)
+
+  val of_string: string -> t
+  val to_string: t -> string
+
+  val matches: Ipaddr.V4.t -> Cohttp.Request.t -> t -> bool
+  (** If true, the given request should bypass the proxy *)
+end
+
 module Make
     (Ip: V1_LWT.IPV4 with type prefix = Ipaddr.V4.t)
     (Udp: V1_LWT.UDPV4)

--- a/src/hostnet_test/suite.ml
+++ b/src/hostnet_test/suite.ml
@@ -407,7 +407,7 @@ module N = Test_nat.Make(Host)
 module H = Test_http.Make(Host)
 
 let tests = Hosts_test.tests @
-  F.tests @ test_dhcp @ (test_dns true) @ (test_dns false) @ test_tcp @ N.tests @ H.tests
+  F.tests @ test_dhcp @ (test_dns true) @ (test_dns false) @ test_tcp @ N.tests @ H.tests @ Test_http.Exclude.tests
 
 let scalability = [
   "1026conns", [ "Test many connections", `Quick, test_many_connections (1024 + 2) ];

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -11,34 +11,34 @@ module Exclude = struct
 
   let test_cidr_match () =
     let exclude = Hostnet_http.Exclude.of_string "10.0.0.0/24" in
-    let req = Cohttp.Request.make (Uri.of_string "http://localhost") in
+    let req = Some (Cohttp.Request.make (Uri.of_string "http://localhost")) in
     assert (Hostnet_http.Exclude.matches (Ipaddr.V4.of_string_exn "10.0.0.1") req exclude)
 
   let test_cidr_no_match () =
     let exclude = Hostnet_http.Exclude.of_string "10.0.0.0/24" in
-    let req = Cohttp.Request.make (Uri.of_string "http://localhost") in
+    let req = Some (Cohttp.Request.make (Uri.of_string "http://localhost")) in
     assert (not(Hostnet_http.Exclude.matches (Ipaddr.V4.of_string_exn "192.168.0.1") req exclude))
 
   let test_domain_match () =
     let exclude = Hostnet_http.Exclude.of_string "mit.edu" in
-    let req = Cohttp.Request.make (Uri.of_string "http://dave.mit.edu/") in
+    let req = Some (Cohttp.Request.make (Uri.of_string "http://dave.mit.edu/")) in
     assert (Hostnet_http.Exclude.matches (Ipaddr.V4.of_string_exn "10.0.0.1") req exclude)
 
   let test_domain_star_match () =
     let exclude = Hostnet_http.Exclude.of_string "*.mit.edu" in
-    let req = Cohttp.Request.make (Uri.of_string "http://dave.mit.edu/") in
+    let req = Some (Cohttp.Request.make (Uri.of_string "http://dave.mit.edu/")) in
     assert (Hostnet_http.Exclude.matches (Ipaddr.V4.of_string_exn "10.0.0.1") req exclude)
 
   let test_domain_no_match () =
     let exclude = Hostnet_http.Exclude.of_string "mit.edu" in
-    let req = Cohttp.Request.make (Uri.of_string "http://dave.recoil.org/") in
+    let req = Some (Cohttp.Request.make (Uri.of_string "http://dave.recoil.org/")) in
     assert (not(Hostnet_http.Exclude.matches (Ipaddr.V4.of_string_exn "10.0.0.1") req exclude))
 
   let test_list () =
     let exclude = Hostnet_http.Exclude.of_string "*.local, 169.254.0.0/16" in
-    let req = Cohttp.Request.make (Uri.of_string "http://dave.local/") in
+    let req = Some (Cohttp.Request.make (Uri.of_string "http://dave.local/")) in
     assert (Hostnet_http.Exclude.matches (Ipaddr.V4.of_string_exn "10.0.0.1") req exclude);
-    let req' = Cohttp.Request.make (Uri.of_string "http://dave.recoil.org/") in
+    let req' = Some (Cohttp.Request.make (Uri.of_string "http://dave.recoil.org/")) in
     assert (Hostnet_http.Exclude.matches (Ipaddr.V4.of_string_exn "169.254.0.1") req' exclude);
     assert (not(Hostnet_http.Exclude.matches (Ipaddr.V4.of_string_exn "10.0.0.1") req' exclude))
 


### PR DESCRIPTION
This PR adds support for basic 'excludes' which are a list (comma or whitespace separated) of entries like:

- `foo.com`: any subdomain of `foo.com`
- `*.foo.com`: any subdomain of `foo.com`
- `foo.*.com`: any subdomain of `foo.(anything).com`
- `1.2.3.4/24`: any address on the IPv4 network

If the IP destination or the HTTP request header (NB the HTTPS header is not available) match any of these excludes then the request is forwarded directly to the destination without being bounced via the proxy.