### PR TITLE
Attempt to fix CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,7 @@ general:
   - OSS-LICENSES
 dependencies:
   override:
-  - brew install wget opam dylibbundler libffi pkg-config
+  - brew install wget opam dylibbundler pkg-config
   - scripts/common.sh
 test:
   override:


### PR DESCRIPTION
The `brew install` step is failing because:

>  Error: libffi 3.0.13 is already installed
>  To upgrade to 3.2.1, run `brew upgrade libffi`

Signed-off-by: David Scott <dave.scott@docker.com>