### PR TITLE
travis: build a docker image with /vpnkit-{forwarder,expose-port}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: c
+
+sudo: required
+
+services:
+  - docker
+
+script:
+  - cd go && make from-scratch

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,0 +1,15 @@
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
+
+RUN apk add --no-cache go musl-dev build-base
+
+ADD . /go/src/github.com/moby/vpnkit/go
+WORKDIR /go/src/github.com/moby/vpnkit/go
+
+RUN GOPATH=/go make build/vpnkit-forwarder.linux build/vpnkit-expose-port.linux
+
+FROM scratch
+COPY --from=mirror /go/src/github.com/moby/vpnkit/go/build/vpnkit-forwarder.linux /vpnkit-forwarder
+COPY --from=mirror /go/src/github.com/moby/vpnkit/go/build/vpnkit-expose-port.linux /vpnkit-expose-port
+CMD ["/vpnkit-forwarder"]
+
+

--- a/go/Dockerfile.build
+++ b/go/Dockerfile.build
@@ -1,9 +1,9 @@
-FROM golang:1.8.1-alpine
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9
 
-RUN apk add --update build-base
+RUN apk add --no-cache go musl-dev build-base
 
 ADD . /go/src/github.com/moby/vpnkit/go
 WORKDIR /go/src/github.com/moby/vpnkit/go
 
-CMD GOPATH=/go make all
+CMD GOPATH=/go make build/vpnkit-forwarder.linux build/vpnkit-expose-port.linux
 

--- a/go/Dockerfile.scratch
+++ b/go/Dockerfile.scratch
@@ -1,0 +1,4 @@
+FROM scratch
+COPY build/vpnkit-forwarder.linux /vpnkit-forwarder
+COPY build/vpnkit-expose-port.linux /vpnkit-expose-port
+CMD ["/vpnkit-forwarder"]

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,14 +1,18 @@
 .PHONY: all clean fmt lint
 
+ORG?=vpnkit
+IMAGE=vpnkit-forwarder
 DEPS:=$(wildcard cmd/vpnkit-forwarder/*.go)
+HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
 
-all: build/vpnkit-forwarder.linux build/vpnkit-expose-port.linux
-
-build-in-container: $(DEPS) 
-	@docker build -t vpnkit-forwarder-build -f ./Dockerfile.build .
-	@docker run --rm \
+build-in-container: $(DEPS)
+	docker build -t vpnkit-forwarder-build -f ./Dockerfile.build .
+	docker run --rm \
 		-v ${CURDIR}/build:/go/src/github.com/moby/vpnkit/go/build \
 		vpnkit-forwarder-build
+
+from-scratch: build-in-container
+	docker build -t $(ORG)/$(IMAGE):$(HASH) -f ./Dockerfile.scratch .
 
 build/vpnkit-forwarder.linux: $(DEPS)
 	GOOS=linux GOARCH=amd64 \

--- a/go/Makefile
+++ b/go/Makefile
@@ -14,6 +14,9 @@ build-in-container: $(DEPS)
 from-scratch: build-in-container
 	docker build -t $(ORG)/$(IMAGE):$(HASH) -f ./Dockerfile.scratch .
 
+multi-stage: $(DEPS)
+	docker build -t $(ORG)/$(IMAGE):$(HASH) .
+
 build/vpnkit-forwarder.linux: $(DEPS)
 	GOOS=linux GOARCH=amd64 \
 	go build -o $@ --ldflags '-s -w -extldflags "-static"' --buildmode pie \


### PR DESCRIPTION
Since travis has a very old Docker, this builds in 2 phases:

1. build the Go binaries in an alpine image
2. build the final FROM scratch image using COPY

This is based on the linuxkit rules in

https://github.com/linuxkit/linuxkit/blob/master/pkg/vpnkit-forwarder/Makefile

Signed-off-by: David Scott <dave.scott@docker.com>