### PR TITLE
Add go/hooks/post_push to push an custom tag

### DIFF
--- a/go/hooks/post_push
+++ b/go/hooks/post_push
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo hooks/post_push: attempting to compute the tree SHA of the current directory
+pwd
+
+HASH=$(git ls-tree HEAD -- ../$(basename $(pwd)) | awk '{print $3}')
+
+echo Tagging "${IMAGE_NAME}" with "${DOCKER_REPO}:${HASH}"
+docker tag "${IMAGE_NAME}" "${DOCKER_REPO}:${HASH}"
+docker push "${DOCKER_REPO}:${HASH}"


### PR DESCRIPTION
Docker Cloud autobuilds support hook scripts which can be used to push custom tags. The LinuxKit convention is to tag binary images with the git tree hash of the source code i.e. the hash of the contents and not the history (the commit). This means that if more commits happen but the contents don't change, the tag remains the same too.

Signed-off-by: David Scott <dave.scott@docker.com>