### PR TITLE
Fix the linux image post_push script

### DIFF
--- a/go/hooks/post_push
+++ b/go/hooks/post_push
@@ -2,8 +2,12 @@
 
 echo hooks/post_push: attempting to compute the tree SHA of the current directory
 pwd
+CURDIR=$(pwd)
+# The git ls-tree HEAD ../<foo> fails on Docker Cloud's hook environment.
+# It works fine from the parent directory.
+cd ..
 
-HASH=$(git ls-tree HEAD -- ../$(basename $(pwd)) | awk '{print $3}')
+HASH=$(git ls-tree HEAD -- $(basename ${CURDIR}) | awk '{print $3}')
 
 echo Tagging "${IMAGE_NAME}" with "${DOCKER_REPO}:${HASH}"
 docker tag "${IMAGE_NAME}" "${DOCKER_REPO}:${HASH}"


### PR DESCRIPTION
Previously the script failed to compute the tree SHA because the `git ls-tree` in the Docker Cloud environment didn't like the path `../go`. It works fine as `go` if we `cd ..` first.

Signed-off-by: David Scott <dave.scott@docker.com>