### PR TITLE
travis: update to docker 17.05 for multistage build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ before_install: # update to 17.05 to get multistage builds
   - sudo apt-get -y install docker-ce=17.05.0~ce-0~ubuntu-trusty
 
 script:
-  - cd go && make multi-stage
+  - cd go && make build-in-container

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,11 @@ sudo: required
 services:
   - docker
 
+before_install: # update to 17.05 to get multistage builds
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) edge"
+  - sudo apt-get update
+  - sudo apt-get -y install docker-ce=17.05.0~ce-0~ubuntu-trusty
+
 script:
-  - cd go && make from-scratch
+  - cd go && make multi-stage

--- a/go/Dockerfile.build
+++ b/go/Dockerfile.build
@@ -1,9 +1,0 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9
-
-RUN apk add --no-cache go musl-dev build-base
-
-ADD . /go/src/github.com/moby/vpnkit/go
-WORKDIR /go/src/github.com/moby/vpnkit/go
-
-CMD GOPATH=/go make build/vpnkit-forwarder.linux build/vpnkit-expose-port.linux
-

--- a/go/Dockerfile.scratch
+++ b/go/Dockerfile.scratch
@@ -1,4 +1,0 @@
-FROM scratch
-COPY build/vpnkit-forwarder.linux /vpnkit-forwarder
-COPY build/vpnkit-expose-port.linux /vpnkit-expose-port
-CMD ["/vpnkit-forwarder"]

--- a/go/Makefile
+++ b/go/Makefile
@@ -5,16 +5,11 @@ IMAGE=vpnkit-forwarder
 DEPS:=$(wildcard cmd/vpnkit-forwarder/*.go)
 HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
 
+# This may fail when cross compiling as virtsock requires cgo
+all: build/vpnkit-forwarder.linux build/vpnkit-expost-port.linux
+
+# Build in linux container
 build-in-container: $(DEPS)
-	docker build -t vpnkit-forwarder-build -f ./Dockerfile.build .
-	docker run --rm \
-		-v ${CURDIR}/build:/go/src/github.com/moby/vpnkit/go/build \
-		vpnkit-forwarder-build
-
-from-scratch: build-in-container
-	docker build -t $(ORG)/$(IMAGE):$(HASH) -f ./Dockerfile.scratch .
-
-multi-stage: $(DEPS)
 	docker build -t $(ORG)/$(IMAGE):$(HASH) .
 
 build/vpnkit-forwarder.linux: $(DEPS)


### PR DESCRIPTION
Try to upgrade Docker to 17.05 to see if we can use the multi-stage build instead of maintaining two sets of Dockerfiles.
