### PR TITLE
go: split into 2 images

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache go musl-dev build-base
 ADD . /go/src/github.com/moby/vpnkit/go
 WORKDIR /go/src/github.com/moby/vpnkit/go
 
-RUN GOPATH=/go make build/vpnkit-forwarder.linux build/vpnkit-expose-port.linux
+RUN GOPATH=/go make build/vpnkit-forwarder.linux
 
 FROM scratch
 COPY --from=mirror /go/src/github.com/moby/vpnkit/go/build/vpnkit-forwarder.linux /vpnkit-forwarder

--- a/go/Dockerfile.expose-port
+++ b/go/Dockerfile.expose-port
@@ -5,7 +5,7 @@ RUN apk add --no-cache go musl-dev build-base
 ADD . /go/src/github.com/moby/vpnkit/go
 WORKDIR /go/src/github.com/moby/vpnkit/go
 
-RUN GOPATH=/go make build/vpnkit-forwarder.linux build/vpnkit-expose-port.linux
+RUN GOPATH=/go make build/vpnkit-expose-port.linux
 
 FROM scratch
-COPY --from=mirror /go/src/github.com/moby/vpnkit/go/build/vpnkit-expose-port.linux /vpnkit-expose-port
+COPY --from=mirror /go/src/github.com/moby/vpnkit/go/build/vpnkit-expose-port.linux /usr/local/bin/vpnkit-expose-port

--- a/go/Dockerfile.expose-port
+++ b/go/Dockerfile.expose-port
@@ -8,7 +8,4 @@ WORKDIR /go/src/github.com/moby/vpnkit/go
 RUN GOPATH=/go make build/vpnkit-forwarder.linux build/vpnkit-expose-port.linux
 
 FROM scratch
-COPY --from=mirror /go/src/github.com/moby/vpnkit/go/build/vpnkit-forwarder.linux /vpnkit-forwarder
-CMD ["/vpnkit-forwarder"]
-
-
+COPY --from=mirror /go/src/github.com/moby/vpnkit/go/build/vpnkit-expose-port.linux /vpnkit-expose-port

--- a/go/Makefile
+++ b/go/Makefile
@@ -9,8 +9,13 @@ HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
 all: build/vpnkit-forwarder.linux build/vpnkit-expost-port.linux
 
 # Build in linux container
-build-in-container: $(DEPS)
-	docker build -t $(ORG)/$(IMAGE):$(HASH) .
+build-in-container: build-forwarder-in-container build-expose-port-in-container
+
+build-forwarder-in-container: $(DEPS)
+	docker build -t $(ORG)/vpnkit-forwarder:$(HASH) -f Dockerfile .
+
+build-expose-port-in-container: $(DEPS)
+	docker build -t $(ORG)/vpnkit-expose-port:$(HASH) -f Dockerfile.expose-port .
 
 build/vpnkit-forwarder.linux: $(DEPS)
 	GOOS=linux GOARCH=amd64 \


### PR DESCRIPTION
- `Dockerfile`: builds `vpnkit-forwarder`
- `Dockerfile.expose-port`: builds `vpnkit-expose-port`

This will allow one to become a linuxkit service and the other to be part of system init.

Signed-off-by: David Scott <dave.scott@docker.com>