### PR TITLE
add vpnkit-iptables-wrapper

### DIFF
--- a/go/Dockerfile.expose-port
+++ b/go/Dockerfile.expose-port
@@ -5,7 +5,8 @@ RUN apk add --no-cache go musl-dev build-base
 ADD . /go/src/github.com/moby/vpnkit/go
 WORKDIR /go/src/github.com/moby/vpnkit/go
 
-RUN GOPATH=/go make build/vpnkit-expose-port.linux
+RUN GOPATH=/go make build/vpnkit-expose-port.linux build/vpnkit-iptables-wrapper.linux
 
 FROM scratch
 COPY --from=mirror /go/src/github.com/moby/vpnkit/go/build/vpnkit-expose-port.linux /usr/local/bin/vpnkit-expose-port
+COPY --from=mirror /go/src/github.com/moby/vpnkit/go/build/vpnkit-iptables-wrapper.linux /usr/local/bin/vpnkit-iptables-wrapper

--- a/go/Makefile
+++ b/go/Makefile
@@ -2,28 +2,35 @@
 
 ORG?=vpnkit
 IMAGE=vpnkit-forwarder
-DEPS:=$(wildcard cmd/vpnkit-forwarder/*.go)
+DEPS_FORWARDER:=$(wildcard cmd/vpnkit-forwarder/*.go)
+DEPS_IPTABLES:=$(wildcard cmd/vpnkit-iptables-wrapper/*.go)
+DEPS:=$(DEPS_IPTABLES) $(DEPS_FORWARDER)
 HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
 
 # This may fail when cross compiling as virtsock requires cgo
-all: build/vpnkit-forwarder.linux build/vpnkit-expost-port.linux
+all: build/vpnkit-iptables-wrapper.linux build/vpnkit-forwarder.linux build/vpnkit-expose-port.linux
 
 # Build in linux container
 build-in-container: build-forwarder-in-container build-expose-port-in-container
 
-build-forwarder-in-container: $(DEPS)
+build-forwarder-in-container: $(DEPS_FORWARDER)
 	docker build -t $(ORG)/vpnkit-forwarder:$(HASH) -f Dockerfile .
 
 build-expose-port-in-container: $(DEPS)
 	docker build -t $(ORG)/vpnkit-expose-port:$(HASH) -f Dockerfile.expose-port .
 
-build/vpnkit-forwarder.linux: $(DEPS)
+build/vpnkit-forwarder.linux: $(DEPS_FORWARDER)
 	GOOS=linux GOARCH=amd64 \
 	go build -o $@ --ldflags '-s -w -extldflags "-static"' --buildmode pie \
-	$(DEPS)
+	$(DEPS_FORWARDER)
 
 build/vpnkit-expose-port.linux: build/vpnkit-forwarder.linux
 	cp -v build/vpnkit-forwarder.linux build/vpnkit-expose-port.linux
+
+build/vpnkit-iptables-wrapper.linux: $(DEPS_IPTABLES)
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 \
+	go build -o $@ --ldflags '-s -w' --buildmode pie \
+	$(DEPS_IPTABLES)
 
 clean:
 	rm -rf build

--- a/go/cmd/vpnkit-iptables-wrapper/README.md
+++ b/go/cmd/vpnkit-iptables-wrapper/README.md
@@ -1,0 +1,6 @@
+#### VPNKit iptables wrapper for dockerd
+
+This is an iptables wrapper that will call `vpnkit-expose-port` when a swarm port is published by `dockerd` inside the guest VM. The wrapper has to be installed as `iptables` in $PATH in a location that comes before the regular iptables. It expects regular iptables to exist in `/sbin/iptables`.
+
+If the file `/var/config/vpnkit/native-port-forwarding` exists and contains a `0` all requests will be passed directly to `/sbin/iptables`, disabling the wrapper.
+

--- a/go/cmd/vpnkit-iptables-wrapper/main.go
+++ b/go/cmd/vpnkit-iptables-wrapper/main.go
@@ -1,0 +1,215 @@
+package main
+
+/*
+Spawns vpnkit-expose-port instances for swarm ports by wrapping calls to iptables in the format:
+
+--wait -t nat -I DOCKER-INGRESS -p tcp --dport 80 -j DNAT --to-destination 172.18.0.2:80
+--wait -t nat -D DOCKER-INGRESS -p tcp --dport 80 -j DNAT --to-destination 172.18.0.2:80
+*/
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+const iptablesPath = "/sbin/iptables"
+const configKey = "/var/config/vpnkit/native-port-forwarding"
+const vpnKitExposePort = "vpnkit-expose-port" // must be in PATH
+const pidDir = "/var/run/service-port-opener"
+
+type exposedPort struct {
+	proto string
+	dport string // host port
+	ip    string // container ip
+	port  string // container port
+}
+
+type stringVal struct {
+	val string
+}
+
+type ipPortVal struct {
+	IP   string
+	Port string
+}
+
+// pidFilename returns the path to a pid file for the exposed port
+func pidFileName(port exposedPort) string {
+	return fmt.Sprintf("%s/%s.%s.%s.%s.pid", pidDir, port.proto, port.dport, port.ip, port.port)
+}
+
+// insert starts a vpnKitExposePort process and writes the pid to a file in pidDir
+func insert(vpnKitExposePort string, port exposedPort) error {
+	cmd := exec.Command(vpnKitExposePort, "-proto", port.proto, "-container-ip", port.ip, "-container-port", port.port, "-host-ip", "0.0.0.0", "-host-port", port.dport, "-i", "-no-local-ip")
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	pidFile := pidFileName(port)
+	pidS := strconv.Itoa(cmd.Process.Pid)
+	if err := ioutil.WriteFile(pidFile, []byte(pidS), 0644); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// remove finds the corresponding pid file in pidDir and kills the vpnKitExposePort process
+func remove(port exposedPort) error {
+	pidFile := pidFileName(port)
+
+	buf, err := ioutil.ReadFile(pidFile)
+	if err != nil {
+		return err
+	}
+	pid, err := strconv.Atoi(string(buf))
+	if err != nil {
+		return err
+	}
+	err = syscall.Kill(pid, syscall.SIGTERM)
+	if err != nil {
+		return err
+	}
+
+	return os.Remove(pidFile)
+}
+
+// useNativePortForwarding is true if the key file exists and contains "1" or "true"
+func useNativePortForwarding() bool {
+	if f, err := os.Open(configKey); err == nil {
+		buf := bufio.NewScanner(f)
+		if buf.Scan() {
+			s := strings.ToLower(strings.Trim(buf.Text(), " \n"))
+			return s == "1" && s == "true"
+		}
+		defer f.Close()
+	} else {
+		if !os.IsNotExist(err) { // If error is different from file not found, output error message (but continue)
+			log.Println("Error opening", configKey, ":", err)
+		}
+	}
+	return false
+}
+
+func (o *stringVal) Set(s string) error {
+	o.val = s
+	return nil
+}
+
+func (o *stringVal) String() string {
+	return o.val
+}
+
+func (o *ipPortVal) Set(s string) error {
+	r := strings.SplitN(s, ":", 2)
+	if len(r) != 2 {
+		return fmt.Errorf("invalid ip:port pair")
+	}
+	o.IP = r[0]
+	o.Port = r[1]
+	return nil
+}
+
+func (o *ipPortVal) String() string {
+	return fmt.Sprintf("%s:%s", o.IP, o.Port)
+}
+
+// matchStringArray matches an array of strings against a pattern that can contain strings or *flag.Value structs.
+// Strings are matched against the input, Value structs will be set to the corresponding value in the input array.
+// May produce partial matches. Error is nil if the full pattern was matched.
+func matchStringArray(input []string, pattern []interface{}) error {
+	var err error
+	if len(input) < len(pattern) {
+		return fmt.Errorf("input shorter than pattern")
+	}
+	for idx := range pattern {
+		switch pattern[idx].(type) {
+		case string:
+			if pattern[idx].(string) != input[idx] {
+				return fmt.Errorf("input doesn't match pattern")
+			}
+		case flag.Value:
+			if err = pattern[idx].(flag.Value).Set(input[idx]); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unknown type in pattern")
+		}
+	}
+	return nil
+}
+
+func main() {
+	var err error
+	var vpnKitExposePortPath string
+	var iptables string
+
+	if iptables, err = exec.LookPath(iptablesPath); err != nil {
+		log.Fatalln(err)
+	}
+
+	if !useNativePortForwarding() {
+		if vpnKitExposePortPath, err = exec.LookPath(vpnKitExposePort); err != nil {
+			log.Fatalln(err)
+		}
+
+		if err = os.MkdirAll(pidDir, 0755); err != nil {
+			log.Fatalln(err)
+		}
+
+		/* This workaround is from the ocaml version. Original comment:
+		Close the vast number of fds I've inherited from docker
+		TODO(djs55): revisit, possibly by filing a docker/docker issue */
+
+		var f *os.File
+		for i := 3; i < 1024; i++ {
+			f = os.NewFile(uintptr(i), "")
+			f.Close()
+		}
+
+		// Expose port via vpnkit
+		var optProto, optDport, optAction stringVal
+		var optIPPort ipPortVal
+
+		err = matchStringArray(os.Args[1:], []interface{}{"--wait", "-t", "nat", &optAction, "DOCKER-INGRESS", "-p", &optProto, "--dport", &optDport, "-j", "DNAT", "--to-destination", &optIPPort})
+
+		if err == nil {
+			port := exposedPort{optProto.String(), optDport.String(), optIPPort.IP, optIPPort.Port}
+			switch optAction.String() {
+			case "-D":
+				remove(port)
+			case "-I":
+				insert(vpnKitExposePortPath, port)
+			}
+		} else {
+			// ignore errors here, just pass to iptables
+		}
+	}
+
+	// Run iptables
+	cmd := exec.Command(iptables, os.Args[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+	if err = cmd.Run(); err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			// exit with exit code from process
+			status := exitError.Sys().(syscall.WaitStatus)
+			os.Exit(status.ExitStatus())
+		} else {
+			// no exit code, report error and exit 1
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+
+}


### PR DESCRIPTION
This wrapper calls vpnkit-expose-port when swarm service ports are
opened by dockerd using iptables.

To be used up by dockerd it has to be in path before the regular
iptables. The wrapper expects /sbin/iptables to contain the original
binary.

This is a go version of the iptables-wrapper originally written in
OCaml:

https://github.com/linuxkit/linuxkit/blob/f27c3ff5eda58d76e49ce5129b3cb29e402be272/alpine/base/pinata-iptables/main.ml

Signed-off-by: Magnus Skjegstad <magnus@skjegstad.com>