### PR TITLE
Don't disable DNS queries for .local

### DIFF
--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -279,7 +279,7 @@ let main_t socket_url port_control_url introspection_url diagnostics_url max_con
       local_ip;
       extra_dns_ip = [];
       get_domain_search = (fun () -> []);
-      get_domain_name = (fun () -> "local");
+      get_domain_name = (fun () -> "localdomain");
       global_arp_table;
       client_uuids;
       bridge_connections = true;

--- a/src/hostnet/host_lwt_unix.ml
+++ b/src/hostnet/host_lwt_unix.ml
@@ -810,16 +810,13 @@ module Dns = struct
       | _ -> acc
     ) [] x
 
-  let is_mdns name =
-    match List.rev @@ Dns.Name.to_string_list name with
-    | [] -> false
-    | n :: _ -> n = "local"
+  let localhost_local = Dns.Name.of_string "localhost.local"
 
   let resolve question =
     let open Dns.Packet in
     begin match question with
-      | { q_class = Q_IN; q_name; _ } when is_mdns q_name ->
-        Log.debug (fun f -> f "DNS lookup of %s: return NXDomain" (Dns.Name.to_string q_name));
+      | { q_class = Q_IN; q_name; _ } when q_name = localhost_local ->
+        Log.debug (fun f -> f "DNS lookup of localhost.local: return NXDomain");
         Lwt.return (q_name, [])
       | { q_class = Q_IN; q_type = Q_A; q_name; _ } ->
         getaddrinfo (Dns.Name.to_string q_name) Unix.PF_INET

--- a/src/hostnet/host_uwt.ml
+++ b/src/hostnet/host_uwt.ml
@@ -961,16 +961,13 @@ module Dns = struct
         | _ -> acc
       ) [] x
 
-  let is_mdns name =
-    match List.rev @@ Dns.Name.to_string_list name with
-    | [] -> false
-    | n :: _ -> n = "local"
+  let localhost_local = Dns.Name.of_string "localhost.local"
 
   let resolve_getaddrinfo question =
     let open Dns.Packet in
     begin match question with
-      | { q_class = Q_IN; q_name; _ } when is_mdns q_name ->
-        Log.debug (fun f -> f "DNS lookup of %s: return NXDomain" (Dns.Name.to_string q_name));
+      | { q_class = Q_IN; q_name; _ } when q_name = localhost_local ->
+        Log.debug (fun f -> f "DNS lookup of localhost.local: return NXDomain");
         Lwt.return (q_name, [])
       | { q_class = Q_IN; q_type = Q_A; q_name; _ } ->
         getaddrinfo (Dns.Name.to_string q_name) Unix.PF_INET
@@ -1003,8 +1000,8 @@ module Dns = struct
         ) () in
 
     begin match question with
-      | { q_class = Q_IN; q_name; _ } when is_mdns q_name ->
-        Log.debug (fun f -> f "DNS lookup of %s: return NXDomain" (Dns.Name.to_string q_name));
+      | { q_class = Q_IN; q_name; _ } when q_name = localhost_local ->
+        Log.debug (fun f -> f "DNS lookup of localhost.local: return NXDomain");
         Lwt.return []
       | { q_class = Q_IN; q_type; q_name; _ } ->
         begin

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -903,7 +903,7 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
       ) string_resolver_settings
     >>= fun resolver_settings ->
 
-    let domain_name = ref "local" in
+    let domain_name = ref "localdomain" in
     let get_domain_name () = !domain_name in
     let domain_name_path = driver @ [ "slirp"; "domain" ] in
     Config.string config ~default:(!domain_name) domain_name_path


### PR DESCRIPTION
Previously we disabled queries for `*.local` to avoid using (slow) mDNS but some users do use this domain and need it to work.

This PR
- removes the workaround so `*.local` queries will work
- sets the default domain name to `localdomain` rather than `local` so we don't trigger mDNS by accident

Related to [docker/for-mac#1811]