### PR TITLE
Dhcp: make the dynamic DHCP range configurable

### DIFF
--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -265,6 +265,7 @@ let main_t socket_url port_control_url introspection_url diagnostics_url max_con
     let server_macaddr = Slirp.default_server_macaddr in
     let peer_ip = Ipaddr.V4.of_string_exn "192.168.65.2" in
     let local_ip = Ipaddr.V4.of_string_exn "192.168.65.1" in
+    let highest_ip = Ipaddr.V4.of_string_exn "192.168.65.254" in
     let client_uuids : Slirp.uuid_table = {
         Slirp.mutex = Lwt_mutex.create ();
         table = Hashtbl.create 50;
@@ -277,6 +278,7 @@ let main_t socket_url port_control_url introspection_url diagnostics_url max_con
       Slirp.server_macaddr;
       peer_ip;
       local_ip;
+      highest_ip;
       extra_dns_ip = [];
       get_domain_search = (fun () -> []);
       get_domain_name = (fun () -> "local");

--- a/src/hostnet/slirp.mli
+++ b/src/hostnet/slirp.mli
@@ -19,6 +19,7 @@ type config = {
   server_macaddr: Macaddr.t;
   peer_ip: Ipaddr.V4.t;
   local_ip: Ipaddr.V4.t;
+  highest_ip: Ipaddr.V4.t;
   extra_dns_ip: Ipaddr.V4.t list;
   get_domain_search: unit -> string list;
   get_domain_name: unit -> string;

--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -111,6 +111,7 @@ let extra_dns_ip = List.map Ipaddr.V4.of_string_exn [
 
 let peer_ip = Ipaddr.V4.of_string_exn "192.168.65.2"
 let local_ip = Ipaddr.V4.of_string_exn "192.168.65.1"
+let highest_ip = Ipaddr.V4.of_string_exn "192.168.65.254"
 let server_macaddr = Slirp.default_server_macaddr
 
 let global_arp_table : Slirp.arp_table =
@@ -127,6 +128,7 @@ let config_without_bridge =
   {
     Slirp.peer_ip;
     local_ip;
+    highest_ip;
     extra_dns_ip;
     server_macaddr;
     get_domain_search = (fun () -> []);


### PR DESCRIPTION
When `bridge-connections` is enabled the server will reserve more IP addresses for clients such as LinuxKit which connect to the vpnkit network. Previously it was not possible to adjust fully the range of addresses handed out, so if you had a clash you were out of luck.

This patch plumbs through a new `slirp/highest-ip` setting so that clashes can be worked around.

Related to [docker/for-mac#1803]

Signed-off-by: David Scott <dave.scott@docker.com>