### PR TITLE
go: add a library to manage exposed ports

### DIFF
--- a/go/cmd/vpnkit-expose-port/main.go
+++ b/go/cmd/vpnkit-expose-port/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+
+	vpnkit "github.com/moby/vpnkit/go/pkg/vpnkit"
+)
+
+// Expose ports via the control interface
+
+func main() {
+	proto := flag.String("proto", "tcp", "proxy protocol")
+	hostIP := flag.String("host-ip", "", "host ip")
+	hostPort := flag.Int("host-port", -1, "host port")
+	containerIP := flag.String("container-ip", "", "container ip")
+	containerPort := flag.Int("container-port", -1, "container port")
+	path := flag.String("vpnkit", os.Getenv("HOME")+"/Library/Containers/com.docker.docker/Data/s51", "path to vpnkit's control socket")
+	flag.Parse()
+
+	c, err := vpnkit.NewConnection(context.Background(), *path)
+	if err != nil {
+		log.Fatal(err)
+	}
+	outIP := net.ParseIP(*hostIP)
+	outPort := int16(*hostPort)
+	inIP := net.ParseIP(*containerIP)
+	inPort := int16(*containerPort)
+	p := vpnkit.NewPort(c, *proto, outIP, outPort, inIP, inPort)
+	if err = p.Expose(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+	defer p.Unexpose(context.Background())
+
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt)
+	<-ch
+}

--- a/go/pkg/vpnkit/connection.go
+++ b/go/pkg/vpnkit/connection.go
@@ -1,0 +1,22 @@
+package vpnkit
+
+import (
+	"context"
+
+	datakit "github.com/moby/datakit/api/go-datakit"
+)
+
+// Connection represents an open control connection to vpnkit
+type Connection struct {
+	client *datakit.Client
+}
+
+// NewConnection connects to a vpnkit Unix domain socket on the given path
+// and returns the connection
+func NewConnection(ctx context.Context, path string) (*Connection, error) {
+	client, err := datakit.Dial(ctx, "unix", path)
+	if err != nil {
+		return nil, err
+	}
+	return &Connection{client}, nil
+}

--- a/go/pkg/vpnkit/doc.go
+++ b/go/pkg/vpnkit/doc.go
@@ -1,0 +1,9 @@
+/*
+Package vpnkit allows a running VPNKit service to be reconfigured.
+
+Features
+
+- expose/unexpose TCP and UDP ports
+
+*/
+package vpnkit

--- a/go/pkg/vpnkit/port.go
+++ b/go/pkg/vpnkit/port.go
@@ -1,0 +1,118 @@
+package vpnkit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"strings"
+
+	p9p "github.com/docker/go-p9p"
+	datakit "github.com/moby/datakit/api/go-datakit"
+)
+
+// Port represents a UDP or TCP exposed port
+type Port struct {
+	client  *datakit.Client
+	proto   string
+	outIP   net.IP
+	outPort int16
+	inIP    net.IP
+	inPort  int16
+	handle  *datakit.File
+}
+
+func NewPort(connection *Connection, proto string, outIP net.IP, outPort int16, inIP net.IP, inPort int16) *Port {
+	return &Port{connection.client, proto, outIP, outPort, inIP, inPort, nil}
+}
+
+// spec returns a string of the form proto:outIP:outPort:proto:inIP:inPort as
+// understood by vpnkit
+func (p *Port) spec() string {
+	return fmt.Sprintf("%s:%s:%d:%s:%s:%d", p.proto, p.outIP.String(), p.outPort, p.proto, p.inIP.String(), p.inPort)
+}
+
+// Expose asks vpnkit to expose the port
+func (p *Port) Expose(ctx context.Context) error {
+	if p.handle != nil {
+		return errors.New("Port is already exposed")
+	}
+	spec := p.spec()
+	client := p.client
+	// use the spec also as a name
+	name := spec
+
+	log.Printf("Expose %s\n", spec)
+	_ = client.Remove(ctx, name)
+
+	err := client.Mkdir(ctx, name)
+	if err != nil {
+		log.Printf("Expose failed to create %s: %#v\n", name, err)
+		return err
+	}
+	ctl, err := client.Open(ctx, p9p.OREAD, name, "ctl")
+	if err != nil {
+		log.Printf("Expose failed to open %s/ctl: %#v\n", name, err)
+		return err
+	}
+	// NB we deliberately leak the fid because we use the clunk as a signal to
+	// shutdown the forward.
+
+	// Read any error from a previous session
+	bytes := make([]byte, 100)
+	n, err := ctl.Read(ctx, bytes, 0)
+	if err != nil {
+		log.Printf("Expose %s: failed to read response from ctl: %#v\n", spec, err)
+		return err
+	}
+	_, _ = ctl.Read(ctx, bytes, int64(n))
+
+	response := string(bytes)
+	if !strings.HasPrefix(response, "ERROR no request received") {
+		log.Printf("Expose %s: read error from previous operation: %s\n", spec, response[0:n])
+	}
+
+	request := []byte(spec)
+	_, err = ctl.Write(ctx, request, 0)
+	if err != nil {
+		log.Printf("Expose %s: failed to write to ctl: %#v\n", spec, err)
+		return err
+	}
+
+	n, err = ctl.Read(ctx, bytes, 0)
+	if err != nil {
+		log.Printf("Expose %s: failed to read response from ctl: %#v\n", spec, err)
+		return err
+	}
+
+	_, _ = ctl.Read(ctx, bytes, int64(n))
+	response = string(bytes)
+	if strings.HasPrefix(response, "OK ") {
+		response = strings.Trim(response[3:n], " \t\r\n")
+		log.Printf("Expose %s: succeeded with %s\n", spec, response)
+		p.handle = ctl
+		return nil
+	}
+
+	log.Printf("Expose %s: failed: %s\n", spec, response[0:n])
+	if strings.HasPrefix(response, "ERROR ") {
+		response = strings.Trim(response[6:n], " \t\r\n")
+		ctl.Close(ctx)
+	}
+
+	return errors.New(response)
+}
+
+// Unexpose asks vpnkit to hide the port again
+func (p *Port) Unexpose(ctx context.Context) error {
+	if p.handle == nil {
+		return errors.New("Port is not exposed")
+	}
+	ctl := p.handle
+	p.handle = nil
+	ctl.Close(ctx)
+	return nil
+}
+
+var enoent = p9p.MessageRerror{Ename: "file not found"}


### PR DESCRIPTION
This hides the details of the current port expose protocol so that we can more easily change the protocol later.

The command-line tool `cmd/vpnkit-expose-port` allows the library to be tested easily.

Signed-off-by: David Scott <dave.scott@docker.com>