### PR TITLE
go: vendor docker/go-p9p and moby/datakit

### DIFF
--- a/go/vendor.conf
+++ b/go/vendor.conf
@@ -1,2 +1,4 @@
 golang.org/x/sys 9c9d83fe39ed3fd2d9249fcf6b755891fff54b03
 github.com/linuxkit/virtsock a381dcc5bcddf1d7f449495c373dbf70f8e501c0
+github.com/docker/go-p9p 87ae8514a3a2d9684994a6c319f96ba9e18a062e
+github.com/moby/datakit 97b3d230535397a813323902c23751e176481a86

--- a/go/vendor/github.com/docker/go-p9p/LICENSE
+++ b/go/vendor/github.com/docker/go-p9p/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2015 Docker, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/go/vendor/github.com/docker/go-p9p/README.md
+++ b/go/vendor/github.com/docker/go-p9p/README.md
@@ -1,0 +1,11 @@
+# p9p [![GoDoc](https://godoc.org/github.com/docker/go-p9p?status.svg)](https://godoc.org/github.com/docker/go-p9p) [![Apache licensed](https://img.shields.io/badge/license-Apache-blue.svg)](https://raw.githubusercontent.com/docker/go-p9p/master/LICENSE) [![CircleCI](https://circleci.com/gh/docker/go-p9p.svg?style=shield)](https://circleci.com/gh/docker/go-p9p) [![TravisCI](https://travis-ci.org/docker/go-p9p.svg?branch=master)](https://travis-ci.org/docker/go-p9p) [![Go Report Card](https://goreportcard.com/badge/github.com/docker/go-p9p)](https://goreportcard.com/report/github.com/docker/go-p9p) [![Badge Badge](http://doyouevenbadge.com/github.com/docker/go-p9p)](http://doyouevenbadge.com/report/github.com/docker/go-p9p)
+
+
+A modern, performant 9P library for Go.
+
+For information on usage, please see the [GoDoc](https://godoc.org/github.com/docker/go-p9p).
+
+## Copyright and license
+
+Copyright © 2015 Docker, Inc. go-p9p is licensed under the Apache License,
+Version 2.0. See [LICENSE](LICENSE) for the full license text.

--- a/go/vendor/github.com/docker/go-p9p/channel.go
+++ b/go/vendor/github.com/docker/go-p9p/channel.go
@@ -1,0 +1,343 @@
+package p9p
+
+import (
+	"bufio"
+	"context"
+	"encoding/binary"
+	"io"
+	"io/ioutil"
+	"log"
+	"net"
+	"time"
+)
+
+const (
+	// channelMessageHeaderSize is the overhead for sending the size of a
+	// message on the wire.
+	channelMessageHeaderSize = 4
+)
+
+// Channel defines the operations necessary to implement a 9p message channel
+// interface. Typically, message channels do no protocol processing except to
+// send and receive message frames.
+type Channel interface {
+	// ReadFcall reads one fcall frame into the provided fcall structure. The
+	// Fcall may be cleared whether there is an error or not. If the operation
+	// is successful, the contents of the fcall will be populated in the
+	// argument. ReadFcall cannot be called concurrently with other calls to
+	// ReadFcall. This both to preserve message ordering and to allow lockless
+	// buffer reusage.
+	ReadFcall(ctx context.Context, fcall *Fcall) error
+
+	// WriteFcall writes the provided fcall to the channel. WriteFcall cannot
+	// be called concurrently with other calls to WriteFcall.
+	WriteFcall(ctx context.Context, fcall *Fcall) error
+
+	// MSize returns the current msize for the channel.
+	MSize() int
+
+	// SetMSize sets the maximum message size for the channel. This must never
+	// be called currently with ReadFcall or WriteFcall.
+	SetMSize(msize int)
+}
+
+// NewChannel returns a new channel to read and write Fcalls with the provided
+// connection and message size.
+func NewChannel(conn net.Conn, msize int) Channel {
+	return newChannel(conn, codec9p{}, msize)
+}
+
+const (
+	defaultRWTimeout = 30 * time.Second // default read/write timeout if not set in context
+)
+
+// channel provides bidirectional protocol framing for 9p over net.Conn.
+// Operations are not thread-safe but reads and writes may be carried out
+// concurrently, supporting separate read and write loops.
+//
+// Lifecyle
+//
+// A connection, or message channel abstraction, has a lifecycle delineated by
+// Tversion/Rversion request response cycles. For now, this is part of the
+// channel itself but doesn't necessarily influence the channels state, except
+// the msize. Visually, it might look something like this:
+//
+// 	[Established] -> [Version] -> [Session] -> [Version]---+
+//	                     ^                                 |
+// 	                     |_________________________________|
+//
+// The connection is established, then we negotiate a version, run a session,
+// then negotiate a version and so on. For most purposes, we are likely going
+// to terminate the connection after the session but we may want to support
+// connection pooling. Pooling may result in possible security leaks if the
+// connections are shared among contexts, since the version is negotiated at
+// the start of the session. To avoid this, we can actually use a "tombstone"
+// version message which clears the server's session state without starting a
+// new session. The next version message would then prepare the session
+// without leaking any Fid's.
+type channel struct {
+	conn   net.Conn
+	codec  Codec
+	brd    *bufio.Reader
+	bwr    *bufio.Writer
+	closed chan struct{}
+	msize  int
+	rdbuf  []byte
+}
+
+func newChannel(conn net.Conn, codec Codec, msize int) *channel {
+	return &channel{
+		conn:   conn,
+		codec:  codec,
+		brd:    bufio.NewReaderSize(conn, msize), // msize may not be optimal buffer size
+		bwr:    bufio.NewWriterSize(conn, msize),
+		closed: make(chan struct{}),
+		msize:  msize,
+		rdbuf:  make([]byte, msize),
+	}
+}
+
+func (ch *channel) MSize() int {
+	return ch.msize
+}
+
+// setmsize resizes the buffers for use with a separate msize. This call must
+// be protected by a mutex or made before passing to other goroutines.
+func (ch *channel) SetMSize(msize int) {
+	// NOTE(stevvooe): We cannot safely resize the buffered reader and writer.
+	// Proceed assuming that original size is sufficient.
+
+	ch.msize = msize
+	if msize < len(ch.rdbuf) {
+		// just change the cap
+		ch.rdbuf = ch.rdbuf[:msize]
+		return
+	}
+
+	ch.rdbuf = make([]byte, msize)
+}
+
+// ReadFcall reads the next message from the channel into fcall.
+//
+// If the incoming message overflows the msize, Overflow(err) will return
+// nonzero with the number of bytes overflowed.
+func (ch *channel) ReadFcall(ctx context.Context, fcall *Fcall) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-ch.closed:
+		return ErrClosed
+	default:
+	}
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		deadline = time.Now().Add(defaultRWTimeout)
+	}
+
+	if err := ch.conn.SetReadDeadline(deadline); err != nil {
+		log.Printf("transport: error setting read deadline on %v: %v", ch.conn.RemoteAddr(), err)
+	}
+
+	n, err := readmsg(ch.brd, ch.rdbuf)
+	if err != nil {
+		// TODO(stevvooe): There may be more we can do here to detect partial
+		// reads. For now, we just propagate the error untouched.
+		return err
+	}
+
+	if n > len(ch.rdbuf) {
+		return overflowErr{size: n - len(ch.rdbuf)}
+	}
+
+	// clear out the fcall
+	*fcall = Fcall{}
+	if err := ch.codec.Unmarshal(ch.rdbuf[:n], fcall); err != nil {
+		return err
+	}
+
+	if err := ch.maybeTruncate(fcall); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// WriteFcall writes the message to the connection.
+//
+// If a message destined for the wire will overflow MSize, an Overflow error
+// may be returned. For Twrite calls, the buffer will simply be truncated to
+// the optimal msize, with the caller detecting this condition with
+// Rwrite.Count.
+func (ch *channel) WriteFcall(ctx context.Context, fcall *Fcall) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-ch.closed:
+		return ErrClosed
+	default:
+	}
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		deadline = time.Now().Add(defaultRWTimeout)
+	}
+
+	if err := ch.conn.SetWriteDeadline(deadline); err != nil {
+		log.Printf("transport: error setting read deadline on %v: %v", ch.conn.RemoteAddr(), err)
+	}
+
+	if err := ch.maybeTruncate(fcall); err != nil {
+		return err
+	}
+
+	p, err := ch.codec.Marshal(fcall)
+	if err != nil {
+		return err
+	}
+
+	if err := sendmsg(ch.bwr, p); err != nil {
+		return err
+	}
+
+	return ch.bwr.Flush()
+}
+
+// maybeTruncate will truncate the message to fit into msize on the wire, if
+// possible, or modify the message to ensure the response won't overflow.
+//
+// If the message cannot be truncated, an error will be returned and the
+// message should not be sent.
+//
+// A nil return value means the message can be sent without
+func (ch *channel) maybeTruncate(fcall *Fcall) error {
+
+	// for certain message types, just remove the extra bytes from the data portion.
+	switch msg := fcall.Message.(type) {
+	// TODO(stevvooe): There is one more problematic message type:
+	//
+	// Rread: while we can employ the same truncation fix as Twrite, we
+	// need to make it observable to upstream handlers.
+
+	case MessageTread:
+		// We can rewrite msg.Count so that a return message will be under
+		// msize.  This is more defensive than anything but will ensure that
+		// calls don't fail on sloppy servers.
+
+		// first, craft the shape of the response message
+		resp := newFcall(fcall.Tag, MessageRread{})
+		overflow := uint32(ch.msgmsize(resp)) + msg.Count - uint32(ch.msize)
+
+		if msg.Count < overflow {
+			// Let the bad thing happen; msize too small to even support valid
+			// rewrite. This will result in a Terror from the server-side or
+			// just work.
+			return nil
+		}
+
+		msg.Count -= overflow
+		fcall.Message = msg
+
+		return nil
+	case MessageTwrite:
+		// If we are going to overflow the msize, we need to truncate the write to
+		// appropriate size or throw an error in all other conditions.
+		size := ch.msgmsize(fcall)
+		if size <= ch.msize {
+			return nil
+		}
+
+		// overflow the msize, including the channel message size fields.
+		overflow := size - ch.msize
+
+		if len(msg.Data) < overflow {
+			// paranoid: if msg.Data is not big enough to handle the
+			// overflow, we should get an overflow error. MSize would have
+			// to be way too small to be realistic.
+			return overflowErr{size: overflow}
+		}
+
+		// The truncation is reflected in the return message (Rwrite) by
+		// the server, so we don't need a return value or error condition
+		// to communicate it.
+		msg.Data = msg.Data[:len(msg.Data)-overflow]
+		fcall.Message = msg // since we have a local copy
+
+		return nil
+	default:
+		size := ch.msgmsize(fcall)
+		if size > ch.msize {
+			// overflow the msize, including the channel message size fields.
+			return overflowErr{size: size - ch.msize}
+		}
+
+		return nil
+	}
+
+}
+
+// msgmsize returns the on-wire msize of the Fcall, including the size header.
+// Typically, this can be used to detect whether or not the message overflows
+// the msize buffer.
+func (ch *channel) msgmsize(fcall *Fcall) int {
+	return channelMessageHeaderSize + ch.codec.Size(fcall)
+}
+
+// readmsg reads a 9p message into p from rd, ensuring that all bytes are
+// consumed from the size header. If the size header indicates the message is
+// larger than p, the entire message will be discarded, leaving a truncated
+// portion in p. Any error should be treated as a framing error unless n is
+// zero. The caller must check that n is less than or equal to len(p) to
+// ensure that a valid message has been read.
+func readmsg(rd io.Reader, p []byte) (n int, err error) {
+	var msize uint32
+
+	if err := binary.Read(rd, binary.LittleEndian, &msize); err != nil {
+		return 0, err
+	}
+
+	n += binary.Size(msize)
+	mbody := int(msize) - 4
+
+	if mbody < len(p) {
+		p = p[:mbody]
+	}
+
+	np, err := io.ReadFull(rd, p)
+	if err != nil {
+		return np + n, err
+	}
+	n += np
+
+	if mbody > len(p) {
+		// message has been read up to len(p) but we must consume the entire
+		// message. This is an error condition but is non-fatal if we can
+		// consume msize bytes.
+		nn, err := io.CopyN(ioutil.Discard, rd, int64(mbody-len(p)))
+		n += int(nn)
+		if err != nil {
+			return n, err
+		}
+	}
+
+	return n, nil
+}
+
+// sendmsg writes a message of len(p) to wr with a 9p size header. All errors
+// should be considered terminal.
+func sendmsg(wr io.Writer, p []byte) error {
+	size := uint32(len(p) + 4) // message size plus 4-bytes for size.
+	if err := binary.Write(wr, binary.LittleEndian, size); err != nil {
+		return err
+	}
+
+	// This assume partial writes to wr aren't possible. Not sure if this
+	// valid. Matters during timeout retries.
+	if n, err := wr.Write(p); err != nil {
+		return err
+	} else if n < len(p) {
+		return io.ErrShortWrite
+	}
+
+	return nil
+}

--- a/go/vendor/github.com/docker/go-p9p/client.go
+++ b/go/vendor/github.com/docker/go-p9p/client.go
@@ -1,0 +1,253 @@
+package p9p
+
+import (
+	"io"
+	"net"
+
+	"context"
+)
+
+type client struct {
+	version   string
+	msize     int
+	ctx       context.Context
+	transport roundTripper
+}
+
+// NewSession returns a session using the connection. The Context ctx provides
+// a context for out of bad messages, such as flushes, that may be sent by the
+// session. The session can effectively shutdown with this context.
+func NewSession(ctx context.Context, conn net.Conn) (Session, error) {
+	ch := newChannel(conn, codec9p{}, DefaultMSize) // sets msize, effectively.
+
+	// negotiate the protocol version
+	version, err := clientnegotiate(ctx, ch, DefaultVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	return &client{
+		version:   version,
+		msize:     ch.MSize(),
+		ctx:       ctx,
+		transport: newTransport(ctx, ch),
+	}, nil
+}
+
+var _ Session = &client{}
+
+func (c *client) Version() (int, string) {
+	return c.msize, c.version
+}
+
+func (c *client) Auth(ctx context.Context, afid Fid, uname, aname string) (Qid, error) {
+	m := MessageTauth{
+		Afid:  afid,
+		Uname: uname,
+		Aname: aname,
+	}
+
+	resp, err := c.transport.send(ctx, m)
+	if err != nil {
+		return Qid{}, err
+	}
+
+	rauth, ok := resp.(MessageRauth)
+	if !ok {
+		return Qid{}, ErrUnexpectedMsg
+	}
+
+	return rauth.Qid, nil
+}
+
+func (c *client) Attach(ctx context.Context, fid, afid Fid, uname, aname string) (Qid, error) {
+	m := MessageTattach{
+		Fid:   fid,
+		Afid:  afid,
+		Uname: uname,
+		Aname: aname,
+	}
+
+	resp, err := c.transport.send(ctx, m)
+	if err != nil {
+		return Qid{}, err
+	}
+
+	rattach, ok := resp.(MessageRattach)
+	if !ok {
+		return Qid{}, ErrUnexpectedMsg
+	}
+
+	return rattach.Qid, nil
+}
+
+func (c *client) Clunk(ctx context.Context, fid Fid) error {
+	resp, err := c.transport.send(ctx, MessageTclunk{
+		Fid: fid,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, ok := resp.(MessageRclunk)
+	if !ok {
+		return ErrUnexpectedMsg
+	}
+
+	return nil
+}
+
+func (c *client) Remove(ctx context.Context, fid Fid) error {
+	resp, err := c.transport.send(ctx, MessageTremove{
+		Fid: fid,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, ok := resp.(MessageRremove)
+	if !ok {
+		return ErrUnexpectedMsg
+	}
+
+	return nil
+}
+
+func (c *client) Walk(ctx context.Context, fid Fid, newfid Fid, names ...string) ([]Qid, error) {
+	if len(names) > 16 {
+		return nil, ErrWalkLimit
+	}
+
+	resp, err := c.transport.send(ctx, MessageTwalk{
+		Fid:    fid,
+		Newfid: newfid,
+		Wnames: names,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	rwalk, ok := resp.(MessageRwalk)
+	if !ok {
+		return nil, ErrUnexpectedMsg
+	}
+
+	return rwalk.Qids, nil
+}
+
+func (c *client) Read(ctx context.Context, fid Fid, p []byte, offset int64) (n int, err error) {
+	resp, err := c.transport.send(ctx, MessageTread{
+		Fid:    fid,
+		Offset: uint64(offset),
+		Count:  uint32(len(p)),
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	rread, ok := resp.(MessageRread)
+	if !ok {
+		return 0, ErrUnexpectedMsg
+	}
+
+	n = copy(p, rread.Data)
+	switch {
+	case len(rread.Data) == 0:
+		err = io.EOF
+	case n < len(p):
+		// TODO(stevvooe): Technically, we should treat this as an io.EOF.
+		// However, we cannot tell if the short read was due to EOF or due to
+		// truncation.
+	}
+
+	return n, err
+}
+
+func (c *client) Write(ctx context.Context, fid Fid, p []byte, offset int64) (n int, err error) {
+	resp, err := c.transport.send(ctx, MessageTwrite{
+		Fid:    fid,
+		Offset: uint64(offset),
+		Data:   p,
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	rwrite, ok := resp.(MessageRwrite)
+	if !ok {
+		return 0, ErrUnexpectedMsg
+	}
+
+	if int(rwrite.Count) < len(p) {
+		err = io.ErrShortWrite
+	}
+
+	return int(rwrite.Count), err
+}
+
+func (c *client) Open(ctx context.Context, fid Fid, mode Flag) (Qid, uint32, error) {
+	resp, err := c.transport.send(ctx, MessageTopen{
+		Fid:  fid,
+		Mode: mode,
+	})
+	if err != nil {
+		return Qid{}, 0, err
+	}
+
+	ropen, ok := resp.(MessageRopen)
+	if !ok {
+		return Qid{}, 0, ErrUnexpectedMsg
+	}
+
+	return ropen.Qid, ropen.IOUnit, nil
+}
+
+func (c *client) Create(ctx context.Context, parent Fid, name string, perm uint32, mode Flag) (Qid, uint32, error) {
+	resp, err := c.transport.send(ctx, MessageTcreate{
+		Fid:  parent,
+		Name: name,
+		Perm: perm,
+		Mode: mode,
+	})
+	if err != nil {
+		return Qid{}, 0, err
+	}
+
+	rcreate, ok := resp.(MessageRcreate)
+	if !ok {
+		return Qid{}, 0, ErrUnexpectedMsg
+	}
+
+	return rcreate.Qid, rcreate.IOUnit, nil
+}
+
+func (c *client) Stat(ctx context.Context, fid Fid) (Dir, error) {
+	resp, err := c.transport.send(ctx, MessageTstat{Fid: fid})
+	if err != nil {
+		return Dir{}, err
+	}
+
+	rstat, ok := resp.(MessageRstat)
+	if !ok {
+		return Dir{}, ErrUnexpectedMsg
+	}
+
+	return rstat.Stat, nil
+}
+
+func (c *client) WStat(ctx context.Context, fid Fid, dir Dir) error {
+	resp, err := c.transport.send(ctx, MessageTwstat{
+		Fid:  fid,
+		Stat: dir,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, ok := resp.(MessageRwstat)
+	if !ok {
+		return ErrUnexpectedMsg
+	}
+
+	return nil
+}

--- a/go/vendor/github.com/docker/go-p9p/context.go
+++ b/go/vendor/github.com/docker/go-p9p/context.go
@@ -1,0 +1,26 @@
+package p9p
+
+import (
+	"context"
+)
+
+type contextKey string
+
+const (
+	versionKey contextKey = "9p.version"
+)
+
+func withVersion(ctx context.Context, version string) context.Context {
+	return context.WithValue(ctx, versionKey, version)
+}
+
+// GetVersion returns the protocol version from the context. If the version is
+// not known, an empty string is returned. This is typically set on the
+// context passed into function calls in a server implementation.
+func GetVersion(ctx context.Context) string {
+	v, ok := ctx.Value(versionKey).(string)
+	if !ok {
+		return ""
+	}
+	return v
+}

--- a/go/vendor/github.com/docker/go-p9p/dispatcher.go
+++ b/go/vendor/github.com/docker/go-p9p/dispatcher.go
@@ -1,0 +1,133 @@
+package p9p
+
+import "context"
+
+// Handler defines an interface for 9p message handlers. A handler
+// implementation could be used to intercept calls of all types before sending
+// them to the next handler.
+type Handler interface {
+	Handle(ctx context.Context, msg Message) (Message, error)
+
+	// TODO(stevvooe): Right now, this interface is functianally identical to
+	// roundtripper. If we find that this is sufficient on the server-side, we
+	// may unify the types. For now, we leave them separated to differentiate
+	// between them.
+}
+
+// HandlerFunc is a convenience type for defining inline handlers.
+type HandlerFunc func(ctx context.Context, msg Message) (Message, error)
+
+// Handle implements the requirements for the Handler interface.
+func (fn HandlerFunc) Handle(ctx context.Context, msg Message) (Message, error) {
+	return fn(ctx, msg)
+}
+
+// Dispatch returns a handler that dispatches messages to the target session.
+// No concurrency is managed by the returned handler. It simply turns messages
+// into function calls on the session.
+func Dispatch(session Session) Handler {
+	return HandlerFunc(func(ctx context.Context, msg Message) (Message, error) {
+		switch msg := msg.(type) {
+		case MessageTauth:
+			qid, err := session.Auth(ctx, msg.Afid, msg.Uname, msg.Aname)
+			if err != nil {
+				return nil, err
+			}
+
+			return MessageRauth{Qid: qid}, nil
+		case MessageTattach:
+			qid, err := session.Attach(ctx, msg.Fid, msg.Afid, msg.Uname, msg.Aname)
+			if err != nil {
+				return nil, err
+			}
+
+			return MessageRattach{
+				Qid: qid,
+			}, nil
+		case MessageTwalk:
+			// TODO(stevvooe): This is one of the places where we need to manage
+			// fid allocation lifecycle. We need to reserve the fid, then, if this
+			// call succeeds, we should alloc the fid for future uses. Also need
+			// to interact correctly with concurrent clunk and the flush of this
+			// walk message.
+			qids, err := session.Walk(ctx, msg.Fid, msg.Newfid, msg.Wnames...)
+			if err != nil {
+				return nil, err
+			}
+
+			return MessageRwalk{
+				Qids: qids,
+			}, nil
+		case MessageTopen:
+			qid, iounit, err := session.Open(ctx, msg.Fid, msg.Mode)
+			if err != nil {
+				return nil, err
+			}
+
+			return MessageRopen{
+				Qid:    qid,
+				IOUnit: iounit,
+			}, nil
+		case MessageTcreate:
+			qid, iounit, err := session.Create(ctx, msg.Fid, msg.Name, msg.Perm, msg.Mode)
+			if err != nil {
+				return nil, err
+			}
+
+			return MessageRcreate{
+				Qid:    qid,
+				IOUnit: iounit,
+			}, nil
+		case MessageTread:
+			p := make([]byte, int(msg.Count))
+			n, err := session.Read(ctx, msg.Fid, p, int64(msg.Offset))
+			if err != nil {
+				return nil, err
+			}
+
+			return MessageRread{
+				Data: p[:n],
+			}, nil
+		case MessageTwrite:
+			n, err := session.Write(ctx, msg.Fid, msg.Data, int64(msg.Offset))
+			if err != nil {
+				return nil, err
+			}
+
+			return MessageRwrite{
+				Count: uint32(n),
+			}, nil
+		case MessageTclunk:
+			// TODO(stevvooe): Manage the clunking of file descriptors based on
+			// walk and attach call progression.
+			if err := session.Clunk(ctx, msg.Fid); err != nil {
+				return nil, err
+			}
+
+			return MessageRclunk{}, nil
+		case MessageTremove:
+			if err := session.Remove(ctx, msg.Fid); err != nil {
+				return nil, err
+			}
+
+			return MessageRremove{}, nil
+		case MessageTstat:
+			dir, err := session.Stat(ctx, msg.Fid)
+			if err != nil {
+				return nil, err
+			}
+
+			return MessageRstat{
+				Stat: dir,
+			}, nil
+		case MessageTwstat:
+			if err := session.WStat(ctx, msg.Fid, msg.Stat); err != nil {
+				return nil, err
+			}
+
+			return MessageRwstat{}, nil
+		default:
+			return nil, ErrUnknownMsg
+		}
+	})
+}

--- a/go/vendor/github.com/docker/go-p9p/doc.go
+++ b/go/vendor/github.com/docker/go-p9p/doc.go
@@ -1,0 +1,78 @@
+/*
+Package p9p implements a compliant 9P2000 client and server library for use
+in modern, production Go services. This package differentiates itself in that
+is has departed from the plan 9 implementation primitives and better follows
+idiomatic Go style.
+
+The package revolves around the session type, which is an enumeration of raw
+9p message calls. A few calls, such as flush and version, have been elided,
+defering their usage to the server implementation. Sessions can be trivially
+proxied through clients and servers.
+
+Getting Started
+
+The best place to get started is with Serve. Serve can be provided a
+connection and a handler. A typical implementation will call Serve as part of
+a listen/accept loop. As each network connection is created, Serve can be
+called with a handler for the specific connection. The handler can be
+implemented with a Session via the Dispatch function or can generate sessions
+for dispatch in response to client messages. (See cmd/9ps for an example)
+
+On the client side, NewSession provides a 9p session from a connection. After
+a version negotiation, methods can be called on the session, in parallel, and
+calls will be sent over the connection. Call timeouts can be controlled via
+the context provided to each method call.
+
+Framework
+
+This package has the beginning of a nice client-server framework for working
+with 9p. Some of the abstractions aren't entirely fleshed out, but most of
+this can center around the Handler.
+
+Missing from this are a number of tools for implementing 9p servers. The most
+glaring are directory read and walk helpers. Other, more complex additions
+might be a system to manage in memory filesystem trees that expose multi-user
+sessions.
+
+Differences
+
+The largest difference between this package and other 9p packages is
+simplification of the types needed to implement a server. To avoid confusing
+bugs and odd behavior, the components are separated by each level of the
+protocol. One example is that requests and responses are separated and they no
+longer hold mutable state. This means that framing, transport management,
+encoding, and dispatching are componentized. Little work will be required to
+swap out encodings, transports or connection implementations.
+
+Context Integration
+
+This package has been wired from top to bottom to support context-based
+resource management. Everything from startup to shutdown can have timeouts
+using contexts. Not all close methods are fully in place, but we are very
+close to having controlled, predictable cleanup for both servers and clients.
+Timeouts can be very granular or very course, depending on the context of the
+timeout. For example, it is very easy to set a short timeout for a stat call
+but a long timeout for reading data.
+
+Multiversion Support
+
+Currently, there is not multiversion support. The hooks and functionality are
+in place to add multi-version support. Generally, the correct space to do this
+is in the codec. Types, such as Dir, simply need to be extended to support the
+possibility of extra fields.
+
+The real question to ask here is what is the role of the version number in the
+9p protocol. It really comes down to the level of support required. Do we just
+need it at the protocol level, or do handlers and sessions need to be have
+differently based on negotiated versions?
+
+Caveats
+
+This package has a number of TODOs to make it easier to use. Most of the
+existing code provides a solid base to work from. Don't be discouraged by the
+sawdust.
+
+In addition, the testing is embarassingly lacking. With time, we can get full
+testing going and ensure we have confidence in the implementation.
+*/
+package p9p

--- a/go/vendor/github.com/docker/go-p9p/encoding.go
+++ b/go/vendor/github.com/docker/go-p9p/encoding.go
@@ -1,0 +1,564 @@
+package p9p
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"log"
+	"reflect"
+	"strings"
+	"time"
+)
+
+// Codec defines the interface for encoding and decoding of 9p types.
+// Unsupported types will throw an error.
+type Codec interface {
+	// Unmarshal from data into the value pointed to by v.
+	Unmarshal(data []byte, v interface{}) error
+
+	// Marshal the value v into a byte slice.
+	Marshal(v interface{}) ([]byte, error)
+
+	// Size returns the encoded size for the target of v.
+	Size(v interface{}) int
+}
+
+// NewCodec returns a new, standard 9P2000 codec, ready for use.
+func NewCodec() Codec {
+	return codec9p{}
+}
+
+type codec9p struct{}
+
+func (c codec9p) Unmarshal(data []byte, v interface{}) error {
+	dec := &decoder{bytes.NewReader(data)}
+	return dec.decode(v)
+}
+
+func (c codec9p) Marshal(v interface{}) ([]byte, error) {
+	var b bytes.Buffer
+	enc := &encoder{&b}
+
+	if err := enc.encode(v); err != nil {
+		return nil, err
+	}
+
+	return b.Bytes(), nil
+}
+
+func (c codec9p) Size(v interface{}) int {
+	return int(size9p(v))
+}
+
+// DecodeDir decodes a directory entry from rd using the provided codec.
+func DecodeDir(codec Codec, rd io.Reader, d *Dir) error {
+	var ll uint16
+
+	// pull the size off the wire
+	if err := binary.Read(rd, binary.LittleEndian, &ll); err != nil {
+		return err
+	}
+
+	p := make([]byte, ll+2)
+	binary.LittleEndian.PutUint16(p, ll) // must have size at start
+
+	// read out the rest of the record
+	if _, err := io.ReadFull(rd, p[2:]); err != nil {
+		return err
+	}
+
+	return codec.Unmarshal(p, d)
+}
+
+// EncodeDir writes the directory to wr.
+func EncodeDir(codec Codec, wr io.Writer, d *Dir) error {
+	p, err := codec.Marshal(d)
+	if err != nil {
+		return err
+	}
+
+	_, err = wr.Write(p)
+	return err
+}
+
+type encoder struct {
+	wr io.Writer
+}
+
+func (e *encoder) encode(vs ...interface{}) error {
+	for _, v := range vs {
+		switch v := v.(type) {
+		case uint8, uint16, uint32, uint64, FcallType, Tag, QType, Fid, Flag,
+			*uint8, *uint16, *uint32, *uint64, *FcallType, *Tag, *QType, *Fid, *Flag:
+			if err := binary.Write(e.wr, binary.LittleEndian, v); err != nil {
+				return err
+			}
+		case []byte:
+			if err := e.encode(uint32(len(v))); err != nil {
+				return err
+			}
+
+			if err := binary.Write(e.wr, binary.LittleEndian, v); err != nil {
+				return err
+			}
+
+		case *[]byte:
+			if err := e.encode(*v); err != nil {
+				return err
+			}
+		case string:
+			if err := binary.Write(e.wr, binary.LittleEndian, uint16(len(v))); err != nil {
+				return err
+			}
+
+			_, err := io.WriteString(e.wr, v)
+			if err != nil {
+				return err
+			}
+		case *string:
+			if err := e.encode(*v); err != nil {
+				return err
+			}
+
+		case []string:
+			if err := e.encode(uint16(len(v))); err != nil {
+				return err
+			}
+
+			for _, m := range v {
+				if err := e.encode(m); err != nil {
+					return err
+				}
+			}
+		case *[]string:
+			if err := e.encode(*v); err != nil {
+				return err
+			}
+		case time.Time:
+			if err := e.encode(uint32(v.Unix())); err != nil {
+				return err
+			}
+		case *time.Time:
+			if err := e.encode(*v); err != nil {
+				return err
+			}
+		case Qid:
+			if err := e.encode(v.Type, v.Version, v.Path); err != nil {
+				return err
+			}
+		case *Qid:
+			if err := e.encode(*v); err != nil {
+				return err
+			}
+		case []Qid:
+			if err := e.encode(uint16(len(v))); err != nil {
+				return err
+			}
+
+			elements := make([]interface{}, len(v))
+			for i := range v {
+				elements[i] = &v[i]
+			}
+
+			if err := e.encode(elements...); err != nil {
+				return err
+			}
+		case *[]Qid:
+			if err := e.encode(*v); err != nil {
+				return err
+			}
+		case Dir:
+			elements, err := fields9p(v)
+			if err != nil {
+				return err
+			}
+
+			if err := e.encode(uint16(size9p(elements...))); err != nil {
+				return err
+			}
+
+			if err := e.encode(elements...); err != nil {
+				return err
+			}
+		case *Dir:
+			if err := e.encode(*v); err != nil {
+				return err
+			}
+		case []Dir:
+			elements := make([]interface{}, len(v))
+			for i := range v {
+				elements[i] = &v[i]
+			}
+
+			if err := e.encode(elements...); err != nil {
+				return err
+			}
+		case *[]Dir:
+			if err := e.encode(*v); err != nil {
+				return err
+			}
+		case Fcall:
+			if err := e.encode(v.Type, v.Tag, v.Message); err != nil {
+				return err
+			}
+		case *Fcall:
+			if err := e.encode(*v); err != nil {
+				return err
+			}
+		case Message:
+			elements, err := fields9p(v)
+			if err != nil {
+				return err
+			}
+
+			switch v.(type) {
+			case MessageRstat, *MessageRstat:
+				// NOTE(stevvooe): Prepend size preceeding Dir. See bugs in
+				// http://man.cat-v.org/plan_9/5/stat to make sense of this.
+				// The field has been included here but we need to make sure
+				// to double emit it for Rstat.
+				if err := e.encode(uint16(size9p(elements...))); err != nil {
+					return err
+				}
+			}
+
+			if err := e.encode(elements...); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+type decoder struct {
+	rd io.Reader
+}
+
+// read9p extracts values from rd and unmarshals them to the targets of vs.
+func (d *decoder) decode(vs ...interface{}) error {
+	for _, v := range vs {
+		switch v := v.(type) {
+		case *uint8, *uint16, *uint32, *uint64, *FcallType, *Tag, *QType, *Fid, *Flag:
+			if err := binary.Read(d.rd, binary.LittleEndian, v); err != nil {
+				return err
+			}
+		case *[]byte:
+			var ll uint32
+
+			if err := d.decode(&ll); err != nil {
+				return err
+			}
+
+			if ll > 0 {
+				*v = make([]byte, int(ll))
+			}
+
+			if err := binary.Read(d.rd, binary.LittleEndian, v); err != nil {
+				return err
+			}
+		case *string:
+			var ll uint16
+
+			// implement string[s] encoding
+			if err := d.decode(&ll); err != nil {
+				return err
+			}
+
+			b := make([]byte, ll)
+
+			n, err := io.ReadFull(d.rd, b)
+			if err != nil {
+				return err
+			}
+
+			if n != int(ll) {
+				return fmt.Errorf("unexpected string length")
+			}
+
+			*v = string(b)
+		case *[]string:
+			var ll uint16
+
+			if err := d.decode(&ll); err != nil {
+				return err
+			}
+
+			elements := make([]interface{}, int(ll))
+			*v = make([]string, int(ll))
+			for i := range elements {
+				elements[i] = &(*v)[i]
+			}
+
+			if err := d.decode(elements...); err != nil {
+				return err
+			}
+		case *time.Time:
+			var epoch uint32
+			if err := d.decode(&epoch); err != nil {
+				return err
+			}
+
+			*v = time.Unix(int64(epoch), 0).UTC()
+		case *Qid:
+			if err := d.decode(&v.Type, &v.Version, &v.Path); err != nil {
+				return err
+			}
+		case *[]Qid:
+			var ll uint16
+
+			if err := d.decode(&ll); err != nil {
+				return err
+			}
+
+			elements := make([]interface{}, int(ll))
+			*v = make([]Qid, int(ll))
+			for i := range elements {
+				elements[i] = &(*v)[i]
+			}
+
+			if err := d.decode(elements...); err != nil {
+				return err
+			}
+		case *Dir:
+			var ll uint16
+
+			if err := d.decode(&ll); err != nil {
+				return err
+			}
+
+			b := make([]byte, ll)
+			// must consume entire dir entry.
+			n, err := io.ReadFull(d.rd, b)
+			if err != nil {
+				log.Println("dir readfull failed:", err, ll, n)
+				return err
+			}
+
+			elements, err := fields9p(v)
+			if err != nil {
+				return err
+			}
+
+			dec := &decoder{bytes.NewReader(b)}
+
+			if err := dec.decode(elements...); err != nil {
+				return err
+			}
+		case *[]Dir:
+			*v = make([]Dir, 0)
+			for {
+				element := Dir{}
+				if err := d.decode(&element); err != nil {
+					if err == io.EOF {
+						return nil
+					}
+					return err
+				}
+				*v = append(*v, element)
+			}
+		case *Fcall:
+			if err := d.decode(&v.Type, &v.Tag); err != nil {
+				return err
+			}
+
+			message, err := newMessage(v.Type)
+			if err != nil {
+				return err
+			}
+
+			// NOTE(stevvooe): We do a little pointer dance to allocate the
+			// new type, write to it, then assign it back to the interface as
+			// a concrete type, avoiding a pointer (the interface) to a
+			// pointer.
+			rv := reflect.New(reflect.TypeOf(message))
+			if err := d.decode(rv.Interface()); err != nil {
+				return err
+			}
+
+			v.Message = rv.Elem().Interface().(Message)
+		case Message:
+			elements, err := fields9p(v)
+			if err != nil {
+				return err
+			}
+
+			switch v.(type) {
+			case *MessageRstat, MessageRstat:
+				// NOTE(stevvooe): Consume extra size preceeding Dir. See bugs
+				// in http://man.cat-v.org/plan_9/5/stat to make sense of
+				// this. The field has been included here but we need to make
+				// sure to double emit it for Rstat. decode extra size header
+				// for stat structure.
+				var ll uint16
+				if err := d.decode(&ll); err != nil {
+					return err
+				}
+			}
+
+			if err := d.decode(elements...); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// size9p calculates the projected size of the values in vs when encoded into
+// 9p binary protocol. If an element or elements are not valid for 9p encoded,
+// the value 0 will be used for the size. The error will be detected when
+// encoding.
+func size9p(vs ...interface{}) uint32 {
+	var s uint32
+	for _, v := range vs {
+		if v == nil {
+			continue
+		}
+
+		switch v := v.(type) {
+		case uint8, uint16, uint32, uint64, FcallType, Tag, QType, Fid, Flag,
+			*uint8, *uint16, *uint32, *uint64, *FcallType, *Tag, *QType, *Fid, *Flag:
+			s += uint32(binary.Size(v))
+		case []byte:
+			s += uint32(binary.Size(uint32(0)) + len(v))
+		case *[]byte:
+			s += size9p(uint32(0), *v)
+		case string:
+			s += uint32(binary.Size(uint16(0)) + len(v))
+		case *string:
+			s += size9p(*v)
+		case []string:
+			s += size9p(uint16(0))
+
+			for _, sv := range v {
+				s += size9p(sv)
+			}
+		case *[]string:
+			s += size9p(*v)
+		case time.Time, *time.Time:
+			// BUG(stevvooe): Y2038 is coming.
+			s += size9p(uint32(0))
+		case Qid:
+			s += size9p(v.Type, v.Version, v.Path)
+		case *Qid:
+			s += size9p(*v)
+		case []Qid:
+			s += size9p(uint16(0))
+			elements := make([]interface{}, len(v))
+			for i := range elements {
+				elements[i] = &v[i]
+			}
+			s += size9p(elements...)
+		case *[]Qid:
+			s += size9p(*v)
+
+		case Dir:
+			// walk the fields of the message to get the total size. we just
+			// use the field order from the message struct. We may add tag
+			// ignoring if needed.
+			elements, err := fields9p(v)
+			if err != nil {
+				// BUG(stevvooe): The options here are to return 0, panic or
+				// make this return an error. Ideally, we make it safe to
+				// return 0 and have the rest of the package do the right
+				// thing. For now, we do this, but may want to panic until
+				// things are stable.
+				panic(err)
+			}
+
+			s += size9p(elements...) + size9p(uint16(0))
+		case *Dir:
+			s += size9p(*v)
+		case []Dir:
+			elements := make([]interface{}, len(v))
+			for i := range elements {
+				elements[i] = &v[i]
+			}
+			s += size9p(elements...)
+		case *[]Dir:
+			s += size9p(*v)
+		case Fcall:
+			s += size9p(v.Type, v.Tag, v.Message)
+		case *Fcall:
+			s += size9p(*v)
+		case Message:
+			// special case twstat and rstat for size fields. See bugs in
+			// http://man.cat-v.org/plan_9/5/stat to make sense of this.
+			switch v.(type) {
+			case *MessageRstat, MessageRstat:
+				s += size9p(uint16(0)) // for extra size field before dir
+			}
+
+			// walk the fields of the message to get the total size. we just
+			// use the field order from the message struct. We may add tag
+			// ignoring if needed.
+			elements, err := fields9p(v)
+			if err != nil {
+				// BUG(stevvooe): The options here are to return 0, panic or
+				// make this return an error. Ideally, we make it safe to
+				// return 0 and have the rest of the package do the right
+				// thing. For now, we do this, but may want to panic until
+				// things are stable.
+				panic(err)
+			}
+
+			s += size9p(elements...)
+		}
+	}
+
+	return s
+}
+
+// fields9p lists the settable fields from a struct type for reading and
+// writing. We are using a lot of reflection here for fairly static
+// serialization but we can replace this in the future with generated code if
+// performance is an issue.
+func fields9p(v interface{}) ([]interface{}, error) {
+	rv := reflect.Indirect(reflect.ValueOf(v))
+
+	if rv.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("cannot extract fields from non-struct: %v", rv)
+	}
+
+	var elements []interface{}
+	for i := 0; i < rv.NumField(); i++ {
+		f := rv.Field(i)
+
+		if !f.CanInterface() {
+			// unexported field, skip it.
+			continue
+		}
+
+		if f.CanAddr() {
+			f = f.Addr()
+		}
+
+		elements = append(elements, f.Interface())
+	}
+
+	return elements, nil
+}
+
+func string9p(v interface{}) string {
+	if v == nil {
+		return "nil"
+	}
+
+	rv := reflect.Indirect(reflect.ValueOf(v))
+
+	if rv.Kind() != reflect.Struct {
+		panic("not a struct")
+	}
+
+	var s string
+
+	for i := 0; i < rv.NumField(); i++ {
+		f := rv.Field(i)
+
+		s += fmt.Sprintf(" %v=%v", strings.ToLower(rv.Type().Field(i).Name), f.Interface())
+	}
+
+	return s
+}

--- a/go/vendor/github.com/docker/go-p9p/errors.go
+++ b/go/vendor/github.com/docker/go-p9p/errors.go
@@ -1,0 +1,58 @@
+package p9p
+
+import (
+	"errors"
+	"fmt"
+)
+
+// MessageRerror provides both a Go error type and message type.
+type MessageRerror struct {
+	Ename string
+}
+
+// 9p wire errors returned by Session interface methods
+var (
+	ErrBadattach    = new9pError("unknown specifier in attach")
+	ErrBadoffset    = new9pError("bad offset")
+	ErrBadcount     = new9pError("bad count")
+	ErrBotch        = new9pError("9P protocol botch")
+	ErrCreatenondir = new9pError("create in non-directory")
+	ErrDupfid       = new9pError("duplicate fid")
+	ErrDuptag       = new9pError("duplicate tag")
+	ErrIsdir        = new9pError("is a directory")
+	ErrNocreate     = new9pError("create prohibited")
+	ErrNomem        = new9pError("out of memory")
+	ErrNoremove     = new9pError("remove prohibited")
+	ErrNostat       = new9pError("stat prohibited")
+	ErrNotfound     = new9pError("file not found")
+	ErrNowrite      = new9pError("write prohibited")
+	ErrNowstat      = new9pError("wstat prohibited")
+	ErrPerm         = new9pError("permission denied")
+	ErrUnknownfid   = new9pError("unknown fid")
+	ErrBaddir       = new9pError("bad directory in wstat")
+	ErrWalknodir    = new9pError("walk in non-directory")
+
+	// extra errors not part of the normal protocol
+
+	ErrTimeout       = new9pError("fcall timeout") // returned when timing out on the fcall
+	ErrUnknownTag    = new9pError("unknown tag")
+	ErrUnknownMsg    = new9pError("unknown message")    // returned when encountering unknown message type
+	ErrUnexpectedMsg = new9pError("unexpected message") // returned when an unexpected message is encountered
+	ErrWalkLimit     = new9pError("too many wnames in walk")
+	ErrClosed        = errors.New("closed")
+)
+
+// new9pError returns a new 9p error ready for the wire.
+func new9pError(s string) error {
+	return MessageRerror{Ename: s}
+}
+
+// Type ensures that 9p errors can be transparently used as a 9p message in an
+// Fcall.
+func (MessageRerror) Type() FcallType {
+	return Rerror
+}
+
+func (e MessageRerror) Error() string {
+	return fmt.Sprintf("9p: %v", e.Ename)
+}

--- a/go/vendor/github.com/docker/go-p9p/fcall.go
+++ b/go/vendor/github.com/docker/go-p9p/fcall.go
@@ -1,0 +1,142 @@
+package p9p
+
+import "fmt"
+
+// FcallType encodes the message type for the target Fcall.
+type FcallType uint8
+
+// Definitions for Fcall's used in 9P2000.
+const (
+	Tversion FcallType = iota + 100
+	Rversion
+	Tauth
+	Rauth
+	Tattach
+	Rattach
+	Terror
+	Rerror
+	Tflush
+	Rflush
+	Twalk
+	Rwalk
+	Topen
+	Ropen
+	Tcreate
+	Rcreate
+	Tread
+	Rread
+	Twrite
+	Rwrite
+	Tclunk
+	Rclunk
+	Tremove
+	Rremove
+	Tstat
+	Rstat
+	Twstat
+	Rwstat
+	Tmax
+)
+
+func (fct FcallType) String() string {
+	switch fct {
+	case Tversion:
+		return "Tversion"
+	case Rversion:
+		return "Rversion"
+	case Tauth:
+		return "Tauth"
+	case Rauth:
+		return "Rauth"
+	case Tattach:
+		return "Tattach"
+	case Rattach:
+		return "Rattach"
+	case Terror:
+		// invalid.
+		return "Terror"
+	case Rerror:
+		return "Rerror"
+	case Tflush:
+		return "Tflush"
+	case Rflush:
+		return "Rflush"
+	case Twalk:
+		return "Twalk"
+	case Rwalk:
+		return "Rwalk"
+	case Topen:
+		return "Topen"
+	case Ropen:
+		return "Ropen"
+	case Tcreate:
+		return "Tcreate"
+	case Rcreate:
+		return "Rcreate"
+	case Tread:
+		return "Tread"
+	case Rread:
+		return "Rread"
+	case Twrite:
+		return "Twrite"
+	case Rwrite:
+		return "Rwrite"
+	case Tclunk:
+		return "Tclunk"
+	case Rclunk:
+		return "Rclunk"
+	case Tremove:
+		return "Tremove"
+	case Rremove:
+		return "Rremove"
+	case Tstat:
+		return "Tstat"
+	case Rstat:
+		return "Rstat"
+	case Twstat:
+		return "Twstat"
+	case Rwstat:
+		return "Rwstat"
+	default:
+		return "Tunknown"
+	}
+}
+
+// Fcall defines the fields for sending a 9p formatted message. The type will
+// be introspected from the Message implementation.
+type Fcall struct {
+	Type    FcallType
+	Tag     Tag
+	Message Message
+}
+
+func newFcall(tag Tag, msg Message) *Fcall {
+	return &Fcall{
+		Type:    msg.Type(),
+		Tag:     tag,
+		Message: msg,
+	}
+}
+
+func newErrorFcall(tag Tag, err error) *Fcall {
+	var msg Message
+
+	switch v := err.(type) {
+	case MessageRerror:
+		msg = v
+	case *MessageRerror:
+		msg = *v
+	default:
+		msg = MessageRerror{Ename: v.Error()}
+	}
+
+	return &Fcall{
+		Type:    Rerror,
+		Tag:     tag,
+		Message: msg,
+	}
+}
+
+func (fc *Fcall) String() string {
+	return fmt.Sprintf("%v(%v) %v", fc.Type, fc.Tag, string9p(fc.Message))
+}

--- a/go/vendor/github.com/docker/go-p9p/logging.go
+++ b/go/vendor/github.com/docker/go-p9p/logging.go
@@ -1,0 +1,77 @@
+// +build ignore
+
+package p9p
+
+import (
+	"log"
+	"os"
+)
+
+type logging struct {
+	session Session
+	logger  log.Logger
+}
+
+var _ Session = &logging{}
+
+func NewLogger(prefix string, session Session) Session {
+	return &logging{
+		session: session,
+		logger:  *log.New(os.Stdout, prefix, 0),
+	}
+}
+
+func (l *logging) Auth(afid Fid, uname, aname string) (Qid, error) {
+	qid, err := l.session.Auth(afid, uname, aname)
+	l.logger.Printf("Auth(%v, %s, %s) -> (%v, %v)", afid, uname, aname, qid, err)
+	return qid, err
+}
+
+func (l *logging) Attach(fid, afid Fid, uname, aname string) (Qid, error) {
+	qid, err := l.session.Attach(fid, afid, uname, aname)
+	l.logger.Printf("Attach(%v, %v, %s, %s) -> (%v, %v)", fid, afid, uname, aname, qid, err)
+	return qid, err
+}
+
+func (l *logging) Clunk(fid Fid) error {
+	return l.session.Clunk(fid)
+}
+
+func (l *logging) Remove(fid Fid) (err error) {
+	defer func() {
+		l.logger.Printf("Remove(%v) -> %v", fid, err)
+	}()
+	return l.session.Remove(fid)
+}
+
+func (l *logging) Walk(fid Fid, newfid Fid, names ...string) ([]Qid, error) {
+	return l.session.Walk(fid, newfid, names...)
+}
+
+func (l *logging) Read(fid Fid, p []byte, offset int64) (n int, err error) {
+	return l.session.Read(fid, p, offset)
+}
+
+func (l *logging) Write(fid Fid, p []byte, offset int64) (n int, err error) {
+	return l.session.Write(fid, p, offset)
+}
+
+func (l *logging) Open(fid Fid, mode int32) (Qid, error) {
+	return l.session.Open(fid, mode)
+}
+
+func (l *logging) Create(parent Fid, name string, perm uint32, mode uint32) (Qid, error) {
+	return l.session.Create(parent, name, perm, mode)
+}
+
+func (l *logging) Stat(fid Fid) (Dir, error) {
+	return l.session.Stat(fid)
+}
+
+func (l *logging) WStat(fid Fid, dir Dir) error {
+	return l.session.WStat(fid, dir)
+}
+
+func (l *logging) Version(msize int32, version string) (int32, string, error) {
+	return l.session.Version(msize, version)
+}

--- a/go/vendor/github.com/docker/go-p9p/messages.go
+++ b/go/vendor/github.com/docker/go-p9p/messages.go
@@ -1,0 +1,216 @@
+package p9p
+
+import "fmt"
+
+// Message represents the target of an fcall.
+type Message interface {
+	// Type returns the type of call for the target message.
+	Type() FcallType
+}
+
+// newMessage returns a new instance of the message based on the Fcall type.
+func newMessage(typ FcallType) (Message, error) {
+	switch typ {
+	case Tversion:
+		return MessageTversion{}, nil
+	case Rversion:
+		return MessageRversion{}, nil
+	case Tauth:
+		return MessageTauth{}, nil
+	case Rauth:
+		return MessageRauth{}, nil
+	case Tattach:
+		return MessageTattach{}, nil
+	case Rattach:
+		return MessageRattach{}, nil
+	case Rerror:
+		return MessageRerror{}, nil
+	case Tflush:
+		return MessageTflush{}, nil
+	case Rflush:
+		return MessageRflush{}, nil // No message body for this response.
+	case Twalk:
+		return MessageTwalk{}, nil
+	case Rwalk:
+		return MessageRwalk{}, nil
+	case Topen:
+		return MessageTopen{}, nil
+	case Ropen:
+		return MessageRopen{}, nil
+	case Tcreate:
+		return MessageTcreate{}, nil
+	case Rcreate:
+		return MessageRcreate{}, nil
+	case Tread:
+		return MessageTread{}, nil
+	case Rread:
+		return MessageRread{}, nil
+	case Twrite:
+		return MessageTwrite{}, nil
+	case Rwrite:
+		return MessageRwrite{}, nil
+	case Tclunk:
+		return MessageTclunk{}, nil
+	case Rclunk:
+		return MessageRclunk{}, nil // no response body
+	case Tremove:
+		return MessageTremove{}, nil
+	case Rremove:
+		return MessageRremove{}, nil
+	case Tstat:
+		return MessageTstat{}, nil
+	case Rstat:
+		return MessageRstat{}, nil
+	case Twstat:
+		return MessageTwstat{}, nil
+	case Rwstat:
+		return MessageRwstat{}, nil
+	}
+
+	return nil, fmt.Errorf("unknown message type")
+}
+
+// MessageVersion encodes the message body for Tversion and Rversion RPC
+// calls. The body is identical in both directions.
+type MessageTversion struct {
+	MSize   uint32
+	Version string
+}
+
+type MessageRversion struct {
+	MSize   uint32
+	Version string
+}
+
+type MessageTauth struct {
+	Afid  Fid
+	Uname string
+	Aname string
+}
+
+type MessageRauth struct {
+	Qid Qid
+}
+
+type MessageTflush struct {
+	Oldtag Tag
+}
+
+type MessageRflush struct{}
+
+type MessageTattach struct {
+	Fid   Fid
+	Afid  Fid
+	Uname string
+	Aname string
+}
+
+type MessageRattach struct {
+	Qid Qid
+}
+
+type MessageTwalk struct {
+	Fid    Fid
+	Newfid Fid
+	Wnames []string
+}
+
+type MessageRwalk struct {
+	Qids []Qid
+}
+
+type MessageTopen struct {
+	Fid  Fid
+	Mode Flag
+}
+
+type MessageRopen struct {
+	Qid    Qid
+	IOUnit uint32
+}
+
+type MessageTcreate struct {
+	Fid  Fid
+	Name string
+	Perm uint32
+	Mode Flag
+}
+
+type MessageRcreate struct {
+	Qid    Qid
+	IOUnit uint32
+}
+
+type MessageTread struct {
+	Fid    Fid
+	Offset uint64
+	Count  uint32
+}
+
+type MessageRread struct {
+	Data []byte
+}
+
+type MessageTwrite struct {
+	Fid    Fid
+	Offset uint64
+	Data   []byte
+}
+
+type MessageRwrite struct {
+	Count uint32
+}
+
+type MessageTclunk struct {
+	Fid Fid
+}
+
+type MessageRclunk struct{}
+
+type MessageTremove struct {
+	Fid Fid
+}
+
+type MessageRremove struct{}
+
+type MessageTstat struct {
+	Fid Fid
+}
+
+type MessageRstat struct {
+	Stat Dir
+}
+
+type MessageTwstat struct {
+	Fid  Fid
+	Stat Dir
+}
+
+type MessageRwstat struct{}
+
+func (MessageTversion) Type() FcallType { return Tversion }
+func (MessageRversion) Type() FcallType { return Rversion }
+func (MessageTauth) Type() FcallType    { return Tauth }
+func (MessageRauth) Type() FcallType    { return Rauth }
+func (MessageTflush) Type() FcallType   { return Tflush }
+func (MessageRflush) Type() FcallType   { return Rflush }
+func (MessageTattach) Type() FcallType  { return Tattach }
+func (MessageRattach) Type() FcallType  { return Rattach }
+func (MessageTwalk) Type() FcallType    { return Twalk }
+func (MessageRwalk) Type() FcallType    { return Rwalk }
+func (MessageTopen) Type() FcallType    { return Topen }
+func (MessageRopen) Type() FcallType    { return Ropen }
+func (MessageTcreate) Type() FcallType  { return Tcreate }
+func (MessageRcreate) Type() FcallType  { return Rcreate }
+func (MessageTread) Type() FcallType    { return Tread }
+func (MessageRread) Type() FcallType    { return Rread }
+func (MessageTwrite) Type() FcallType   { return Twrite }
+func (MessageRwrite) Type() FcallType   { return Rwrite }
+func (MessageTclunk) Type() FcallType   { return Tclunk }
+func (MessageRclunk) Type() FcallType   { return Rclunk }
+func (MessageTremove) Type() FcallType  { return Tremove }
+func (MessageRremove) Type() FcallType  { return Rremove }
+func (MessageTstat) Type() FcallType    { return Tstat }
+func (MessageRstat) Type() FcallType    { return Rstat }
+func (MessageTwstat) Type() FcallType   { return Twstat }
+func (MessageRwstat) Type() FcallType   { return Rwstat }

--- a/go/vendor/github.com/docker/go-p9p/overflow.go
+++ b/go/vendor/github.com/docker/go-p9p/overflow.go
@@ -1,0 +1,49 @@
+package p9p
+
+import "fmt"
+
+// Overflow will return a positive number, indicating there was an overflow for
+// the error.
+func Overflow(err error) int {
+	if of, ok := err.(overflow); ok {
+		return of.Size()
+	}
+
+	// traverse cause, if above fails.
+	if causal, ok := err.(interface {
+		Cause() error
+	}); ok {
+		return Overflow(causal.Cause())
+	}
+
+	return 0
+}
+
+// overflow is a resolvable error type that can help callers negotiate
+// session msize. If this error is encountered, no message was sent.
+//
+// The return value of `Size()` represents the number of bytes that would have
+// been truncated if the message were sent. This IS NOT the optimal buffer size
+// for operations like read and write.
+//
+// In the case of `Twrite`, the caller can Size() from the local size to get an
+// optimally size buffer or the write can simply be truncated to `len(buf) -
+// err.Size()`.
+//
+// For the most part, no users of this package should see this error in
+// practice. If this escapes the Session interface, it is a bug.
+type overflow interface {
+	Size() int // number of bytes overflowed.
+}
+
+type overflowErr struct {
+	size int // number of bytes overflowed
+}
+
+func (o overflowErr) Error() string {
+	return fmt.Sprintf("message overflowed %d bytes", o.size)
+}
+
+func (o overflowErr) Size() int {
+	return o.size
+}

--- a/go/vendor/github.com/docker/go-p9p/readdir.go
+++ b/go/vendor/github.com/docker/go-p9p/readdir.go
@@ -1,0 +1,93 @@
+package p9p
+
+import (
+	"io"
+
+	"context"
+)
+
+// ReaddirAll reads all the directory entries for the resource fid.
+func ReaddirAll(session Session, fid Fid) ([]Dir, error) {
+	panic("not implemented")
+}
+
+// Readdir helps one to implement the server-side of Session.Read on
+// directories.
+type Readdir struct {
+	nextfn func() (Dir, error)
+	buf    *Dir // one-item buffer
+	codec  Codec
+	offset int64
+}
+
+// NewReaddir returns a new Readdir to assist implementing server-side Readdir.
+// The codec will be used to decode messages with Dir entries. The provided
+// function next will be called until io.EOF is returned.
+func NewReaddir(codec Codec, next func() (Dir, error)) *Readdir {
+	return &Readdir{
+		nextfn: next,
+		codec:  codec,
+	}
+}
+
+// NewFixedReaddir returns a Readdir that will returned a fixed set of
+// directory entries.
+func NewFixedReaddir(codec Codec, dir []Dir) *Readdir {
+	dirs := make([]Dir, len(dir))
+	copy(dirs, dir) // make our own copy!
+
+	return NewReaddir(codec,
+		func() (Dir, error) {
+			if len(dirs) == 0 {
+				return Dir{}, io.EOF
+			}
+
+			d := dirs[0]
+			dirs = dirs[1:]
+			return d, nil
+		})
+}
+
+func (rd *Readdir) Read(ctx context.Context, p []byte, offset int64) (n int, err error) {
+	if rd.offset != offset {
+		return 0, ErrBadoffset
+	}
+
+	p = p[:0:len(p)]
+	for len(p) < cap(p) {
+		var d Dir
+		if rd.buf != nil {
+			d = *rd.buf
+			rd.buf = nil
+		} else {
+			d, err = rd.nextfn()
+			if err != nil {
+				goto done
+			}
+		}
+
+		var dp []byte
+		dp, err = rd.codec.Marshal(d)
+		if err != nil {
+			goto done
+		}
+
+		if len(p)+len(dp) > cap(p) {
+			// will over fill buffer. save item and exit.
+			rd.buf = &d
+			goto done
+		}
+
+		p = append(p, dp...)
+	}
+
+done:
+	if err == io.EOF && len(p) > 0 {
+		// Don't let io.EOF escape if we've written to p. 9p doesn't handle
+		// this like Go.
+		err = nil
+	}
+
+	rd.offset += int64(len(p))
+	return len(p), err
+}

--- a/go/vendor/github.com/docker/go-p9p/server.go
+++ b/go/vendor/github.com/docker/go-p9p/server.go
@@ -1,0 +1,257 @@
+package p9p
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"sync"
+	"time"
+
+	"context"
+)
+
+// TODO(stevvooe): Add net/http.Server-like type here to manage connections.
+// Coupled with Handler mux, we can get a very http-like experience for 9p
+// servers.
+
+// ServeConn the 9p handler over the provided network connection.
+func ServeConn(ctx context.Context, cn net.Conn, handler Handler) error {
+
+	// TODO(stevvooe): It would be nice if the handler could declare the
+	// supported version. Before we had handler, we used the session to get
+	// the version (msize, version := session.Version()). We must decided if
+	// we want to proxy version and message size decisions all the back to the
+	// origin server or make those decisions at each link of a proxy chain.
+
+	ch := newChannel(cn, codec9p{}, DefaultMSize)
+	negctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+
+	// TODO(stevvooe): For now, we negotiate here. It probably makes sense to
+	// do this outside of this function and then pass in a ready made channel.
+	// We are not really ready to export the channel type yet.
+
+	if err := servernegotiate(negctx, ch, DefaultVersion); err != nil {
+		// TODO(stevvooe): Need better error handling and retry support here.
+		return fmt.Errorf("error negotiating version: %s", err)
+	}
+
+	ctx = withVersion(ctx, DefaultVersion)
+
+	c := &conn{
+		ctx:     ctx,
+		ch:      ch,
+		handler: handler,
+		closed:  make(chan struct{}),
+	}
+
+	return c.serve()
+}
+
+// conn plays role of session dispatch for handler in a server.
+type conn struct {
+	ctx     context.Context
+	session Session
+	ch      Channel
+	handler Handler
+
+	once   sync.Once
+	closed chan struct{}
+	err    error // terminal error for the conn
+}
+
+// activeRequest includes information about the active request.
+type activeRequest struct {
+	ctx     context.Context
+	request *Fcall
+	cancel  context.CancelFunc
+}
+
+// serve messages on the connection until an error is encountered.
+func (c *conn) serve() error {
+	tags := map[Tag]*activeRequest{} // active requests
+
+	requests := make(chan *Fcall)  // sync, read-limited
+	responses := make(chan *Fcall) // sync, goroutine consumed
+	completed := make(chan *Fcall) // sync, send in goroutine per request
+
+	// read loop
+	go c.read(requests)
+	go c.write(responses)
+
+	log.Println("server.run()")
+	for {
+		select {
+		case req := <-requests:
+			if _, ok := tags[req.Tag]; ok {
+				select {
+				case responses <- newErrorFcall(req.Tag, ErrDuptag):
+					// Send to responses, bypass tag management.
+				case <-c.ctx.Done():
+					return c.ctx.Err()
+				case <-c.closed:
+					return c.err
+				}
+				continue
+			}
+
+			switch msg := req.Message.(type) {
+			case MessageTflush:
+				log.Println("server: flushing message", msg.Oldtag)
+
+				var resp *Fcall
+				// check if we have actually know about the requested flush
+				active, ok := tags[msg.Oldtag]
+				if ok {
+					active.cancel() // propagate cancellation to callees
+					delete(tags, msg.Oldtag)
+					resp = newFcall(req.Tag, MessageRflush{})
+				} else {
+					resp = newErrorFcall(req.Tag, ErrUnknownTag)
+				}
+
+				select {
+				case responses <- resp:
+					// bypass tag management in completed.
+				case <-c.ctx.Done():
+					return c.ctx.Err()
+				case <-c.closed:
+					return c.err
+				}
+			default:
+				// Allows us to session handlers to cancel processing of the fcall
+				// through context.
+				ctx, cancel := context.WithCancel(c.ctx)
+
+				// The contents of these instances are only writable in the main
+				// server loop. The value of tag will not change.
+				tags[req.Tag] = &activeRequest{
+					ctx:     ctx,
+					request: req,
+					cancel:  cancel,
+				}
+
+				go func(ctx context.Context, req *Fcall) {
+					// TODO(stevvooe): Re-write incoming Treads so that handler
+					// can always respond with a message of the correct msize.
+
+					var resp *Fcall
+					msg, err := c.handler.Handle(ctx, req.Message)
+					if err != nil {
+						// all handler errors are forwarded as protocol errors.
+						resp = newErrorFcall(req.Tag, err)
+					} else {
+						resp = newFcall(req.Tag, msg)
+					}
+
+					select {
+					case completed <- resp:
+					case <-ctx.Done():
+						return
+					case <-c.closed:
+						return
+					}
+				}(ctx, req)
+			}
+		case resp := <-completed:
+			// only responses that flip the tag state traverse this section.
+			active, ok := tags[resp.Tag]
+			if !ok {
+				// The tag is no longer active. Likely a flushed message.
+				continue
+			}
+
+			select {
+			case responses <- resp:
+			case <-active.ctx.Done():
+				// the context was canceled for some reason, perhaps timeout or
+				// due to a flush call. We treat this as a condition where a
+				// response should not be sent.
+				log.Println("canceled", resp, active.ctx.Err())
+			}
+			delete(tags, resp.Tag)
+		case <-c.ctx.Done():
+			return c.ctx.Err()
+		case <-c.closed:
+			return c.err
+		}
+	}
+}
+
+// read takes requests off the channel and sends them on requests.
+func (c *conn) read(requests chan *Fcall) {
+	for {
+		req := new(Fcall)
+		if err := c.ch.ReadFcall(c.ctx, req); err != nil {
+			if err, ok := err.(net.Error); ok {
+				if err.Timeout() || err.Temporary() {
+					// TODO(stevvooe): A full idle timeout on the connection
+					// should be enforced here. No logging because it is quite
+					// chatty.
+					continue
+				}
+			}
+
+			c.CloseWithError(fmt.Errorf("error reading fcall: %v", err))
+			return
+		}
+
+		select {
+		case requests <- req:
+		case <-c.ctx.Done():
+			c.CloseWithError(c.ctx.Err())
+			return
+		case <-c.closed:
+			return
+		}
+	}
+}
+
+func (c *conn) write(responses chan *Fcall) {
+	for {
+		select {
+		case resp := <-responses:
+			// TODO(stevvooe): Correctly protect againt overflowing msize from
+			// handler. This can be done above, in the main message handler
+			// loop, by adjusting incoming Tread calls to have a Count that
+			// won't overflow the msize.
+
+			if err := c.ch.WriteFcall(c.ctx, resp); err != nil {
+				if err, ok := err.(net.Error); ok {
+					if err.Timeout() || err.Temporary() {
+						// TODO(stevvooe): A full idle timeout on the
+						// connection should be enforced here. We log here,
+						// since this is less common.
+						log.Printf("9p server: temporary error writing fcall: %v", err)
+						continue
+					}
+				}
+
+				c.CloseWithError(fmt.Errorf("error writing fcall: %v", err))
+				return
+			}
+		case <-c.ctx.Done():
+			c.CloseWithError(c.ctx.Err())
+			return
+		case <-c.closed:
+			return
+		}
+	}
+}
+
+func (c *conn) Close() error {
+	return c.CloseWithError(nil)
+}
+
+func (c *conn) CloseWithError(err error) error {
+	c.once.Do(func() {
+		if err == nil {
+			err = ErrClosed
+		}
+
+		c.err = err
+		close(c.closed)
+	})
+
+	return c.err
+}

--- a/go/vendor/github.com/docker/go-p9p/session.go
+++ b/go/vendor/github.com/docker/go-p9p/session.go
@@ -1,0 +1,42 @@
+package p9p
+
+import "context"
+
+// Session provides the central abstraction for a 9p connection. Clients
+// implement sessions and servers serve sessions. Sessions can be proxied by
+// serving up a client session.
+//
+// The interface is also wired up with full context support to manage timeouts
+// and resource clean up.
+//
+// Session represents the operations covered in section 5 of the plan 9 manual
+// (http://man.cat-v.org/plan_9/5/). Requests are managed internally, so the
+// Flush method is handled by the internal implementation. Consider preceeding
+// these all with context to control request timeout.
+type Session interface {
+	Auth(ctx context.Context, afid Fid, uname, aname string) (Qid, error)
+	Attach(ctx context.Context, fid, afid Fid, uname, aname string) (Qid, error)
+	Clunk(ctx context.Context, fid Fid) error
+	Remove(ctx context.Context, fid Fid) error
+	Walk(ctx context.Context, fid Fid, newfid Fid, names ...string) ([]Qid, error)
+
+	// Read follows the semantics of io.ReaderAt.ReadAtt method except it takes
+	// a contxt and Fid.
+	Read(ctx context.Context, fid Fid, p []byte, offset int64) (n int, err error)
+
+	// Write follows the semantics of io.WriterAt.WriteAt except takes a context and an Fid.
+	//
+	// If n == len(p), no error is returned.
+	// If n < len(p), io.ErrShortWrite will be returned.
+	Write(ctx context.Context, fid Fid, p []byte, offset int64) (n int, err error)
+
+	Open(ctx context.Context, fid Fid, mode Flag) (Qid, uint32, error)
+	Create(ctx context.Context, parent Fid, name string, perm uint32, mode Flag) (Qid, uint32, error)
+	Stat(ctx context.Context, fid Fid) (Dir, error)
+	WStat(ctx context.Context, fid Fid, dir Dir) error
+
+	// Version returns the supported version and msize of the session. This
+	// can be affected by negotiating or the level of support provided by the
+	// session implementation.
+	Version() (msize int, version string)
+}

--- a/go/vendor/github.com/docker/go-p9p/transport.go
+++ b/go/vendor/github.com/docker/go-p9p/transport.go
@@ -1,0 +1,250 @@
+package p9p
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"sync"
+
+	"context"
+)
+
+// roundTripper manages the request and response from the client-side. A
+// roundTripper must abide by similar rules to the http.RoundTripper.
+// Typically, the roundTripper will manage tag assignment and message
+// serialization.
+type roundTripper interface {
+	send(ctx context.Context, msg Message) (Message, error)
+}
+
+// transport plays the role of being a client channel manager. It multiplexes
+// function calls onto the wire and dispatches responses to blocking calls to
+// send. On the whole, transport is thread-safe for calling send
+type transport struct {
+	ctx      context.Context
+	ch       Channel
+	requests chan *fcallRequest
+
+	shutdown chan struct{}
+	once     sync.Once // protect closure of shutdown
+	closed   chan struct{}
+
+	tags uint16
+}
+
+var _ roundTripper = &transport{}
+
+func newTransport(ctx context.Context, ch Channel) roundTripper {
+	t := &transport{
+		ctx:      ctx,
+		ch:       ch,
+		requests: make(chan *fcallRequest),
+		shutdown: make(chan struct{}),
+		closed:   make(chan struct{}),
+	}
+
+	go t.handle()
+
+	return t
+}
+
+// fcallRequest encompasses the request to send a message via fcall.
+type fcallRequest struct {
+	ctx      context.Context
+	message  Message
+	response chan *Fcall
+	err      chan error
+}
+
+func newFcallRequest(ctx context.Context, msg Message) *fcallRequest {
+	return &fcallRequest{
+		ctx:      ctx,
+		message:  msg,
+		response: make(chan *Fcall, 1),
+		err:      make(chan error, 1),
+	}
+}
+
+func (t *transport) send(ctx context.Context, msg Message) (Message, error) {
+	req := newFcallRequest(ctx, msg)
+
+	// dispatch the request.
+	select {
+	case <-t.closed:
+		return nil, ErrClosed
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case t.requests <- req:
+	}
+
+	// wait for the response.
+	select {
+	case <-t.closed:
+		return nil, ErrClosed
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case err := <-req.err:
+		return nil, err
+	case resp := <-req.response:
+		if resp.Type == Rerror {
+			// pack the error into something useful
+			respmesg, ok := resp.Message.(MessageRerror)
+			if !ok {
+				return nil, fmt.Errorf("invalid error response: %v", resp)
+			}
+
+			return nil, respmesg
+		}
+
+		return resp.Message, nil
+	}
+}
+
+// allocateTag returns a valid tag given a tag pool map. It receives a hint as
+// to where to start the tag search. It returns an error if the allocation is
+// not possible. The provided map must not contain NOTAG as a key.
+func allocateTag(r *fcallRequest, m map[Tag]*fcallRequest, hint Tag) (Tag, error) {
+	// The tag pool is depleted if 65535 (0xFFFF) tags are taken.
+	if len(m) >= 0xFFFF {
+		return 0, errors.New("tag pool depleted")
+	}
+
+	// Look for the first tag that doesn't exist in the map and return it.
+	for i := 0; i < 0xFFFF; i++ {
+		hint++
+		if hint == NOTAG {
+			hint = 0
+		}
+
+		if _, exists := m[hint]; !exists {
+			return hint, nil
+		}
+	}
+
+	return 0, errors.New("allocateTag: unexpected error")
+}
+
+// handle takes messages off the wire and wakes up the waiting tag call.
+func (t *transport) handle() {
+	defer func() {
+		log.Println("exited handle loop")
+		close(t.closed)
+	}()
+
+	// the following variable block are protected components owned by this thread.
+	var (
+		responses = make(chan *Fcall)
+		// outstanding provides a map of tags to outstanding requests.
+		outstanding = map[Tag]*fcallRequest{}
+		selected    Tag
+	)
+
+	// loop to read messages off of the connection
+	go func() {
+		defer func() {
+			log.Println("exited read loop")
+			t.close() // single main loop
+		}()
+	loop:
+		for {
+			fcall := new(Fcall)
+			if err := t.ch.ReadFcall(t.ctx, fcall); err != nil {
+				switch err := err.(type) {
+				case net.Error:
+					if err.Timeout() || err.Temporary() {
+						// BUG(stevvooe): There may be partial reads under
+						// timeout errors where this is actually fatal.
+
+						// can only retry if we haven't offset the frame.
+						continue loop
+					}
+				}
+
+				log.Println("fatal error reading msg:", err)
+				return
+			}
+
+			select {
+			case <-t.ctx.Done():
+				return
+			case <-t.closed:
+				log.Println("transport closed")
+				return
+			case responses <- fcall:
+			}
+		}
+	}()
+
+	for {
+		select {
+		case req := <-t.requests:
+			var err error
+
+			selected, err = allocateTag(req, outstanding, selected)
+			if err != nil {
+				req.err <- err
+				continue
+			}
+
+			outstanding[selected] = req
+			fcall := newFcall(selected, req.message)
+
+			// TODO(stevvooe): Consider the case of requests that never
+			// receive a response. We need to remove the fcall context from
+			// the tag map and dealloc the tag. We may also want to send a
+			// flush for the tag.
+			if err := t.ch.WriteFcall(req.ctx, fcall); err != nil {
+				delete(outstanding, fcall.Tag)
+				req.err <- err
+			}
+		case b := <-responses:
+			req, ok := outstanding[b.Tag]
+			if !ok {
+				// BUG(stevvooe): The exact handling of an unknown tag is
+				// unclear at this point. These may not necessarily fatal to
+				// the session, since they could be messages that the client no
+				// longer cares for. When we figure this out, replace this
+				// panic with something more sensible.
+				panic(fmt.Sprintf("unknown tag received: %v", b))
+			}
+
+			// BUG(stevvooe): Must detect duplicate tag and ensure that we are
+			// waking up the right caller. If a duplicate is received, the
+			// entry should not be deleted.
+			delete(outstanding, b.Tag)
+
+			req.response <- b
+
+			// TODO(stevvooe): Reclaim tag id.
+		case <-t.shutdown:
+			return
+		case <-t.ctx.Done():
+			return
+		}
+	}
+}
+
+func (t *transport) flush(ctx context.Context, tag Tag) error {
+	// TODO(stevvooe): We need to fire and forget flush messages when a call
+	// context gets cancelled.
+	panic("not implemented")
+}
+
+func (t *transport) Close() error {
+	t.close()
+
+	select {
+	case <-t.closed:
+		return nil
+	case <-t.ctx.Done():
+		return t.ctx.Err()
+	}
+}
+
+// close starts the shutdown process.
+func (t *transport) close() {
+	t.once.Do(func() {
+		close(t.shutdown)
+	})
+}

--- a/go/vendor/github.com/docker/go-p9p/types.go
+++ b/go/vendor/github.com/docker/go-p9p/types.go
@@ -1,0 +1,149 @@
+package p9p
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	// DefaultMSize messages size used to establish a session.
+	DefaultMSize = 64 << 10
+
+	// DefaultVersion for this package. Currently, the only supported version.
+	DefaultVersion = "9P2000"
+)
+
+// Mode constants for use Dir.Mode.
+const (
+	DMDIR    = 0x80000000 // mode bit for directories
+	DMAPPEND = 0x40000000 // mode bit for append only files
+	DMEXCL   = 0x20000000 // mode bit for exclusive use files
+	DMMOUNT  = 0x10000000 // mode bit for mounted channel
+	DMAUTH   = 0x08000000 // mode bit for authentication file
+	DMTMP    = 0x04000000 // mode bit for non-backed-up files
+
+	// 9p2000.u extensions
+
+	DMSYMLINK   = 0x02000000
+	DMDEVICE    = 0x00800000
+	DMNAMEDPIPE = 0x00200000
+	DMSOCKET    = 0x00100000
+	DMSETUID    = 0x00080000
+	DMSETGID    = 0x00040000
+
+	DMREAD  = 0x4 // mode bit for read permission
+	DMWRITE = 0x2 // mode bit for write permission
+	DMEXEC  = 0x1 // mode bit for execute permission
+)
+
+// Flag defines the flag type for use with open and create
+type Flag uint8
+
+// Constants to use when opening files.
+const (
+	OREAD  Flag = 0x00 // open for read
+	OWRITE Flag = 0x01 // write
+	ORDWR  Flag = 0x02 // read and write
+	OEXEC  Flag = 0x03 // execute, == read but check execute permission
+
+	// PROPOSAL(stevvooe): Possible protocal extension to allow the create of
+	// symlinks. Initially, the link is created with no value. Read and write
+	// to read and set the link value.
+
+	OSYMLINK Flag = 0x04
+
+	OTRUNC  Flag = 0x10 // or'ed in (except for exec), truncate file first
+	OCEXEC  Flag = 0x20 // or'ed in, close on exec
+	ORCLOSE Flag = 0x40 // or'ed in, remove on close
+)
+
+// QType indicates the type of a resource within the Qid.
+type QType uint8
+
+// Constants for use in Qid to indicate resource type.
+const (
+	QTDIR    QType = 0x80 // type bit for directories
+	QTAPPEND QType = 0x40 // type bit for append only files
+	QTEXCL   QType = 0x20 // type bit for exclusive use files
+	QTMOUNT  QType = 0x10 // type bit for mounted channel
+	QTAUTH   QType = 0x08 // type bit for authentication file
+	QTTMP    QType = 0x04 // type bit for not-backed-up file
+	QTFILE   QType = 0x00 // plain file
+)
+
+func (qt QType) String() string {
+	switch qt {
+	case QTDIR:
+		return "dir"
+	case QTAPPEND:
+		return "append"
+	case QTEXCL:
+		return "excl"
+	case QTMOUNT:
+		return "mount"
+	case QTAUTH:
+		return "auth"
+	case QTTMP:
+		return "tmp"
+	case QTFILE:
+		return "file"
+	}
+
+	return "unknown"
+}
+
+// Tag uniquely identifies an outstanding fcall in a 9p session.
+type Tag uint16
+
+// NOTAG is a reserved values for messages sent before establishing a session,
+// such as Tversion.
+const NOTAG Tag = ^Tag(0)
+
+// Fid defines a type to hold Fid values.
+type Fid uint32
+
+// NOFID indicates the lack of an Fid.
+const NOFID Fid = ^Fid(0)
+
+// Qid indicates the type, path and version of the resource returned by a
+// server. It is only valid for a session.
+//
+// Typically, a client maintains a mapping of Fid-Qid as Qids are returned by
+// the server.
+type Qid struct {
+	Type    QType `9p:"type,1"`
+	Version uint32
+	Path    uint64
+}
+
+func (qid Qid) String() string {
+	return fmt.Sprintf("qid(%v, v=%x, p=%x)",
+		qid.Type, qid.Version, qid.Path)
+}
+
+// Dir defines the structure used for expressing resources in stat/wstat and
+// when reading directories.
+type Dir struct {
+	Type uint16
+	Dev  uint32
+	Qid  Qid
+	Mode uint32
+
+	// BUG(stevvooe): The Year 2038 is coming soon. 9p wire protocol has these
+	// as 4 byte epoch times. Some possibilities include time dilation fields
+	// or atemporal files. We can also just not use them and set them to zero.
+
+	AccessTime time.Time
+	ModTime    time.Time
+
+	Length uint64
+	Name   string
+	UID    string
+	GID    string
+	MUID   string
+}
+
+func (d Dir) String() string {
+	return fmt.Sprintf("dir(%v mode=%v atime=%v mtime=%v length=%v name=%v uid=%v gid=%v muid=%v)",
+		d.Qid, d.Mode, d.AccessTime, d.ModTime, d.Length, d.Name, d.UID, d.GID, d.MUID)
+}

--- a/go/vendor/github.com/docker/go-p9p/version.go
+++ b/go/vendor/github.com/docker/go-p9p/version.go
@@ -1,0 +1,112 @@
+package p9p
+
+import (
+	"fmt"
+
+	"context"
+)
+
+// NOTE(stevvooe): This file contains functions for negotiating version on the
+// client and server. There are some nasty details to get right for
+// downgrading the connection on the server-side that are not present yet.
+// Really, these should be refactored into some sort of channel type that can
+// support resets through version messages during the protocol exchange.
+
+// clientnegotiate negiotiates the protocol version using channel, blocking
+// until a response is received. The received value will be the version
+// implemented by the server.
+func clientnegotiate(ctx context.Context, ch Channel, version string) (string, error) {
+	req := newFcall(NOTAG, MessageTversion{
+		MSize:   uint32(ch.MSize()),
+		Version: version,
+	})
+
+	if err := ch.WriteFcall(ctx, req); err != nil {
+		return "", err
+	}
+
+	resp := new(Fcall)
+	if err := ch.ReadFcall(ctx, resp); err != nil {
+		return "", err
+	}
+
+	switch v := resp.Message.(type) {
+	case MessageRversion:
+
+		if v.Version != version {
+			// TODO(stevvooe): A stubborn client indeed!
+			return "", fmt.Errorf("unsupported server version: %v", version)
+		}
+
+		if int(v.MSize) < ch.MSize() {
+			// upgrade msize if server differs.
+			ch.SetMSize(int(v.MSize))
+		}
+
+		return v.Version, nil
+	case error:
+		return "", v
+	default:
+		return "", ErrUnexpectedMsg
+	}
+}
+
+// servernegotiate blocks until a version message is received or a timeout
+// occurs. The msize for the tranport will be set from the negotiation. If
+// negotiate returns nil, a server may proceed with the connection.
+//
+// In the future, it might be better to handle the version messages in a
+// separate object that manages the session. Each set of version requests
+// effectively "reset" a connection, meaning all fids get clunked and all
+// outstanding IO is aborted. This is probably slightly racy, in practice with
+// a misbehaved client. The main issue is that we cannot tell which session
+// messages belong to.
+func servernegotiate(ctx context.Context, ch Channel, version string) error {
+	// wait for the version message over the transport.
+	req := new(Fcall)
+	if err := ch.ReadFcall(ctx, req); err != nil {
+		return err
+	}
+
+	mv, ok := req.Message.(MessageTversion)
+	if !ok {
+		return fmt.Errorf("expected version message: %v", mv)
+	}
+
+	respmsg := MessageRversion{
+		Version: version,
+	}
+
+	if mv.Version != version {
+		// TODO(stevvooe): Not the best place to do version handling. We need
+		// to have a way to pass supported versions into this method then have
+		// it return the actual version. For now, respond with 9P2000 for
+		// anything that doesn't match the provided version string.
+		//
+		// version(9) says "The server may respond with the client’s
+		// version string, or a version string identifying an earlier
+		// defined protocol version. Currently, the only defined
+		// version is the 6 characters 9P2000." Therefore, it is always
+		// OK to respond with this.
+		respmsg.Version = "9P2000"
+	}
+
+	if int(mv.MSize) < ch.MSize() {
+		// if the server msize is too large, use the client's suggested msize.
+		ch.SetMSize(int(mv.MSize))
+		respmsg.MSize = mv.MSize
+	} else {
+		respmsg.MSize = uint32(ch.MSize())
+	}
+
+	resp := newFcall(NOTAG, respmsg)
+	if err := ch.WriteFcall(ctx, resp); err != nil {
+		return err
+	}
+
+	if respmsg.Version == "unknown" {
+		return fmt.Errorf("bad version negotiation")
+	}
+
+	return nil
+}

--- a/go/vendor/github.com/moby/datakit/LICENSE.md
+++ b/go/vendor/github.com/moby/datakit/LICENSE.md
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2013-2016 Docker, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/go/vendor/github.com/moby/datakit/README.md
+++ b/go/vendor/github.com/moby/datakit/README.md
@@ -1,0 +1,112 @@
+## DataKit -- Orchestrate applications using a Git-like dataflow
+
+*DataKit* is a tool to orchestrate applications using a Git-like dataflow. It
+revisits the UNIX pipeline concept, with a modern twist: streams of
+tree-structured data instead of raw text. DataKit allows you to define
+complex build pipelines over version-controlled data.
+
+DataKit is currently used as the coordination
+layer for [HyperKit](http://github.com/docker/hyperkit), the
+hypervisor component of
+[Docker for Mac and Windows](https://blog.docker.com/2016/03/docker-for-mac-windows-beta/), and
+for the [DataKitCI][] continuous integration system.
+
+---
+
+[![Build Status (OSX, Linux)](https://travis-ci.org/moby/datakit.svg)](https://travis-ci.org/moby/datakit)
+[![Build status (Windows)](https://ci.appveyor.com/api/projects/status/6qrdgiqbhi4sehmy/branch/master?svg=true)](https://ci.appveyor.com/project/moby/datakit/branch/master)
+[![docs](https://img.shields.io/badge/doc-online-blue.svg)](https://docker.github.io/datakit/)
+
+There are several components in this repository:
+
+- `src` contains the main DataKit service. This is a Git-like database to which other services can connect.
+- `ci` contains [DataKitCI][], a continuous integration system that uses DataKit to monitor repositories and store build results.
+- `ci/self-ci` is the CI configuration for DataKitCI that tests DataKit itself.
+- `bridge/github` is a service that monitors repositories on GitHub and syncs their metadata with a DataKit database.
+  e.g. when a pull request is opened or updated, it will commit that information to DataKit. If you commit a status message to DataKit, the bridge will push it to GitHub.
+- `bridge/local` is a drop-in replacement for `bridge/github` that just monitors a local Git repository. This is useful for local testing.
+
+### Quick Start
+
+The easiest way to use DataKit is to start both the server and the client in containers.
+
+To expose a Git repository as a 9p endpoint on port 5640 on a private network, run:
+
+```shell
+$ docker network create datakit-net # create a private network
+$ docker run -it --net datakit-net --name datakit -v <path/to/git/repo>:/data datakit/db
+```
+
+*Note*: The `--name datakit` option is mandatory.  It will allow the client
+to connect to a known name on the private network.
+
+You can then start a DataKit client, which will mount the 9p endpoint and
+expose the database as a filesystem API:
+
+```shell
+# In an other terminal
+$ docker run -it --privileged --net datakit-net datakit/client
+$ ls /db
+branch     remotes    snapshots  trees
+```
+
+*Note*: the `--privileged` option is needed because the container will have
+to mount the 9p endpoint into its local filesystem.
+
+Now you can explore, edit and script `/db`. See the
+[Filesystem API][]
+for more details.
+
+### Building
+
+The easiest way to build the DataKit project is to use [docker](https://docker.com),
+(which is what the
+[start-datakit.sh](https://github.com/moby/datakit/blob/master/scripts/start-datakit.sh) script
+does under the hood):
+
+```shell
+docker build -t datakit/db -f Dockerfile .
+docker run -p 5640:5640 -it --rm datakit/db --listen-9p=tcp://0.0.0.0:5640
+```
+These commands will expose the database's 9p endpoint on port 5640.
+
+If you want to build the project from source without Docker, you will need to install
+[ocaml](http://ocaml.org/) and [opam](http://opam.ocaml.org/). Then write:
+
+```shell
+$ make depends
+$ make && make test
+```
+
+For information about command-line options:
+
+```shell
+$ datakit --help
+```
+
+## Prometheus metric reporting
+
+Run with `--listen-prometheus 9090` to expose metrics at `http://*:9090/metrics`.
+
+Note: there is no encryption and no access control. You are expected to run the
+database in a container and to not export this port to the outside world. You
+can either collect the metrics by running a Prometheus service in a container
+on the same Docker network, or front the service with nginx or similar if you
+want to collect metrics remotely.
+
+## Language bindings
+
+* **Go** bindings are in the `api/go` directory.
+* **OCaml** bindings are in the `api/ocaml` directory. See `examples/ocaml-client` for an example.
+
+## Licensing
+
+DataKit is licensed under the Apache License, Version 2.0. See
+[LICENSE](https://github.com/moby/datakit/blob/master/LICENSE.md) for the full
+license text.
+
+Contributions are welcome under the terms of this license. You may wish to browse
+the [weekly reports](reports) to read about overall activity in the repository.
+
+[DataKitCI]: https://github.com/moby/datakit/tree/master/ci
+[Filesystem API]: https://github.com/moby/datakit/tree/master/9p.md

--- a/go/vendor/github.com/moby/datakit/api/go-datakit/README
+++ b/go/vendor/github.com/moby/datakit/api/go-datakit/README
@@ -1,0 +1,1 @@
+To run test on windows, launch the a datakit server with --url \\.\pipe\datakit-test

--- a/go/vendor/github.com/moby/datakit/api/go-datakit/client.go
+++ b/go/vendor/github.com/moby/datakit/api/go-datakit/client.go
@@ -1,0 +1,352 @@
+package datakit
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"net"
+	"sync"
+
+	p9p "github.com/docker/go-p9p"
+	"context"
+)
+
+type Client struct {
+	conn     net.Conn
+	session  p9p.Session
+	m        *sync.Mutex
+	c        *sync.Cond
+	usedFids map[p9p.Fid]bool
+	freeFids []p9p.Fid
+	root     p9p.Fid
+}
+
+var badFid = p9p.Fid(0)
+
+var rwx = p9p.DMREAD | p9p.DMWRITE | p9p.DMEXEC
+var rx = p9p.DMREAD | p9p.DMEXEC
+var rw = p9p.DMREAD | p9p.DMWRITE
+var r = p9p.DMREAD
+var dirperm = uint32(rwx<<6 | rx<<3 | rx | p9p.DMDIR)
+var fileperm = uint32(rw<<6 | r<<3 | r)
+
+// Dial opens a connection to a 9P server
+func Dial(ctx context.Context, network, address string) (*Client, error) {
+	log.Println("Dialling", network, address)
+	conn, err := net.Dial(network, address)
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(ctx, conn)
+}
+
+// NewClient creates opens a connection with the p9p server
+func NewClient(ctx context.Context, conn net.Conn) (*Client, error) {
+	session, err := p9p.NewSession(ctx, conn)
+	if err != nil {
+		log.Println("Failed to establish 9P session to", err)
+		return nil, err
+	}
+	root := p9p.Fid(1)
+	if _, err := session.Attach(ctx, root, p9p.NOFID, "anyone", "/"); err != nil {
+		log.Println("Failed to Attach to filesystem", err)
+		return nil, err
+	}
+	usedFids := make(map[p9p.Fid]bool, 0)
+	freeFids := make([]p9p.Fid, 0)
+	for i := 0; i < 128; i++ {
+		fid := p9p.Fid(i)
+		if fid == root {
+			usedFids[fid] = true
+		} else {
+			freeFids = append(freeFids, fid)
+			usedFids[fid] = false
+		}
+	}
+	var m sync.Mutex
+	c := sync.NewCond(&m)
+	return &Client{conn, session, &m, c, usedFids, freeFids, root}, nil
+}
+
+func (c *Client) Close(ctx context.Context) {
+	if err := c.session.Clunk(ctx, c.root); err != nil {
+		log.Println("Failed to Clunk root fid", err)
+	} else {
+		c.usedFids[c.root] = false
+	}
+	c.m.Lock()
+	defer c.m.Unlock()
+	for fid, inuse := range c.usedFids {
+		if inuse {
+			log.Println("I don't know how to flush: leaking", fid)
+		}
+	}
+	c.conn.Close()
+}
+
+// allocFid returns a fresh fid, bound to a clone of from
+func (c *Client) allocFid(ctx context.Context, from p9p.Fid) (p9p.Fid, error) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	for len(c.freeFids) == 0 {
+		c.c.Wait()
+	}
+	fid := c.freeFids[len(c.freeFids)-1]
+	c.freeFids = c.freeFids[0 : len(c.freeFids)-1]
+	c.usedFids[fid] = true
+	_, err := c.session.Walk(ctx, from, fid)
+	if err != nil {
+		log.Println("Failed to clone root fid", err)
+		return badFid, err
+	}
+	return fid, nil
+}
+
+// freeFid removes resources associated with the given fid
+func (c *Client) freeFid(ctx context.Context, fid p9p.Fid) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	c.freeFids = append(c.freeFids, fid)
+	c.usedFids[fid] = false
+	if err := c.session.Clunk(ctx, fid); err != nil {
+		log.Println("Failed to clunk fid", fid)
+	}
+	c.c.Signal()
+}
+
+// Mkdir acts like 'mkdir -p'
+func (c *Client) Mkdir(ctx context.Context, path ...string) error {
+	fid, err := c.allocFid(ctx, c.root)
+	if err != nil {
+		return nil
+	}
+	defer c.freeFid(ctx, fid)
+	// mkdir -p
+	for _, dir := range path {
+		dirfid, err := c.allocFid(ctx, fid)
+		if err != nil {
+			return err
+		}
+		// dir may or may not exist
+		_, _, _ = c.session.Create(ctx, dirfid, dir, dirperm, p9p.OREAD)
+		c.freeFid(ctx, dirfid)
+		// dir should definitely exist
+		if _, err := c.session.Walk(ctx, fid, fid, dir); err != nil {
+			log.Println("Failed to Walk to", dir, err)
+			return err
+		}
+	}
+	return nil
+}
+
+var enoent = p9p.MessageRerror{Ename: "No such file or directory"}
+var enotdir = p9p.MessageRerror{Ename: "Can't walk from a file"}
+
+// Remove acts like 'rm -f'
+func (c *Client) Remove(ctx context.Context, path ...string) error {
+	fid, err := c.allocFid(ctx, c.root)
+	if err != nil {
+		return err
+	}
+	if _, err := c.session.Walk(ctx, fid, fid, path...); err != nil {
+		if err == enoent || err == enotdir {
+			c.freeFid(ctx, fid)
+			return nil
+		}
+		log.Println("Failed to walk to", path, err)
+		c.freeFid(ctx, fid)
+		return err
+	}
+	// Remove will cluck the fid, even if it fails
+	if err := c.session.Remove(ctx, fid); err != nil {
+		if err == enoent {
+			return nil
+		}
+		log.Println("Failed to Remove", path, err)
+		return err
+	}
+	return nil
+}
+
+type File struct {
+	fid  p9p.Fid
+	c    *Client
+	m    *sync.Mutex
+	open bool
+}
+
+// Create creates a file
+func (c *Client) Create(ctx context.Context, path ...string) (*File, error) {
+	fid, err := c.allocFid(ctx, c.root)
+	if err != nil {
+		return nil, err
+	}
+	dir := path[0 : len(path)-1]
+	_, err = c.session.Walk(ctx, fid, fid, dir...)
+	if err != nil {
+		if err != enoent {
+			// This is a common error
+			log.Println("Failed to Walk to", path, err)
+		}
+		c.freeFid(ctx, fid)
+		return nil, err
+	}
+	_, _, err = c.session.Create(ctx, fid, path[len(path)-1], fileperm, p9p.ORDWR)
+	if err != nil {
+		log.Println("Failed to Create", path, err)
+		return nil, err
+	}
+	var m sync.Mutex
+	return &File{fid: fid, c: c, m: &m, open: true}, nil
+}
+
+// Open opens a file
+func (c *Client) Open(ctx context.Context, mode p9p.Flag, path ...string) (*File, error) {
+	fid, err := c.allocFid(ctx, c.root)
+	if err != nil {
+		return nil, err
+	}
+	_, err = c.session.Walk(ctx, fid, fid, path...)
+	if err != nil {
+		if err != enoent {
+			// This is a common error
+			log.Println("Failed to Walk to", path, err)
+		}
+		c.freeFid(ctx, fid)
+		return nil, err
+	}
+	_, _, err = c.session.Open(ctx, fid, mode)
+	if err != nil {
+		log.Println("Failed to Open", path, err)
+		c.freeFid(ctx, fid)
+		return nil, err
+	}
+	var m sync.Mutex
+	return &File{fid: fid, c: c, m: &m, open: true}, nil
+}
+
+// List a directory
+func (c *Client) List(ctx context.Context, path []string) ([]string, error) {
+	file, err := c.Open(ctx, p9p.OREAD, path...)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close(ctx)
+
+	msize, _ := c.session.Version()
+	iounit := uint32(msize - 24) // size of message max minus fcall io header (Rread)
+
+	p := make([]byte, iounit)
+
+	n, err := c.session.Read(ctx, file.fid, p, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	files := []string{}
+
+	rd := bytes.NewReader(p[:n])
+	codec := p9p.NewCodec() // TODO(stevvooe): Need way to resolve codec based on session.
+	for {
+		var d p9p.Dir
+		if err := p9p.DecodeDir(codec, rd, &d); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return files, err
+		}
+		files = append(files, d.Name)
+	}
+	return files, nil
+}
+
+// Close closes a file
+func (f *File) Close(ctx context.Context) {
+	f.m.Lock()
+	defer f.m.Unlock()
+	if f.open {
+		f.c.freeFid(ctx, f.fid)
+	}
+	f.open = false
+}
+
+// Read reads a value
+func (f *File) Read(ctx context.Context, p []byte, offset int64) (int, error) {
+	f.m.Lock()
+	defer f.m.Unlock()
+	if !f.open {
+		return 0, io.EOF
+	}
+	return f.c.session.Read(ctx, f.fid, p, offset)
+}
+
+// Write writes a value
+func (f *File) Write(ctx context.Context, p []byte, offset int64) (int, error) {
+	f.m.Lock()
+	defer f.m.Unlock()
+	if !f.open {
+		return 0, io.EOF
+	}
+	return f.c.session.Write(ctx, f.fid, p, offset)
+}
+
+type FileReader struct {
+	file   *File
+	offset int64
+	ctx    context.Context
+}
+
+func (f *File) NewFileReader(ctx context.Context) *FileReader {
+	offset := int64(0)
+	return &FileReader{file: f, offset: offset, ctx: ctx}
+}
+
+func (f *FileReader) Read(p []byte) (int, error) {
+	n, err := f.file.Read(f.ctx, p, f.offset)
+	f.offset = f.offset + int64(n)
+	if n == 0 {
+		return 0, io.EOF
+	}
+	return n, err
+}
+
+type ioFileReaderWriter struct {
+	f      *File
+	ctx    context.Context
+	offset int64
+}
+
+// NewIOReader creates a standard io.Reader at a given position in the file
+func (f *File) NewIOReader(ctx context.Context, offset int64) io.Reader {
+	return &ioFileReaderWriter{f, ctx, offset}
+}
+
+// NewIOWriter creates a standard io.Writer at a given position in the file
+func (f *File) NewIOWriter(ctx context.Context, offset int64) io.Writer {
+	return &ioFileReaderWriter{f, ctx, offset}
+}
+
+func (r *ioFileReaderWriter) Read(p []byte) (n int, err error) {
+
+	r.f.m.Lock()
+	defer r.f.m.Unlock()
+	n, err = r.f.c.session.Read(r.ctx, r.f.fid, p, r.offset)
+
+	r.offset += int64(n)
+	return n, err
+}
+func (w *ioFileReaderWriter) Write(p []byte) (n int, err error) {
+	w.f.m.Lock()
+	defer w.f.m.Unlock()
+	for err == nil || err == io.ErrShortWrite {
+		var written int
+		written, err = w.f.c.session.Write(w.ctx, w.f.fid, p, w.offset)
+		p = p[written:]
+		w.offset += int64(written)
+		n += written
+		if len(p) == 0 {
+			break
+		}
+	}
+	return
+}

--- a/go/vendor/github.com/moby/datakit/api/go-datakit/config.go
+++ b/go/vendor/github.com/moby/datakit/api/go-datakit/config.go
@@ -1,0 +1,380 @@
+package datakit
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"context"
+)
+
+type Version int
+
+var InitialVersion = Version(0)
+
+// Record is a typed view on top of a database branch
+type Record struct {
+	client    *Client
+	path      []string // directory inside the store
+	version   Version
+	schemaF   *IntField
+	fields    []*StringRefField // registered fields, for schema upgrades
+	lookupB   []string          // priority ordered list of branches to look up values in
+	defaultsB string            // name of the branch containing built-in defaults
+	stateB    string            // name of the branch containing run-time state
+	event     chan (interface{})
+	onUpdate  [](func([]*Snapshot, Version))
+}
+
+func NewRecord(ctx context.Context, client *Client, lookupB []string, defaultsB string, stateB string, path []string) (*Record, error) {
+	event := make(chan (interface{}), 0)
+	for _, b := range append(lookupB, stateB) {
+		// Create the branch if it doesn't exist
+		t, err := NewTransaction(ctx, client, b)
+		if err != nil {
+			log.Fatalf("Failed to open a new transaction: %#v", err)
+		}
+		if err = t.Write(ctx, []string{"branch-created"}, ""); err != nil {
+			log.Fatalf("Failed to write branch-created: %#v", err)
+		}
+		if err = t.Commit(ctx, "Creating branch"); err != nil {
+			log.Fatalf("Failed to commit transaction: %#v", err)
+		}
+	}
+	for _, b := range lookupB {
+		if err := client.Mkdir(ctx, "branch", b); err != nil {
+			return nil, err
+		}
+		w, err := NewWatch(ctx, client, b, path)
+		if err != nil {
+			return nil, err
+		}
+		go func() {
+			for {
+				_, err := w.Next(ctx)
+				if err != nil {
+					return
+				}
+				log.Printf("Snapshot has changed\n")
+				event <- 0
+			}
+		}()
+	}
+	onUpdate := make([](func([]*Snapshot, Version)), 0)
+	fields := make([]*StringRefField, 0)
+	r := &Record{
+		client:    client,
+		path:      path,
+		version:   InitialVersion,
+		fields:    fields,
+		lookupB:   lookupB,
+		defaultsB: defaultsB,
+		stateB:    stateB,
+		event:     event,
+		onUpdate:  onUpdate,
+	}
+	r.schemaF = r.IntField("schema-version", 1)
+	return r, nil
+}
+
+func (r *Record) updateAll(ctx context.Context) error {
+	snapshots := make([]*Snapshot, 0)
+	for _, b := range r.lookupB {
+		head, err := Head(ctx, r.client, b)
+		if err != nil {
+			return err
+		}
+		snap := NewSnapshot(ctx, r.client, COMMIT, head)
+		snapshots = append(snapshots, snap)
+	}
+	for _, fn := range r.onUpdate {
+		fn(snapshots, r.version)
+	}
+	return nil
+}
+
+func (r *Record) Seal(ctx context.Context) error {
+	return r.updateAll(ctx)
+}
+
+func (r *Record) Wait(ctx context.Context) error {
+	<-r.event
+	r.version = r.version + 1
+	return r.updateAll(ctx)
+}
+
+func (r *Record) Upgrade(ctx context.Context, schemaVersion int) error {
+	currentVersion, _ := r.schemaF.Get()
+	if schemaVersion <= currentVersion {
+		log.Printf("No schema upgrade necessary because new version (%d) <= current version (%d)\n", schemaVersion, currentVersion)
+		return nil
+	}
+	r.schemaF.defaultInt = schemaVersion
+	defaultString := fmt.Sprintf("%d", schemaVersion)
+	r.schemaF.raw.defaultValue = &defaultString
+	// Create defaults branch
+	log.Printf("Performing schema upgrade to version %d\n", schemaVersion)
+	t, err := NewTransaction(ctx, r.client, r.defaultsB)
+	if err != nil {
+		return err
+	}
+	// For each known field, write default value to branch
+	for _, f := range r.fields {
+		p := append(r.path, f.path...)
+		if f.defaultValue == nil {
+			err = t.Remove(ctx, p)
+		} else {
+			err = t.Write(ctx, p, *f.defaultValue)
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	// Merge to the defaults branch
+	err = t.Commit(ctx, fmt.Sprintf("Upgrade to schema version %d", schemaVersion))
+	if err != nil {
+		return err
+	}
+	return r.Wait(ctx)
+}
+
+// fillInDefault updates the default branch to contain the new value.
+func (r *Record) fillInDefault(path []string, valueref *string) error {
+	ctx := context.Background()
+	t, err := NewTransaction(ctx, r.client, r.defaultsB)
+	if err != nil {
+		return err
+	}
+	p := append(r.path, path...)
+	if valueref == nil {
+		log.Printf("Removing default value at %s", strings.Join(p, "/"))
+
+		if err = t.Remove(ctx, p); err != nil {
+			log.Printf("Failed to remove key at %s", strings.Join(p, "/"))
+			return err
+		}
+	} else {
+		log.Printf("Updating default value at %s to %s", strings.Join(p, "/"), *valueref)
+		if err = t.Write(ctx, p, *valueref); err != nil {
+			log.Printf("Failed to write key %s = %s", strings.Join(p, "/"), *valueref)
+			return err
+		}
+	}
+	return t.Commit(ctx, fmt.Sprintf("fill-in default for %s", p))
+}
+
+func (r *Record) SetMultiple(description string, fields []*StringField, values []string) error {
+	if len(fields) != len(values) {
+		return fmt.Errorf("Length of fields and values is not equal")
+	}
+	ctx := context.Background()
+	t, err := NewTransaction(ctx, r.client, r.lookupB[0])
+	if err != nil {
+		return err
+	}
+	for i, k := range fields {
+		p := append(r.path, k.raw.path...)
+		v := values[i]
+		log.Printf("Setting value in store: %#v=%s\n", p, v)
+		err = t.Write(ctx, p, v)
+		if err != nil {
+			return err
+		}
+	}
+	return t.Commit(ctx, description)
+}
+
+type StringRefField struct {
+	path         []string
+	value        *string
+	defaultValue *string
+	version      Version // version of last change
+	record       *Record
+}
+
+// Set unconditionally sets the value of the key
+func (f *StringRefField) Set(description string, value *string) error {
+	// TODO: maybe this should return Version, too?
+	ctx := context.Background()
+	p := append(f.record.path, f.path...)
+	log.Printf("Setting value in store: %#v=%#v\n", p, value)
+	t, err := NewTransaction(ctx, f.record.client, f.record.lookupB[0])
+	if err != nil {
+		return err
+	}
+	if value == nil {
+		err = t.Remove(ctx, p)
+	} else {
+		err = t.Write(ctx, p, *value)
+	}
+	if err != nil {
+		return err
+	}
+	return t.Commit(ctx, fmt.Sprintf("Unconditionally set %s: %s", f.path, description))
+}
+
+// Get retrieves the current value of the key
+func (f *StringRefField) Get() (*string, Version) {
+	if f.value == nil {
+		return nil, f.version
+	}
+	raw := strings.TrimSpace(*f.value)
+	return &raw, f.version
+}
+
+// HasChanged returns true if the key has changed since the given version
+func (f *StringRefField) HasChanged(version Version) bool {
+	return version < f.version
+}
+
+// StringRefField defines a string option which can be nil with a specified
+// key and default value
+func (f *Record) StringRefField(key string, value *string) *StringRefField {
+	path := strings.Split(key, "/")
+	field := &StringRefField{path: path, value: value, defaultValue: value, version: InitialVersion, record: f}
+	// If the value is not in the database, write the default Value.
+	err := f.fillInDefault(path, value)
+	if err != nil {
+		log.Println("Failed to write default value", key, "=", value)
+	}
+	fn := func(snaps []*Snapshot, version Version) {
+		ctx := context.Background()
+		var newValue *string
+		for _, snap := range snaps {
+			v, err := snap.Read(ctx, append(f.path, path...))
+			if err != nil {
+				if err != enoent {
+					log.Println("Failed to read key", key, "from directory snapshot", snap)
+					return
+				}
+				// if enoent then newValue == nil
+			} else {
+				newValue = &v
+				break
+			}
+		}
+		if (field.value == nil && newValue != nil) || (field.value != nil && newValue == nil) || (field.value != nil && newValue != nil && *field.value != *newValue) {
+			field.value = newValue
+			field.version = version
+		}
+
+		// Update the value in memory and in the state branch
+		t, err := NewTransaction(ctx, f.client, f.stateB)
+		if err != nil {
+			log.Fatalf("Failed to create transaction for updating state branch: %#v", err)
+		}
+		if newValue != nil {
+			if err = t.Write(ctx, append(f.path, path...), *newValue); err != nil {
+				log.Fatalf("Failed to write state %#v = %s: %#v", path, *newValue, err)
+			}
+		} else {
+			if err = t.Remove(ctx, append(f.path, path...)); err != nil {
+				log.Fatalf("Failed to remove state %#v: %#v", path, err)
+			}
+		}
+		if err = t.Commit(ctx, "Updating state branch"); err != nil {
+			log.Fatalf("Failed to commit transaction: %#v", err)
+		}
+
+	}
+	f.onUpdate = append(f.onUpdate, fn)
+	//fn(f.version)
+	f.fields = append(f.fields, field)
+	return field
+}
+
+type StringField struct {
+	raw           *StringRefField
+	defaultString string
+}
+
+// Get retrieves the current value of the key
+func (f *StringField) Get() (string, Version) {
+	if f.raw.value == nil {
+		log.Printf("Failed to find string in database at %s, defaulting to %s", strings.Join(f.raw.path, "/"), f.defaultString)
+		return f.defaultString, f.raw.version
+	}
+	return *f.raw.value, f.raw.version
+}
+
+// Set unconditionally sets the value of the key
+func (f *StringField) Set(description string, value string) error {
+	return f.raw.Set(description, &value)
+}
+
+// HasChanged returns true if the key has changed since the given version
+func (f *StringField) HasChanged(version Version) bool {
+	return version < f.raw.version
+}
+
+// StringField defines a string
+func (f *Record) StringField(key string, value string) *StringField {
+	raw := f.StringRefField(key, &value)
+	return &StringField{raw: raw, defaultString: value}
+}
+
+type IntField struct {
+	raw        *StringRefField
+	defaultInt int
+}
+
+// Get retrieves the current value of the key
+func (f *IntField) Get() (int, Version) {
+	if f.raw.value == nil {
+		log.Printf("Key %s missing in database, defaulting value to %t", strings.Join(f.raw.path, "/"), f.defaultInt)
+		return f.defaultInt, f.raw.version
+	}
+	value64, err := strconv.ParseInt(strings.TrimSpace(*f.raw.value), 10, 0)
+	if err != nil {
+		// revert to default if we can't parse the result
+		log.Printf("Failed to parse int in database: '%s', defaulting to %d", f.raw.value, f.defaultInt)
+		return f.defaultInt, f.raw.version
+	}
+	return int(value64), f.raw.version
+}
+
+// HasChanged returns true if the key has changed since the given version
+func (f *IntField) HasChanged(version Version) bool {
+	return version < f.raw.version
+}
+
+// IntField defines an boolean option with a specified key and default value
+func (f *Record) IntField(key string, value int) *IntField {
+	stringValue := fmt.Sprintf("%d", value)
+	raw := f.StringRefField(key, &stringValue)
+	return &IntField{raw: raw, defaultInt: value}
+}
+
+type BoolField struct {
+	raw         *StringRefField
+	defaultBool bool
+}
+
+// Get retrieves the current value of the key
+func (f *BoolField) Get() (bool, Version) {
+	if f.raw.value == nil {
+		log.Printf("Key %s missing in database, defaulting value to %t", strings.Join(f.raw.path, "/"), f.defaultBool)
+		return f.defaultBool, f.raw.version
+	}
+	value, err := strconv.ParseBool(strings.TrimSpace(*f.raw.value))
+	if err != nil {
+		// revert to default if we can't parse the result
+		log.Printf("Failed to parse boolean in database: '%s', defaulting to %t", f.raw.value, f.defaultBool)
+		return f.defaultBool, f.raw.version
+	}
+	return value, f.raw.version
+}
+
+// HasChanged returns true if the key has changed since the given version
+func (f *BoolField) HasChanged(version Version) bool {
+	return version < f.raw.version
+}
+
+// BoolField defines an boolean option with a specified key and default value
+func (f *Record) BoolField(key string, value bool) *BoolField {
+	stringValue := fmt.Sprintf("%t", value)
+	raw := f.StringRefField(key, &stringValue)
+	return &BoolField{raw: raw, defaultBool: value}
+}

--- a/go/vendor/github.com/moby/datakit/api/go-datakit/doc.go
+++ b/go/vendor/github.com/moby/datakit/api/go-datakit/doc.go
@@ -1,0 +1,5 @@
+/*
+The datakit package contains common patterns over 9P, which avoids the need
+for applications to use 9P directly.
+*/
+package datakit

--- a/go/vendor/github.com/moby/datakit/api/go-datakit/snapshot.go
+++ b/go/vendor/github.com/moby/datakit/api/go-datakit/snapshot.go
@@ -1,0 +1,87 @@
+package datakit
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"strings"
+
+	p9p "github.com/docker/go-p9p"
+	"context"
+)
+
+type SnapshotKind uint8
+
+const (
+	COMMIT SnapshotKind = 0x01 // from a commit hash
+	OBJECT SnapshotKind = 0x02 // from an object hash
+)
+
+type snapshot struct {
+	client *Client
+	kind   SnapshotKind
+	thing  string
+}
+
+type Snapshot struct {
+	snapshot
+}
+
+// NewSnapshot opens a new snapshot referencing the given object.
+func NewSnapshot(ctx context.Context, client *Client, kind SnapshotKind, thing string) *Snapshot {
+	return &Snapshot{snapshot{client: client, kind: kind, thing: thing}}
+}
+
+// Head retrieves the commit sha of the given branch
+func Head(ctx context.Context, client *Client, fromBranch string) (string, error) {
+	// SHA=$(cat branch/<fromBranch>/head)
+	file, err := client.Open(ctx, p9p.ORDWR, "branch", fromBranch, "head")
+	if err != nil {
+		log.Println("Failed to open branch/", fromBranch, "/head")
+		return "", err
+	}
+	defer file.Close(ctx)
+	buf := make([]byte, 512)
+	n, err := file.Read(ctx, buf, 0)
+	if err != nil {
+		log.Println("Failed to Read branch", fromBranch, "head", err)
+		return "", err
+	}
+	return strings.TrimSpace(string(buf[0:n])), nil
+}
+
+func (s *Snapshot) getFullPath(path []string) []string {
+	var p []string
+
+	switch s.kind {
+	case COMMIT:
+		p = []string{"snapshots", s.thing, "ro"}
+	case OBJECT:
+		p = []string{"trees", s.thing}
+	}
+
+	for _, element := range path {
+		p = append(p, element)
+	}
+	return p
+}
+
+// Read reads a value from the snapshot
+func (s *Snapshot) Read(ctx context.Context, path []string) (string, error) {
+	p := s.getFullPath(path)
+	file, err := s.client.Open(ctx, p9p.OREAD, p...)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close(ctx)
+	reader := file.NewIOReader(ctx, 0)
+	buf := bytes.NewBuffer(nil)
+	io.Copy(buf, reader)
+	return string(buf.Bytes()), nil
+}
+
+// List returns filenames list in directory
+func (s *Snapshot) List(ctx context.Context, path []string) ([]string, error) {
+	p := s.getFullPath(path)
+	return s.client.List(ctx, p)
+}

--- a/go/vendor/github.com/moby/datakit/api/go-datakit/transaction.go
+++ b/go/vendor/github.com/moby/datakit/api/go-datakit/transaction.go
@@ -1,0 +1,136 @@
+package datakit
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"strconv"
+	"sync/atomic"
+
+	p9p "github.com/docker/go-p9p"
+	"context"
+)
+
+type transaction struct {
+	client     *Client
+	fromBranch string
+	newBranch  string
+}
+
+var nextTransaction = int64(0)
+
+// NewTransaction opens a new transaction originating from fromBranch, named
+// newBranch.
+func NewTransaction(ctx context.Context, client *Client, fromBranch string) (*transaction, error) {
+
+	id := atomic.AddInt64(&nextTransaction, 1)
+	newBranch := strconv.FormatInt(id, 10)
+	err := client.Mkdir(ctx, "branch", fromBranch)
+	if err != nil {
+		log.Println("Failed to Create branch/", fromBranch, err)
+		return nil, err
+	}
+	err = client.Mkdir(ctx, "branch", fromBranch, "transactions", newBranch)
+	if err != nil {
+		log.Println("Failed to Create branch/", fromBranch, "/transactions/", newBranch, err)
+		return nil, err
+	}
+
+	return &transaction{client: client, fromBranch: fromBranch, newBranch: newBranch}, nil
+}
+
+func (t *transaction) close(ctx context.Context) {
+	// TODO: do we need to clear up unmerged branches?
+}
+
+// Abort ensures the update will not be committed.
+func (t *transaction) Abort(ctx context.Context) {
+	t.close(ctx)
+}
+
+// Commit merges the newBranch back into the fromBranch, or fails
+func (t *transaction) Commit(ctx context.Context, msg string) error {
+	// msg
+	msgPath := []string{"branch", t.fromBranch, "transactions", t.newBranch, "msg"}
+	msgFile, err := t.client.Open(ctx, p9p.ORDWR, msgPath...)
+	if err != nil {
+		log.Println("Failed to Open msg", err)
+		return err
+	}
+	defer msgFile.Close(ctx)
+	_, err = msgFile.Write(ctx, []byte(msg), 0)
+	if err != nil {
+		log.Println("Failed to Write msg", err)
+	}
+
+	// ctl
+	ctlPath := []string{"branch", t.fromBranch, "transactions", t.newBranch, "ctl"}
+	ctlFile, err := t.client.Open(ctx, p9p.ORDWR, ctlPath...)
+	if err != nil {
+		log.Println("Failed to Open ctl", err)
+		return err
+	}
+	defer ctlFile.Close(ctx)
+	_, err = ctlFile.Write(ctx, []byte("commit"), 0)
+	if err != nil {
+		log.Println("Failed to Write ctl", err)
+		return err
+	}
+	return nil
+}
+
+// Write updates a key=value pair within the transaction.
+func (t *transaction) Write(ctx context.Context, path []string, value string) error {
+	p := []string{"branch", t.fromBranch, "transactions", t.newBranch, "rw"}
+	for _, dir := range path[0 : len(path)-1] {
+		p = append(p, dir)
+	}
+	err := t.client.Mkdir(ctx, p...)
+	if err != nil {
+		log.Println("Failed to Mkdir", p)
+	}
+	p = append(p, path[len(path)-1])
+	file, err := t.client.Create(ctx, p...)
+	if err != nil {
+		log.Println("Failed to Create", p)
+		return err
+	}
+	defer file.Close(ctx)
+	writer := file.NewIOWriter(ctx, 0)
+	_, err = writer.Write([]byte(value))
+	if err != nil {
+		log.Println("Failed to Write", path, "=", value, ":", err)
+		return err
+	}
+	return nil
+}
+
+// Read reads a key within the transaction.
+func (t *transaction) Read(ctx context.Context, path []string) (string, error) {
+	p := []string{"branch", t.fromBranch, "transactions", t.newBranch, "rw"}
+	for _, dir := range path[0 : len(path)-1] {
+		p = append(p, dir)
+	}
+	file, err := t.client.Open(ctx, p9p.OREAD, p...)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close(ctx)
+	reader := file.NewIOReader(ctx, 0)
+	buf := bytes.NewBuffer(nil)
+	io.Copy(buf, reader)
+	return string(buf.Bytes()), nil
+}
+
+// Remove deletes a key within the transaction.
+func (t *transaction) Remove(ctx context.Context, path []string) error {
+	p := []string{"branch", t.fromBranch, "transactions", t.newBranch, "rw"}
+	for _, dir := range path {
+		p = append(p, dir)
+	}
+	err := t.client.Remove(ctx, p...)
+	if err != nil {
+		log.Println("Failed to Remove ", p)
+	}
+	return nil
+}

--- a/go/vendor/github.com/moby/datakit/api/go-datakit/watch.go
+++ b/go/vendor/github.com/moby/datakit/api/go-datakit/watch.go
@@ -1,0 +1,77 @@
+package datakit
+
+import (
+	"io"
+	"log"
+	"strings"
+
+	p9p "github.com/docker/go-p9p"
+	"context"
+)
+
+type watch struct {
+	client *Client
+	file   *File
+	offset int64 // current offset within head.live file
+}
+
+type Watch struct {
+	watch
+}
+
+// NewWatch starts watching a path within a branch
+func NewWatch(ctx context.Context, client *Client, fromBranch string, path []string) (*Watch, error) {
+	// SHA=$(cat branch/<fromBranch>/watch/<path.node>/tree.live)
+	p := []string{"branch", fromBranch, "watch"}
+	for _, dir := range path {
+		p = append(p, dir+".node")
+	}
+	p = append(p, "tree.live")
+	file, err := client.Open(ctx, p9p.OREAD, p...)
+	if err != nil {
+		log.Println("Failed to open", p, err)
+		return nil, err
+	}
+	offset := int64(0)
+	return &Watch{watch{client: client, file: file, offset: offset}}, nil
+}
+
+func (w *Watch) Next(ctx context.Context) (*Snapshot, error) {
+	buf := make([]byte, 512)
+	sawFlush := false
+	for {
+		// NOTE: irmin9p-direct will never return a fragment;
+		// we can rely on the buffer containing a whold number
+		// of lines.
+		n, err := w.file.Read(ctx, buf, w.offset)
+		if n == 0 {
+			// Two reads of "" in a row means end-of-file
+			if sawFlush {
+				return nil, io.EOF
+			} else {
+				sawFlush = true
+				continue
+			}
+		} else {
+			sawFlush = false
+		}
+		w.offset = w.offset + int64(n)
+		if err != nil {
+			log.Println("Failed to Read head.live", err)
+			return nil, io.EOF
+		}
+		lines := strings.Split(string(buf[0:n]), "\n")
+		// Use the last non-empty line
+		thing := ""
+		for _, line := range lines {
+			if line != "" {
+				thing = line
+			}
+		}
+		return NewSnapshot(ctx, w.client, OBJECT, thing), nil
+	}
+}
+
+func (w *Watch) Close(ctx context.Context) {
+	w.file.Close(ctx)
+}


### PR DESCRIPTION
This should make the `vpnkit` package self-contained. Note none of the types from these libraries are visible in the interface.

Signed-off-by: David Scott <dave.scott@docker.com>