### PR TITLE
Temporarily revert the MTU to 1500

### DIFF
--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -26,7 +26,7 @@ let safe_outgoing_mtu = 1452 (* packets above this size with DNF set will get IC
 
 (* The default MTU is limited by the maximum message size on a Hyper-V socket.
    On currently available windows versions, we need to stay below 8192 bytes *)
-let default_mtu = 8000 (* used for the virtual ethernet link *)
+let default_mtu = 1500 (* used for the virtual ethernet link *)
 
 let log_exception_continue description f =
   Lwt.catch


### PR DESCRIPTION
This reverts 732bdaa734db1f94f0e5e859974dfaa320ad5587 and may prevent https://github.com/djs55/miragetcpip/blob/f5b16043c57f71d5fdf1a7cf7ab7ccdde291cca1/tcp/user_buffer.ml#L164 from raiseing `Invalid_argument` exceptions

Related to #255

Signed-off-by: David Scott <dave.scott@docker.com>