### PR TITLE
test: add cases for half-close

### DIFF
--- a/src/hostnet_test/suite.ml
+++ b/src/hostnet_test/suite.ml
@@ -382,11 +382,13 @@ module Make(Host: Sig.HOST) = struct
   module F = Forwarding.Make(Host)
   module N = Test_nat.Make(Host)
   module H = Test_http.Make(Host)
+  module T = Test_half_close.Make(Host)
 
   let tests =
     Hosts_test.tests @ F.tests @ test_dhcp
     @ (test_dns true) @ (test_dns false)
     @ test_tcp @ N.tests @ H.tests @ Test_http.Exclude.tests
+    @ T.tests
 
   let scalability = [
     "1026conns",

--- a/src/hostnet_test/test_half_close.ml
+++ b/src/hostnet_test/test_half_close.ml
@@ -1,0 +1,185 @@
+open Lwt.Infix
+
+let src =
+  let src = Logs.Src.create "tcp" ~doc:"Test TCP half-close in the proxy" in
+  Logs.Src.set_level src (Some Logs.Debug);
+  src
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+module Make(Host: Sig.HOST) = struct
+
+  module Slirp_stack = Slirp_stack.Make(Host)
+
+  module Server = struct
+    type t = {
+      server: Host.Sockets.Stream.Tcp.server;
+      port: int;
+    }
+    let create on_accept =
+      Host.Sockets.Stream.Tcp.bind (Ipaddr.V4 Ipaddr.V4.localhost, 0)
+      >>= fun server ->
+      let _, port = Host.Sockets.Stream.Tcp.getsockname server in
+      Host.Sockets.Stream.Tcp.listen server on_accept;
+      Lwt.return { server; port }
+    let destroy t =
+      Host.Sockets.Stream.Tcp.shutdown t.server
+  end
+  let with_server on_accept f =
+    Server.create on_accept
+    >>= fun server ->
+    Lwt.finalize (fun () -> f server) (fun () -> Server.destroy server)
+
+  module Outgoing = struct
+    module C = Channel.Make(Slirp_stack.Client.TCPV4)
+  end
+  module Incoming = struct
+    module C = Channel.Make(Host.Sockets.Stream.Tcp)
+  end
+
+  let request = "Hello there"
+  let response = "And hello to you"
+
+  (* Run a simple server on localhost and connect to it via vpnkit.
+     The Mirage client will call `close` to trigger a half-close of the TCP
+     connection before reading the response. This verifies that the other side
+     of the connection remains open. *)
+  let test_mirage_half_close () =
+    Host.Main.run begin
+      let forwarded, forwarded_u = Lwt.task () in
+      Slirp_stack.with_stack
+        (fun _ stack ->
+          with_server
+            (fun flow ->
+              (* Read the request until EOF *)
+              let ic = Incoming.C.create flow in
+              Incoming.C.read_line ic
+              >>= fun bufs ->
+              let txt = Cstruct.(to_string @@ concat bufs) in
+              if txt <> request
+              then failwith (Printf.sprintf "Expected to read '%s', got '%s'" request txt);
+              Incoming.C.read_line ic
+              >>= fun bufs ->
+              assert (Cstruct.(len @@ concat bufs) = 0);
+              Log.info (fun f -> f "Read the request (up to and including EOF)");
+
+              (* Write a response. If the connection is fully closed rather than half-closed
+                 then this will fail. *)
+              Incoming.C.write_line ic response;
+              Incoming.C.flush ic
+              >>= fun () ->
+              Log.info (fun f -> f "Written response");
+              Lwt.wakeup_later forwarded_u ();
+              Lwt.return_unit
+            ) (fun server ->
+              (* Now that the server is running, connect to it and send a
+                 request. *)
+              let open Slirp_stack in
+              let ip = Ipaddr.V4.localhost in
+              let port = server.Server.port in
+              Client.TCPV4.create_connection (Client.tcpv4 stack) (ip, port)
+              >>= function
+              | `Ok flow ->
+                Log.info (fun f -> f "Connected to %s:%d" (Ipaddr.V4.to_string ip) port);
+                let oc = Outgoing.C.create flow in
+                Outgoing.C.write_line oc request;
+                Outgoing.C.flush oc
+                >>= fun () ->
+                (* This will perform a TCP half-close *)
+                Client.TCPV4.close flow
+                >>= fun () ->
+                (* Verify the response is still intact *)
+                Outgoing.C.read_line oc
+                >>= fun bufs ->
+                let txt = Cstruct.(to_string @@ concat bufs) in
+                if txt <> response
+                then failwith (Printf.sprintf "Expected to read '%s', got '%s'" response txt);
+                Log.info (fun f -> f "Read the response. Waiting for cleanup");
+                Lwt.pick [ (Host.Time.sleep 100. >>= fun () -> Lwt.return `Timeout); (forwarded >>= fun x -> Lwt.return (`Result x)) ]
+              | `Error _ ->
+                Log.err (fun f -> f "Failed to connect to %s:%d" (Ipaddr.V4.to_string ip) port);
+                failwith "Client.TCPV4.create_connection"
+            )
+          >>= function
+          | `Timeout ->
+            failwith "TCP half close test timed-out"
+          | `Result x ->
+            Lwt.return x
+        )
+    end
+
+  (* Run a simple server on localhost and connect to it via vpnkit.
+     The server on the host will call `close` to trigger a half-close of the TCP
+     connection before reading the response. This verifies that the other side
+     of the connection remains open. *)
+  let test_host_half_close () =
+    Host.Main.run begin
+      let forwarded, forwarded_u = Lwt.task () in
+      Slirp_stack.with_stack
+        (fun _ stack ->
+          with_server
+            (fun flow ->
+              (* Write a request *)
+              let ic = Incoming.C.create flow in
+              Incoming.C.write_line ic request;
+              Incoming.C.flush ic
+              >>= fun () ->
+              (* This will perform a TCP half-close *)
+              Host.Sockets.Stream.Tcp.shutdown_write flow
+              >>= fun () ->
+              (* Read the response from the other side of the connection *)
+              Incoming.C.read_line ic
+              >>= fun bufs ->
+              let txt = Cstruct.(to_string @@ concat bufs) in
+              if txt <> response
+              then failwith (Printf.sprintf "Expected to read '%s', got '%s'" response txt);
+              Log.info (fun f -> f "Read the response, signalling complete");
+              Lwt.wakeup_later forwarded_u ();
+              Lwt.return_unit
+            ) (fun server ->
+              (* Now that the server is running, connect to it and send a
+                 request. *)
+              let open Slirp_stack in
+              let ip = Ipaddr.V4.localhost in
+              let port = server.Server.port in
+              Client.TCPV4.create_connection (Client.tcpv4 stack) (ip, port)
+              >>= function
+              | `Ok flow ->
+                Log.info (fun f -> f "Connected to %s:%d" (Ipaddr.V4.to_string ip) port);
+                let oc = Outgoing.C.create flow in
+                (* Read the request *)
+                Outgoing.C.read_line oc
+                >>= fun bufs ->
+                let txt = Cstruct.(to_string @@ concat bufs) in
+                if txt <> request
+                then failwith (Printf.sprintf "Expected to read '%s', got '%s'" request txt);
+                (* Check we're at EOF *)
+                Outgoing.C.read_line oc
+                >>= fun bufs ->
+                assert (Cstruct.(len @@ concat bufs) = 0);
+                Log.info (fun f -> f "Read the request (up to and including EOF)");
+                (* Write response *)
+                Outgoing.C.write_line oc response;
+                Outgoing.C.flush oc
+                >>= fun () ->
+                Log.info (fun f -> f "Written response and will wait.");
+                Lwt.pick [ (Host.Time.sleep 100. >>= fun () -> Lwt.return `Timeout); (forwarded >>= fun x -> Lwt.return (`Result x)) ]
+              | `Error _ ->
+                Log.err (fun f -> f "Failed to connect to %s:%d" (Ipaddr.V4.to_string ip) port);
+                failwith "Client.TCPV4.create_connection"
+            )
+          >>= function
+          | `Timeout ->
+            failwith "TCP half close test timed-out"
+          | `Result x ->
+            Lwt.return x
+        )
+    end
+
+  let tests = [
+
+    "TCP: test Mirage half close", [ "check that Mirage half-close isn't a full-close", `Quick, test_mirage_half_close ];
+    "TCP: test Host half close", [ "check that the Host half-close isn't a full-close", `Quick, test_host_half_close ];
+  ]
+
+end


### PR DESCRIPTION
This patch adds 2 simple test cases, where a server is run on localhost and connected to via vpnkit via the Mirage TCP client. Both cases use a simple request / response protocol where the connection is half-closed after the request is written and before the response is written, to check that the response is still relayed correctly.

The `test_mirage_half_close` performs the half-close via the Mirage stack; the `test_host_half_close` performs the half-close via the Host stack.

Signed-off-by: David Scott <dave.scott@docker.com>