### PR TITLE
Remove non-bridge mode

### DIFF
--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -322,7 +322,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
 
     let uri = Uri.of_string socket_url in
 
-    let l2_switch = Vnet.create () in
+    let vnet_switch = Vnet.create () in
 
     match Uri.scheme uri with
     | Some "hyperv-connect" ->
@@ -340,7 +340,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       ) >>= fun stack_config ->
       hvsock_connect_forever socket_url sockaddr (fun fd ->
           let conn = HV.connect fd in
-          Slirp_stack.connect stack_config conn l2_switch >>= fun stack ->
+          Slirp_stack.connect stack_config conn vnet_switch >>= fun stack ->
           Log.info (fun f -> f "stack connected");
           start_introspection introspection_url (Slirp_stack.filesystem stack);
           start_diagnostics diagnostics_url @@ Slirp_stack.diagnostics stack;
@@ -358,7 +358,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       | None -> Lwt.return hardcoded_configuration
       ) >>= fun stack_config ->
       Host.Sockets.Stream.Unix.listen server (fun conn ->
-          Slirp_stack.connect stack_config conn l2_switch >>= fun stack ->
+          Slirp_stack.connect stack_config conn vnet_switch >>= fun stack ->
           Log.info (fun f -> f "stack connected");
           start_introspection introspection_url (Slirp_stack.filesystem stack);
           start_diagnostics diagnostics_url @@ Slirp_stack.diagnostics stack;

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -276,6 +276,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
     in
 
     Mclock.connect () >>= fun clock ->
+    let vnet_switch = Vnet.create () in
 
     let hardcoded_configuration =
       let server_macaddr = Slirp.default_server_macaddr in
@@ -300,6 +301,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
         get_domain_name = (fun () -> "localdomain");
         global_arp_table;
         client_uuids;
+        vnet_switch;
         bridge_connections = true;
         mtu = 1500;
         host_names;
@@ -322,7 +324,6 @@ let hvsock_addr_of_uri ~default_serviceid uri =
 
     let uri = Uri.of_string socket_url in
 
-    let vnet_switch = Vnet.create () in
 
     match Uri.scheme uri with
     | Some "hyperv-connect" ->
@@ -335,12 +336,12 @@ let hvsock_addr_of_uri ~default_serviceid uri =
           (Uri.of_string socket_url)
       in
       ( match config with
-      | Some config -> Slirp_stack.create ~host_names clock config
+      | Some config -> Slirp_stack.create ~host_names clock vnet_switch config
       | None -> Lwt.return hardcoded_configuration
       ) >>= fun stack_config ->
       hvsock_connect_forever socket_url sockaddr (fun fd ->
           let conn = HV.connect fd in
-          Slirp_stack.connect stack_config conn vnet_switch >>= fun stack ->
+          Slirp_stack.connect stack_config conn >>= fun stack ->
           Log.info (fun f -> f "stack connected");
           start_introspection introspection_url (Slirp_stack.filesystem stack);
           start_diagnostics diagnostics_url @@ Slirp_stack.diagnostics stack;
@@ -354,11 +355,11 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       in
       unix_listen socket_url >>= fun server ->
       ( match config with
-      | Some config -> Slirp_stack.create ~host_names clock config
+      | Some config -> Slirp_stack.create ~host_names clock vnet_switch config
       | None -> Lwt.return hardcoded_configuration
       ) >>= fun stack_config ->
       Host.Sockets.Stream.Unix.listen server (fun conn ->
-          Slirp_stack.connect stack_config conn vnet_switch >>= fun stack ->
+          Slirp_stack.connect stack_config conn >>= fun stack ->
           Log.info (fun f -> f "stack connected");
           start_introspection introspection_url (Slirp_stack.filesystem stack);
           start_diagnostics diagnostics_url @@ Slirp_stack.diagnostics stack;

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -302,7 +302,6 @@ let hvsock_addr_of_uri ~default_serviceid uri =
         global_arp_table;
         client_uuids;
         vnet_switch;
-        bridge_connections = true;
         mtu = 1500;
         host_names;
         clock }

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -1370,7 +1370,7 @@ struct
     } in
     Lwt.return t
 
-  let client_macaddr_of_uuid t (uuid:Uuidm.t) =
+  let client_connect_by_uuid t (uuid:Uuidm.t) =
     Lwt_mutex.with_lock t.client_uuids.mutex (fun () ->
         if (Hashtbl.mem t.client_uuids.table uuid) then begin
           (* uuid already used, get config *)
@@ -1472,7 +1472,7 @@ struct
       if t.bridge_connections then begin
         or_failwith "vmnet" @@
         Vmnet.of_fd
-          ~client_macaddr_of_uuid:(client_macaddr_of_uuid t)
+          ~client_macaddr_of_uuid:(client_connect_by_uuid t)
           ~server_macaddr:t.server_macaddr ~mtu:t.mtu client
         >>= fun x ->
         let client_macaddr = Vmnet.get_client_macaddr x in

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -15,7 +15,6 @@ let default_highest_ip = Ipaddr.V4.of_string_exn "192.168.65.254"
 
 (* random MAC from https://www.hellion.org.uk/cgi-bin/randmac.pl *)
 let default_server_macaddr = Macaddr.of_string_exn "F6:16:36:BC:F9:C6"
-let default_client_macaddr = Macaddr.of_string_exn "C0:FF:EE:C0:FF:EE"
 let default_dns_extra = []
 let default_uuid_preferred_ip_prefix = Bytes.make 12 '\000'
 

--- a/src/hostnet/slirp.mli
+++ b/src/hostnet/slirp.mli
@@ -28,7 +28,6 @@ type ('clock, 'vnet_switch) config = {
   global_arp_table: arp_table;
   client_uuids: uuid_table;
   vnet_switch: 'vnet_switch;
-  bridge_connections: bool;
   mtu: int;
   host_names: Dns.Name.t list;
   clock: 'clock;

--- a/src/hostnet/slirp.mli
+++ b/src/hostnet/slirp.mli
@@ -85,4 +85,3 @@ end
 val print_pcap: pcap -> string
 
 val default_server_macaddr: Macaddr.t
-val default_client_macaddr: Macaddr.t

--- a/src/hostnet/slirp.mli
+++ b/src/hostnet/slirp.mli
@@ -17,7 +17,7 @@ type uuid_table = {
 (** A slirp TCP/IP stack ready to accept connections *)
 
 
-type 'clock config = {
+type ('clock, 'vnet_switch) config = {
   server_macaddr: Macaddr.t;
   peer_ip: Ipaddr.V4.t;
   local_ip: Ipaddr.V4.t;
@@ -27,6 +27,7 @@ type 'clock config = {
   get_domain_name: unit -> string;
   global_arp_table: arp_table;
   client_uuids: uuid_table;
+  vnet_switch: 'vnet_switch;
   bridge_connections: bool;
   mtu: int;
   host_names: Dns.Name.t list;
@@ -45,13 +46,13 @@ module Make
     (Vnet : Vnetif.BACKEND with type macaddr = Macaddr.t) :
 sig
 
-  val create: ?host_names:Dns.Name.t list -> Clock.t -> Config.t ->
-    Clock.t config Lwt.t
+  val create: ?host_names:Dns.Name.t list -> Clock.t -> Vnet.t -> Config.t ->
+    (Clock.t, Vnet.t) config Lwt.t
   (** Initialise a TCP/IP stack, taking configuration from the Config.t *)
 
   type t
 
-  val connect: Clock.t config -> Vmnet.fd -> Vnet.t -> t Lwt.t
+  val connect: (Clock.t, Vnet.t) config -> Vmnet.fd -> t Lwt.t
   (** Read and write ethernet frames on the given fd, connected to the
       specified Vnetif backend *)
 

--- a/src/hostnet/vmnet.ml
+++ b/src/hostnet/vmnet.ml
@@ -340,8 +340,8 @@ module Make(C: Sig.CONN) = struct
     client_negotiate ~uuid ~fd:channel
     >>= fun vif ->
     let t =
-      make ~client_macaddr:vif.Vif.client_macaddr
-        ~server_macaddr:server_macaddr ~mtu:vif.Vif.mtu ~client_uuid:uuid
+      make ~client_macaddr:server_macaddr
+        ~server_macaddr:vif.Vif.client_macaddr ~mtu:vif.Vif.mtu ~client_uuid:uuid
         ~log_prefix:client_log_prefix
         channel in
     Lwt_result.return t

--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -140,7 +140,6 @@ let config_without_bridge =
     get_domain_name = (fun () -> "local");
     client_uuids;
     vnet_switch = Vnet.create ();
-    bridge_connections = false;
     global_arp_table;
     mtu = 1500;
     host_names = [];

--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -159,12 +159,12 @@ let set_slirp_stack c =
   slirp_stack := Some c;
   Lwt_condition.signal slirp_stack_c ()
 
-let start_stack l2_switch config () =
+let start_stack vnet_switch config () =
   Host.Sockets.Stream.Tcp.bind (Ipaddr.V4 Ipaddr.V4.localhost, 0)
   >|= fun server ->
   let _, port = Host.Sockets.Stream.Tcp.getsockname server in
   Host.Sockets.Stream.Tcp.listen server (fun flow ->
-      Slirp_stack.connect config flow l2_switch >>= fun stack ->
+      Slirp_stack.connect config flow vnet_switch >>= fun stack ->
       set_slirp_stack stack;
       Log.info (fun f -> f "stack connected");
       Slirp_stack.after_disconnect stack >|= fun () ->

--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -128,7 +128,7 @@ let client_uuids : Slirp.uuid_table =
     table = Hashtbl.create 50;
   }
 
-let config_without_bridge =
+let config =
   Mclock.connect () >|= fun clock ->
   {
     Slirp.peer_ip;
@@ -173,7 +173,7 @@ let start_stack config () =
   port
 
 let connection =
-  config_without_bridge >>= fun config ->
+  config >>= fun config ->
   start_stack config ()
 
 let with_stack f =
@@ -183,13 +183,13 @@ let with_stack f =
   | Error (`Msg x) -> failwith x
   | Ok flow ->
     Log.info (fun f -> f "Made a loopback connection");
-    let client_macaddr = Slirp.default_client_macaddr in
+    let server_macaddr = Slirp.default_server_macaddr in
     let uuid =
       match Uuidm.of_string "d1d9cd61-d0dc-4715-9bb3-4c11da7ad7a5" with
       | Some x -> x
       | None -> failwith "unable to parse test uuid"
     in
-    VMNET.client_of_fd ~uuid ~server_macaddr:client_macaddr flow
+    VMNET.client_of_fd ~uuid ~server_macaddr:server_macaddr flow
     >>= function
     | Error (`Msg x ) ->
       (* Server will close when it gets EOF *)


### PR DESCRIPTION
The virtual bridge support in vpnkit has been enabled by default in Docker for Mac for several edge releases and 17.06 stable without any reported issues. This PR removes the old code that could still be enabled with a database key.

Changes:
- Remove non-bridge mode everywhere and move the vnet switch to the config, so we don't have to pass it around
- Rename l2_switch and other l2_* variables to vnet_* to make it clearer that they relate to the virtual network
- Fix tests to use a dynamic mac and run them on the new bridge (bridge mode was disabled for tests)