### PR TITLE
Add a Endpoint.destroy which closes active connections

### DIFF
--- a/src/hostnet/hostnet_dns.ml
+++ b/src/hostnet/hostnet_dns.ml
@@ -356,7 +356,7 @@ struct
     | Ok buffer ->
       Udp.write ~src_port:53 ~dst:src ~dst_port:src_port udp buffer
 
-  let handle_tcp ~t =
+  let handle_tcp ~t ~close =
     (* FIXME: need to record the upstream request *)
     let listeners _ =
       Log.debug (fun f -> f "DNS TCP handshake complete");
@@ -384,7 +384,10 @@ struct
             Lwt.async queries;
             loop ()
         in
-        loop ()
+        Lwt.pick [
+          loop ();
+          close
+        ]
       in
       Some f
     in

--- a/src/hostnet/hostnet_dns.mli
+++ b/src/hostnet/hostnet_dns.mli
@@ -40,7 +40,7 @@ sig
     t:t -> udp:Udp.t -> src:Ipaddr.V4.t -> dst:Ipaddr.V4.t -> src_port:int ->
     Cstruct.t -> (unit, Udp.error) result Lwt.t
 
-  val handle_tcp: t:t -> (int -> (Tcp.flow -> unit Lwt.t) option) Lwt.t
+  val handle_tcp: t:t -> close:(unit Lwt.t) -> (int -> (Tcp.flow -> unit Lwt.t) option) Lwt.t
 
   val destroy: t -> unit Lwt.t
 end


### PR DESCRIPTION
Previously there was no way to locate the connections associated with
an endpoint to shut them down. This patch adds a map of TCP `id` to
`unit Lwt.u` and a function `Endpoint.destroy` which triggers the
disconnection of all the active connections.

Related to #260

Signed-off-by: David Scott <dave.scott@docker.com>