### PR TITLE
Add support for ICMP echo request forwarding

### DIFF
--- a/src/hostnet/frame.mli
+++ b/src/hostnet/frame.mli
@@ -1,7 +1,8 @@
 type t =
   | Ethernet: { src: Macaddr.t; dst: Macaddr.t; payload: t } -> t
   | Arp:      { op: [ `Request | `Reply | `Unknown ] } -> t
-  | Icmp:     { raw: Cstruct.t; payload: t } -> t
+  | Icmp:     { ty: int; code: int; seq: int; id: int;
+                raw: Cstruct.t; payload: t } -> t
   | Ipv4:     { src: Ipaddr.V4.t; dst: Ipaddr.V4.t; dnf: bool; ihl: int;
                 raw: Cstruct.t; payload: t } -> t
   | Udp:      { src: int; dst: int; len: int; payload: t } -> t

--- a/src/hostnet/hostnet_icmp.ml
+++ b/src/hostnet/hostnet_icmp.ml
@@ -1,0 +1,223 @@
+open Lwt.Infix
+
+let src =
+  let src = Logs.Src.create "ICMP" ~doc:"ICMP NAT implementation" in
+  Logs.Src.set_level src (Some Logs.Info);
+  src
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+type reply = Cstruct.t -> unit Lwt.t
+
+type address = Ipaddr.V4.t
+
+type datagram = {
+  src: address;
+  dst: address;
+  ty: int;
+  code: int;
+  seq: int;
+  id: int;
+  payload: Cstruct.t;
+}
+
+module Make
+    (Sockets: Sig.SOCKETS)
+    (Clock: Mirage_clock_lwt.MCLOCK)
+    (Time: Mirage_time_lwt.S)
+= struct
+
+  module Icmp = Sockets.Datagram.Udp
+
+  type key = Ipaddr.V4.t * int (* IP * ICMP ty *)
+
+  (* An active ICMP "flow" *)
+  type flow = {
+    description: string;
+    phys: key;
+    virt: key;
+    mutable last_use: int64;
+  }
+
+  module IntSet = Set.Make(struct type t = int let compare = compare end)
+
+  type t = {
+    clock: Clock.t;
+    server: Icmp.server;
+    phys_to_flow: (key, flow) Hashtbl.t;
+    virt_to_flow: (key, flow) Hashtbl.t;
+    ids_in_use: IntSet.t ref;
+    mutable next_id: int;
+    mutable send_reply: (src:address -> dst:address -> payload:Cstruct.t -> unit Lwt.t) option;
+  }
+
+  let start_background_gc clock phys_to_flow virt_to_flow ids_in_use max_idle_time =
+    let rec loop () =
+      Time.sleep_ns max_idle_time >>= fun () ->
+      let now_ns = Clock.elapsed_ns clock in
+      let to_shutdown =
+        Hashtbl.fold (fun phys flow acc ->
+            if Int64.(sub now_ns flow.last_use) > max_idle_time then begin
+              Log.info (fun f ->
+                  f "Hostnet_icmp %s: expiring ICMP NAT rule" flow.description);
+              (phys, flow) :: acc
+            end else acc
+          ) phys_to_flow []
+      in
+      List.iter (fun (phys, flow) ->
+        ids_in_use := IntSet.remove (snd flow.phys) !ids_in_use;
+        Hashtbl.remove phys_to_flow phys;
+        Hashtbl.remove virt_to_flow flow.virt;
+      ) to_shutdown;
+      loop () in
+    loop ()
+
+  (* Allocate a free physical id for a new "flow" *)
+  let allocate_next_id t =
+    let start = t.next_id in
+    let in_use = !(t.ids_in_use) in
+    let rec find from =
+      if not(IntSet.mem from in_use) then begin
+        t.ids_in_use := IntSet.add from in_use;
+        t.next_id <- from;
+        Some from
+      end else begin
+        let next = (from + 1) mod 0xffff in
+        if next = start
+        then None (* all are in use, we'll have to drop the packet *)
+        else find next
+      end in
+    find start
+
+  let is_win32 = Sys.os_type = "Win32"
+
+  let sock_icmp =
+    (* Windows uses SOCK_RAW protocol 1 for ICMP
+      Unix uses SOCK_DGRAM protocol 1 for ICMP *)
+    if is_win32 then Unix.SOCK_RAW else Unix.SOCK_DGRAM
+
+  let ipproto_icmp = 1 (* according to BSD /etc/protocols *)
+  let _port = 0 (* port isn't meaningful in this context *)
+
+  let create ?(max_idle_time = Duration.(of_sec 60)) clock =
+    let phys_to_flow = Hashtbl.create 7 in
+    let virt_to_flow = Hashtbl.create 7 in
+    let fd = Unix.socket Unix.PF_INET sock_icmp ipproto_icmp in
+    let server = Icmp.of_bound_fd fd in
+    let ids_in_use = ref IntSet.empty in
+    let next_id = 0 in
+    let send_reply = None in
+    let _background_gc_t = start_background_gc clock phys_to_flow virt_to_flow ids_in_use max_idle_time in
+    { clock; server; phys_to_flow; virt_to_flow; ids_in_use; next_id; send_reply }
+
+  let start_receiver t =
+    let buf = Cstruct.create 4096 in
+    let rec loop () =
+      Lwt.catch (fun () ->
+        Icmp.recvfrom t.server buf
+        >>= fun (n, _) ->
+        let datagram = Cstruct.sub buf 0 n in
+        (* On macOS the IP length field is set to a very large value (16384) which
+           probably reflects some kernel datastructure size rather than the real
+           on-the-wire size. This confuses our IPv4 parser so we correct the size
+           here. *)
+        let len = Ipv4_wire.get_ipv4_len datagram in
+        Ipv4_wire.set_ipv4_len datagram (min len n);
+        match Ipv4_packet.Unmarshal.of_cstruct buf with
+        | Error msg ->
+          Log.err (fun f -> f "Error unmarshalling IP datagram: %s" msg);
+          Lwt.return_true
+        | Ok (ipv4, ip_payload) ->
+          match Icmpv4_packet.Unmarshal.of_cstruct ip_payload with
+          | Error msg ->
+            Log.err (fun f -> f "Error unmarshalling ICMP message: %s" msg);
+            Lwt.return_true
+          | Ok (icmp, icmp_payload) ->
+            let open Icmpv4_packet in
+            begin match icmp.subheader with
+            | Next_hop_mtu _ | Pointer _ | Address _ | Unused ->
+              Log.debug (fun f ->
+                f "received an ICMP message which wasn't an echo-request or reply: %a" Cstruct.hexdump_pp buf);
+              Lwt.return true
+            | Id_and_seq (id, seq) ->
+              let ty = Icmpv4_wire.ty_to_int icmp.Icmpv4_packet.ty in
+              let phys = ipv4.Ipv4_packet.src, id in
+              if Hashtbl.mem t.phys_to_flow phys then begin
+                let flow = Hashtbl.find t.phys_to_flow phys in
+                let id' = snd flow.virt in
+                let icmp' = { icmp with subheader = Id_and_seq(id', seq) } in
+                let header = Marshal.make_cstruct icmp' ~payload:icmp_payload in
+                let payload = Cstruct.concat [ header; icmp_payload ] in
+                Log.debug (fun f ->
+                  f "ICMP sending %a -> %a ty=%d code=%d id=%d seq=%d payload len %d"
+                    Ipaddr.V4.pp_hum ipv4.Ipv4_packet.src Ipaddr.V4.pp_hum ipv4.Ipv4_packet.dst
+                    ty icmp.Icmpv4_packet.code id seq
+                    (Cstruct.len icmp_payload));
+                match t.send_reply with
+                | Some fn ->
+                  fn ~src:ipv4.Ipv4_packet.src ~dst:(fst flow.virt) ~payload
+                  >>= fun () ->
+                  Lwt.return true
+                | None ->
+                  Log.warn (fun f -> f "dropping ICMP because reply callback not set");
+                  Lwt.return true
+              end else begin
+                (* This happens when the host receives other ICMP which we're not listening for *)
+                Log.info (fun f ->
+                  f "ICMP dropping %a -> %a ty=%d code=%d id=%d seq=%d %a"
+                    Ipaddr.V4.pp_hum ipv4.Ipv4_packet.src Ipaddr.V4.pp_hum ipv4.Ipv4_packet.dst
+                    ty icmp.Icmpv4_packet.code id seq
+                    Cstruct.hexdump_pp icmp_payload);
+                Lwt.return true
+              end
+            end
+      ) (fun e ->
+        Log.err (fun f ->
+            f "Hostnet_icmp: caught unexpected exception %a"
+              Fmt.exn e);
+        Lwt.return false
+      ) >>= function
+      | false ->
+        Lwt.return_unit
+      | true -> loop () in
+    Lwt.async loop
+
+  let set_send_reply ~t ~send_reply =
+    t.send_reply <- Some send_reply;
+    start_receiver t
+
+  let input ~t ~datagram:{src; dst; ty; code; id; seq; payload} () =
+    Log.debug (fun f ->
+      f "ICMP received %a -> %a ty=%d code=%d id=%d seq=%d payload len %d"
+        Ipaddr.V4.pp_hum src Ipaddr.V4.pp_hum dst
+        ty code id seq (Cstruct.len payload));
+    match Icmpv4_wire.int_to_ty ty with
+      | None ->
+        Log.err (fun f -> f "Unknown ICMP type: %d" ty);
+        Lwt.return_unit
+      | Some ty ->
+        let virt = src, id in
+        let id =
+          if Hashtbl.mem t.virt_to_flow virt then begin
+            let flow = Hashtbl.find t.virt_to_flow virt in
+            Some (snd flow.phys)
+          end else allocate_next_id t in
+        begin match id with
+          | None ->
+            Log.warn (fun f -> f "Dropping ICMP because we've run out of external ids");
+            Lwt.return_unit
+          | Some id' ->
+            let phys = dst, id' in
+            let description = Printf.sprintf "%s id=%d -> %s id=%d"
+              (Ipaddr.V4.to_string @@ fst virt) (snd virt) (Ipaddr.V4.to_string @@ fst phys) (snd phys) in
+            let last_use = Clock.elapsed_ns t.clock in
+            let flow = { description; virt; phys; last_use } in
+            Hashtbl.replace t.phys_to_flow phys flow;
+            Hashtbl.replace t.virt_to_flow virt flow;
+            let req = Icmpv4_packet.({code; ty;
+                                      subheader = Id_and_seq (id', seq)}) in
+            let header = Icmpv4_packet.Marshal.make_cstruct req ~payload in
+            let icmp = Cstruct.concat [ header; payload ] in
+            Icmp.sendto t.server (Ipaddr.V4 dst, 0) icmp
+        end
+end

--- a/src/hostnet/hostnet_icmp.mli
+++ b/src/hostnet/hostnet_icmp.mli
@@ -1,0 +1,41 @@
+(** A simple ICMP NAT implementation.
+
+*)
+
+type address = Ipaddr.V4.t
+
+type datagram = {
+  src: address;
+  dst: address;
+  ty: int;
+  code: int;
+  seq: int;
+  id: int;
+  payload: Cstruct.t;
+}
+(** An ICMP datagram *)
+
+type reply = Cstruct.t -> unit Lwt.t
+
+module Make
+    (Sockets: Sig.SOCKETS)
+    (Clock: Mirage_clock_lwt.MCLOCK)
+    (Time: Mirage_time_lwt.S)
+: sig
+
+  type t
+  (** An ICMP NAT implementation *)
+
+  val create: ?max_idle_time:int64 -> Clock.t -> t
+  (** Create an ICMP NAT implementation which will keep "NAT rules" alive until
+      they become idle for the given [?max_idle_time] *)
+
+  val set_send_reply: t:t -> send_reply:(src:address -> dst:address -> payload:Cstruct.t -> unit Lwt.t) -> unit
+  (** Register a reply callback which will be used to send datagrams to the
+      NAT client. *)
+
+  val input: t:t -> datagram:datagram -> unit -> unit Lwt.t
+  (** Process an incoming datagram, forwarding it over the Sockets implementation
+      and set up a listening rule to catch replies. *)
+
+end

--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -86,6 +86,11 @@ module Client = struct
     | `Error _ -> Fmt.kstrf failwith "Failed to connect %s device" name
     | `Ok x    -> Lwt.return x
 
+  type stack = {
+    t: t;
+    icmpv4: Icmpv41.t;
+  }
+
   let connect (interface: VMNET.t) =
     Ethif1.connect interface >>= fun ethif ->
     Mclock.connect () >>= fun clock ->
@@ -100,8 +105,8 @@ module Client = struct
       interface;
     } in
     connect cfg ethif arp ipv4 icmpv4 udp4 tcp4
-    >>= fun stack ->
-    Lwt.return stack
+    >>= fun t ->
+    Lwt.return { t; icmpv4 }
 end
 
 module DNS = Dns_resolver_mirage.Make(Host.Time)(Client)

--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -75,7 +75,27 @@ module Client = struct
 
   module Dhcp_client_mirage1 = Dhcp_client_mirage.Make(Host.Time)(Netif)
   module Ipv41 = Dhcp_ipv4.Make(Dhcp_client_mirage1)(Ethif1)(Arpv41)
-  module Icmpv41 = Icmpv4.Make(Ipv41)
+  module Icmpv41 = struct
+    include Icmpv4.Make(Ipv41)
+    let packets = Queue.create ()
+    let input _ ~src ~dst buf =
+      match Icmpv4_packet.Unmarshal.of_cstruct buf with
+      | Error msg ->
+        Log.err (fun f -> f "Error unmarshalling ICMP message: %s" msg);
+        Lwt.return_unit
+      | Ok (reply, _) ->
+        let open Icmpv4_packet in
+        begin match reply.subheader with
+          | Next_hop_mtu _ | Pointer _ | Address _ | Unused ->
+            Log.err (fun f -> f "received an ICMP message which wasn't an echo-request or reply");
+            Lwt.return_unit
+          | Id_and_seq (id, _) ->
+            Log.info (fun f ->
+              f "ICMP src:%a dst:%a id:%d" Ipaddr.V4.pp_hum src Ipaddr.V4.pp_hum dst id);
+              Queue.push (src, dst, id) packets;
+              Lwt.return_unit
+        end
+  end
   module Udp1 = Udp.Make(Ipv41)(Stdlibrandom)
   module Tcp1 = Tcp.Flow.Make(Ipv41)(Host.Time)(Mclock)(Stdlibrandom)
   include Tcpip_stack_direct.Make(Host.Time)

--- a/src/hostnet_test/suite.ml
+++ b/src/hostnet_test/suite.ml
@@ -385,7 +385,7 @@ let tests =
   Hosts_test.tests @ Forwarding.tests @ test_dhcp
   @ (test_dns true) @ (test_dns false)
   @ test_tcp @ Test_nat.tests @ Test_http.tests @ Test_http.Exclude.tests
-  @ Test_half_close.tests
+  @ Test_half_close.tests @ Test_ping.tests
 
 let scalability = [
   "1026conns",

--- a/src/hostnet_test/test_half_close.ml
+++ b/src/hostnet_test/test_half_close.ml
@@ -84,7 +84,7 @@ let test_mirage_half_close () =
         let open Slirp_stack in
         let ip = Ipaddr.V4.localhost in
         let port = server.Server.port in
-        Client.TCPV4.create_connection (Client.tcpv4 stack) (ip, port)
+        Client.TCPV4.create_connection (Client.tcpv4 stack.t) (ip, port)
         >|= flow ip port >>= fun flow ->
         Log.info (fun f -> f "Connected to %a:%d" Ipaddr.V4.pp_hum ip port);
         let oc = Outgoing.C.create flow in
@@ -140,7 +140,7 @@ let test_host_half_close () =
         let open Slirp_stack in
         let ip = Ipaddr.V4.localhost in
         let port = server.Server.port in
-        Client.TCPV4.create_connection (Client.tcpv4 stack) (ip, port)
+        Client.TCPV4.create_connection (Client.tcpv4 stack.t) (ip, port)
         >|= flow ip port >>= fun flow ->
         Log.info (fun f -> f "Connected to %a:%d" Ipaddr.V4.pp_hum ip port);
         let oc = Outgoing.C.create flow in

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -141,7 +141,7 @@ let intercept request =
           >>= function
           | Error (`Msg m) -> failwith ("Failed to enable HTTP proxy: " ^ m)
           | Ok () ->
-            send_http_request stack (Ipaddr.V4.of_string_exn "127.0.0.1")
+            send_http_request stack.t (Ipaddr.V4.of_string_exn "127.0.0.1")
               request
             >>= fun () ->
             Lwt.pick [
@@ -289,7 +289,7 @@ let test_http_connect () =
             | Error (`Msg m) -> failwith ("Failed to enable HTTP proxy: " ^ m)
             | Ok () ->
               let open Slirp_stack in
-              Client.TCPV4.create_connection (Client.tcpv4 stack)
+              Client.TCPV4.create_connection (Client.tcpv4 stack.t)
                 (test_dst_ip, 443)
               >>= function
               | Error _ ->

--- a/src/hostnet_test/test_nat.ml
+++ b/src/hostnet_test/test_nat.ml
@@ -110,9 +110,9 @@ let test_udp () =
           let buffer = Cstruct.create 1024 in
           (* Send '1' *)
           Cstruct.set_uint8 buffer 0 1;
-          let udpv4 = Client.udpv4 stack in
+          let udpv4 = Client.udpv4 stack.t in
           let virtual_port = 1024 in
-          let server = UdpServer.make stack virtual_port in
+          let server = UdpServer.make stack.t virtual_port in
           let rec loop remaining =
             if remaining = 0 then
               failwith "Timed-out before UDP response arrived";
@@ -144,11 +144,11 @@ let test_udp_2 () =
           let buffer = Cstruct.create 1024 in
           (* Send '1' *)
           Cstruct.set_uint8 buffer 0 1;
-          let udpv4 = Client.udpv4 stack in
+          let udpv4 = Client.udpv4 stack.t in
 
           (* Listen on one virtual source port and count received packets *)
           let virtual_port1 = 1024 in
-          let server1 = UdpServer.make stack virtual_port1 in
+          let server1 = UdpServer.make stack.t virtual_port1 in
 
           let rec loop remaining =
             if remaining = 0 then
@@ -173,7 +173,7 @@ let test_udp_2 () =
           (* Send '2' *)
           Cstruct.set_uint8 buffer 0 2;
           let virtual_port2 = 1025 in
-          let server2 = UdpServer.make stack virtual_port2 in
+          let server2 = UdpServer.make stack.t virtual_port2 in
           let rec loop remaining =
             if remaining = 0 then
               failwith "Timed-out before UDP response arrived";
@@ -208,11 +208,11 @@ let test_nat_punch () =
           let buffer = Cstruct.create 1024 in
           (* Send '1' *)
           Cstruct.set_uint8 buffer 0 1;
-          let udpv4 = Client.udpv4 stack in
+          let udpv4 = Client.udpv4 stack.t in
 
           (* Listen on one virtual source port and count received packets *)
           let virtual_port1 = 1024 in
-          let server1 = UdpServer.make stack virtual_port1 in
+          let server1 = UdpServer.make stack.t virtual_port1 in
 
           let rec loop remaining =
             if remaining = 0 then
@@ -269,9 +269,9 @@ let test_shared_nat_rule () =
           let buffer = Cstruct.create 1024 in
           (* Send '1' *)
           Cstruct.set_uint8 buffer 0 1;
-          let udpv4 = Client.udpv4 stack in
+          let udpv4 = Client.udpv4 stack.t in
           let virtual_port = 1024 in
-          let server = UdpServer.make stack virtual_port in
+          let server = UdpServer.make stack.t virtual_port in
           let init_table_size =
             Slirp_stack.Debug.get_nat_table_size slirp_server
           in
@@ -335,10 +335,10 @@ let test_source_ports () =
            (fun { EchoServer.local_port = local_port2; _ } ->
               with_stack (fun _ stack ->
                   let buffer = Cstruct.create 1024 in
-                  let udpv4 = Client.udpv4 stack in
+                  let udpv4 = Client.udpv4 stack.t in
                   (* This is the port we shall send from *)
                   let virtual_port = 1024 in
-                  let server = UdpServer.make stack virtual_port in
+                  let server = UdpServer.make stack.t virtual_port in
                   let rec loop remaining =
                     Printf.fprintf stderr "remaining=%d\n%!" remaining;
                     if remaining = 0 then

--- a/src/hostnet_test/test_ping.ml
+++ b/src/hostnet_test/test_ping.ml
@@ -1,0 +1,102 @@
+open Lwt.Infix
+
+let src =
+  let src = Logs.Src.create "tcp" ~doc:"Test ICMP ping" in
+  Logs.Src.set_level src (Some Logs.Debug);
+  src
+
+let failf fmt = Fmt.kstrf failwith fmt
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+let google_1 = Ipaddr.V4.of_string_exn "8.8.8.8"
+let google_2 = Ipaddr.V4.of_string_exn "8.8.4.4"
+
+let make_ping ~id ~seq ~len =
+  let payload = Cstruct.create len in
+  let pattern = "plz reply i'm so lonely" in
+  for i = 0 to Cstruct.len payload - 1 do
+    Cstruct.set_char payload i pattern.[i mod (String.length pattern)]
+  done;
+  let req = Icmpv4_packet.({code = 0x00; ty = Icmpv4_wire.Echo_request;
+                            subheader = Id_and_seq (id, seq)}) in
+  let header = Icmpv4_packet.Marshal.make_cstruct req ~payload in
+  Cstruct.concat [ header; payload ]
+
+let test_ping () =
+  let id = 0x1234 in
+  Queue.clear Slirp_stack.Client.Icmpv41.packets;
+  Host.Main.run begin
+    Slirp_stack.with_stack (fun _ stack ->
+      let rec loop seq =
+        if Queue.length Slirp_stack.Client.Icmpv41.packets > 0
+        then Lwt.return_unit
+        else begin
+          let ping = make_ping ~id ~seq ~len:0 in
+          Printf.printf "sending ping\n%!";
+          Slirp_stack.Client.Icmpv41.write stack.Slirp_stack.Client.icmpv4 ~dst:google_1 ping
+          >>= function
+          | Error e -> failf "Icmpv41.write failed: %a" Slirp_stack.Client.Icmpv41.pp_error e
+          | Ok () ->
+            Host.Time.sleep_ns (Duration.of_sec 1)
+            >>= fun () ->
+            loop (seq + 1)
+        end in
+      loop 0
+    )
+  end
+
+let test_two_pings () =
+  Queue.clear Slirp_stack.Client.Icmpv41.packets;
+  Host.Main.run begin
+    Slirp_stack.with_stack (fun _ stack ->
+      let rec loop seq =
+        let id_1 = 0x1234 in
+        let id_2 = 0x4321 in
+        let ping_1 = make_ping ~id:id_1 ~seq ~len:0 in
+        let ping_2 = make_ping ~id:id_2 ~seq ~len:128 in
+
+        Printf.printf "sending ping\n%!";
+        Slirp_stack.Client.Icmpv41.write stack.Slirp_stack.Client.icmpv4 ~dst:google_1 ping_1
+        >>= function
+        | Error e -> failf "Icmpv41.write failed: %a" Slirp_stack.Client.Icmpv41.pp_error e
+        | Ok () ->
+          Slirp_stack.Client.Icmpv41.write stack.Slirp_stack.Client.icmpv4 ~dst:google_2 ping_2
+          >>= function
+          | Error e -> failf "Icmpv41.write failed: %a" Slirp_stack.Client.Icmpv41.pp_error e
+          | Ok () ->
+            Host.Time.sleep_ns (Duration.of_sec 1)
+            >>= fun () ->
+            if Queue.length Slirp_stack.Client.Icmpv41.packets > 0 then begin
+              let all = Queue.fold (fun xs x -> x :: xs) [] Slirp_stack.Client.Icmpv41.packets in
+              let one, two = List.partition (fun (_, _, id) -> id = id_1) all in
+              let src_one = List.map (fun (src, _, _) -> src) one in
+              let src_two = List.map (fun (src, _, _) -> src) two in
+              let one_from_1, one_from_2 = List.partition (fun src -> Ipaddr.V4.compare google_1 src = 0) src_one in
+              let two_from_1, two_from_2 = List.partition (fun src -> Ipaddr.V4.compare google_1 src = 0) src_two in
+              (* all id_2 (two) should have come from google_2 *)
+              (* all id_1 (one) should have come from google_1 *)
+              if two_from_1 <> [] || one_from_2 <> []
+              then failf "Received pings from the wrong IP addresses"
+              else
+                if one_from_1 <> [] && two_from_2 <> [] then begin
+                  Printf.printf "Received %d pings from google_1 and %d from google_2\n%!"
+                    (List.length one_from_1) (List.length two_from_2);
+                  Lwt.return_unit
+                end else loop (seq + 1)
+            end else loop (seq + 1) in
+      loop 0
+    )
+  end
+
+let tests = [
+  "ICMP: ping 8.8.8.8", [
+    "check that we can ping google's DNS", `Quick,
+    test_ping
+  ] ;
+
+  "ICMP: two pings", [
+    "check that two processes can send pings without the responses getting confused", `Quick,
+    test_two_pings
+  ];
+]


### PR DESCRIPTION
This PR adds NAT-like support for ICMP echo requests and responses.

When requests arrive, they are forwarded via use-space sockets with distinct ids, and then the ids are used to route the responses back to the correct sender.