### PR TITLE
Update CHANGES for a v0.1.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,6 @@
+### v0.1.0 (2017-08-17)
+
+* use Mirage 3 interfaces
+* add support for ICMP ECHO_REQUESTS
+* add support for transparent HTTP/HTTPS proxying
+

--- a/Makefile
+++ b/Makefile
@@ -69,3 +69,16 @@ clean:
 	rm -f vpnkit.exe
 	rm -f vpnkit.tgz
 	rm -f src/bin/depends.ml
+
+REPO=../../mirage/opam-repository
+PACKAGES=$(REPO)/packages
+# until we have https://github.com/ocaml/opam-publish/issues/38
+pkg-%:
+	topkg opam pkg -n $*
+	mkdir -p $(PACKAGES)/$*
+	cp -r _build/$*.* $(PACKAGES)/$*/
+	cd $(PACKAGES) && git add $*
+
+PKGS=$(basename $(wildcard *.opam))
+opam-pkg:
+	$(MAKE) $(PKGS:%=pkg-%)

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -1,0 +1,3 @@
+#!/usr/bin/env ocaml
+#use "topfind"
+#require "topkg-jbuilder.auto"

--- a/vpnkit.descr
+++ b/vpnkit.descr
@@ -1,0 +1,6 @@
+VPN-friendly networking devices for HyperKit
+
+HyperKit is a hypervisor which runs on macOS using the "hypervisor.framework".
+VPNKit implements a virtual ethernet device for HyperKit VMs in a VPN-friendly
+way, by terminating and proxying all the TCP flows, caching and forwarding
+DNS requests etc. HyperKit and VPNKit are used in Docker for Mac and Windows.

--- a/vpnkit.opam
+++ b/vpnkit.opam
@@ -27,7 +27,6 @@ install: [make "install" "BINDIR=%{bin}%"]
 remove: [make "uninstall" "BINDIR=%{bin}%"]
 
 depends: [
-  "ocamlfind"  {build}
   "jbuilder"   {build}
   "alcotest"   {test}
   "result"

--- a/vpnkit.opam
+++ b/vpnkit.opam
@@ -12,10 +12,10 @@ authors: [
   "Thomas Gazagnaire <thomas@gazagnaire.com>"
   "Thomas Leonard <thomas.leonard@docker.com>"
 ]
-homepage:     "https://github.com/docker/vpnkit"
-bug-reports:  "https://github.com/docker/vpnkit/issues"
-dev-repo:     "https://github.com/docker/vpnkit.git"
-doc:          "https://docker.github.io/vpnkit/"
+homepage:     "https://github.com/moby/vpnkit"
+bug-reports:  "https://github.com/moby/vpnkit/issues"
+dev-repo:     "https://github.com/moby/vpnkit.git"
+doc:          "https://moby.github.io/vpnkit/"
 
 build: [
   [make]


### PR DESCRIPTION
This PR adds the modern OCaml/opam boilerplate for handling releases i.e.
- a simple `topkg` configuration (set to automatic)
- a `make opam-pkg` target which will (hopefully) create a set of package metadata which is acceptable to the upstream opam-repository

Minor changes include
- fix URLs in the opam file to point to `moby` rather than `docker`
- remove an unnecessary dependency on `ocamlfind`