### PR TITLE
Simplify the opam build

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### v0.1.1 (2017-08-17)
+
+* simplify the build by watermarking with `jbuilder subst`
+* fix the build of the released package archive
+
 ### v0.1.0 (2017-08-17)
 
 * use Mirage 3 interfaces

--- a/Makefile
+++ b/Makefile
@@ -25,13 +25,6 @@ uninstall:
 
 artefacts: $(ARTEFACTS)
 
-src/bin/depends.ml: src/bin/depends.ml.in
-	$(OPAMFLAGS) opam config subst src/bin/depends.ml || true
-	cp src/bin/depends.ml src/bin/depends.tmp
-	sed -e 's/££VERSION££/$(shell git rev-parse HEAD)/g' src/bin/depends.tmp > src/bin/depends.ml
-	cp src/bin/depends.ml src/bin/depends.tmp
-	sed -e 's/££HVSOCK_PINNED££/$(shell opam info hvsock -f pinned)/g' src/bin/depends.tmp > src/bin/depends.ml
-
 vpnkit.tgz: vpnkit.exe
 	mkdir -p _build/root/Contents/MacOS
 	cp vpnkit.exe _build/root/Contents/MacOS/vpnkit
@@ -42,7 +35,7 @@ vpnkit.tgz: vpnkit.exe
 	tar -C _build/root -cvzf vpnkit.tgz Contents
 
 .PHONY: vpnkit.exe
-vpnkit.exe: src/bin/depends.ml
+vpnkit.exe:
 	jbuilder build --dev src/bin/main.exe
 	cp _build/default/src/bin/main.exe vpnkit.exe
 
@@ -68,7 +61,6 @@ clean:
 	rm -rf _build
 	rm -f vpnkit.exe
 	rm -f vpnkit.tgz
-	rm -f src/bin/depends.ml
 
 REPO=../../mirage/opam-repository
 PACKAGES=$(REPO)/packages

--- a/src/bin/depends.ml.in
+++ b/src/bin/depends.ml.in
@@ -1,4 +1,0 @@
-let version = "££VERSION££"
-let uwt_version = "%{uwt:version}%"
-let hvsock_version = "%{hvsock:version}%"
-let hvsock_pinned = "££HVSOCK_PINNED££"

--- a/src/bin/jbuild
+++ b/src/bin/jbuild
@@ -8,3 +8,8 @@
      mirage-clock-unix mirage-random
    ))
    (preprocess  no_preprocessing)))
+
+(install
+ ((section bin)
+  (package vpnkit)
+  (files ((main.exe as vpnkit)))))

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -229,11 +229,9 @@ let hvsock_addr_of_uri ~default_serviceid uri =
     (try Sys.set_signal Sys.sigpipe Sys.Signal_ignore
     with Invalid_argument _ -> ());
     Log.info (fun f ->
-        f "vpnkit version %s with uwt version %s hvsock version %s %s"
-          Depends.version
-          Depends.uwt_version
-          Depends.hvsock_version Depends.hvsock_pinned
-      );
+        f "vpnkit version %%VERSION%% from %%VCS_COMMIT_ID%%"
+    );
+
     Log.info (fun f -> f "System SOMAXCONN is %d" !Utils.somaxconn);
     Utils.somaxconn :=
       (match listen_backlog with None -> !Utils.somaxconn | Some x -> x);
@@ -521,7 +519,7 @@ let command =
         $ socket $ port_control_path $ introspection_path $ diagnostics_path
         $ max_connections $ vsock_path $ db_path $ db_branch $ dns $ hosts
         $ host_names $ listen_backlog $ port_max_idle_time $ debug),
-  Term.info (Filename.basename Sys.argv.(0)) ~version:Depends.version ~doc ~man
+  Term.info (Filename.basename Sys.argv.(0)) ~version:"%%VERSION%%" ~doc ~man
 
 let () =
   Printexc.record_backtrace true;

--- a/vpnkit.opam
+++ b/vpnkit.opam
@@ -18,16 +18,12 @@ dev-repo:     "https://github.com/moby/vpnkit.git"
 doc:          "https://moby.github.io/vpnkit/"
 
 build: [
-  [make]
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
-build-test: [
-  [make "test"]
-]
-install: [make "install" "BINDIR=%{bin}%"]
-remove: [make "uninstall" "BINDIR=%{bin}%"]
 
 depends: [
-  "jbuilder"   {build}
+  "jbuilder" {build & >="1.0+beta10"}
   "alcotest"   {test}
   "result"
   "tar" {>= "0.8.0"}


### PR DESCRIPTION
Previously the opam file invoked `make` which performed some watermarking and then invoked `jbuilder`. This PR simplifies the build by using `jbuilder subst` for watermarking and having the `opam` file directly invoke `jbuilder`.