### PR TITLE
go: add ability to list exposed ports and unexpose

### DIFF
--- a/go/cmd/vpnkit-list-ports/.gitignore
+++ b/go/cmd/vpnkit-list-ports/.gitignore
@@ -1,0 +1,1 @@
+vpnkit-list-ports

--- a/go/cmd/vpnkit-list-ports/main.go
+++ b/go/cmd/vpnkit-list-ports/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	vpnkit "github.com/moby/vpnkit/go/pkg/vpnkit"
+)
+
+// List currently exposed ports
+
+func main() {
+	path := flag.String("vpnkit", os.Getenv("HOME")+"/Library/Containers/com.docker.docker/Data/s51", "path to vpnkit's control socket")
+	flag.Parse()
+
+	c, err := vpnkit.NewConnection(context.Background(), *path)
+	if err != nil {
+		log.Fatal(err)
+	}
+	ports, err := vpnkit.ListExposed(c)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, p := range ports {
+		fmt.Println(p.String())
+	}
+}


### PR DESCRIPTION
The function `ListExposed` returns the list of current port forwards.
The function `Unexpose` allows a listed port forward to be unexposed
by internally opening and then closing the `ctl` file-- the protocol
unexposes the port on `clunk`.

Signed-off-by: David Scott <dave.scott@docker.com>