### PR TITLE
go: add accessor functions to Port

### DIFF
--- a/go/pkg/vpnkit/port.go
+++ b/go/pkg/vpnkit/port.go
@@ -172,4 +172,29 @@ func (p *Port) Unexpose(ctx context.Context) error {
 	return nil
 }
 
+// Proto returns the protocol: either "tcp" or "udp"
+func (p *Port) Proto() string {
+	return p.proto
+}
+
+// OutIP returns the public IP
+func (p *Port) OutIP() net.IP {
+	return p.outIP
+}
+
+// OutPort returns the public port number
+func (p *Port) OutPort() int16 {
+	return p.outPort
+}
+
+// InIP returns the private IP
+func (p *Port) InIP() net.IP {
+	return p.inIP
+}
+
+// InPort returns the private port number
+func (p *Port) InPort() int16 {
+	return p.inPort
+}
+
 var enoent = p9p.MessageRerror{Ename: "file not found"}


### PR DESCRIPTION
Rather than expose the fields of the Port structure directly
which might tempt people to replace them, we keep them private but
return accessor functions. These allow people to discover (for example)
the external port of a forward.

Signed-off-by: David Scott <dave.scott@docker.com>