### PR TITLE
Protocol update: Add support for error messages, preferred IPv4 addresses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+### unreleased
+
+* socket protocol updated to v22:
+    - support error messages returned to client for Ethernet and Preferred_ipv4
+      slirp commands
+    - allow client to request an IPv4 address without encoding it in the UUID
+    - v1 no longer supported, clients have to be updated. Version 22 is used to
+      match the current version number in Docker for Desktop.
+
 ### v0.1.1 (2017-08-17)
 
 * simplify the build by watermarking with `jbuilder subst`

--- a/src/hostnet/capture.ml
+++ b/src/hostnet/capture.ml
@@ -217,7 +217,7 @@ module Make(Input: Sig.VMNET) = struct
     t.stats.rx_pkts <- 0l;
     t.stats.tx_pkts <- 0l
 
-  let of_fd ~client_macaddr_of_uuid:_ ~server_macaddr:_ ~mtu:_ =
+  let of_fd ~connect_client_fn:_ ~server_macaddr:_ ~mtu:_ =
     failwith "Capture.of_fd unimplemented"
 
   let start_capture _ ?size_limit:_ _ =

--- a/src/hostnet/filter.ml
+++ b/src/hostnet/filter.ml
@@ -120,7 +120,7 @@ module Make(Input: Sig.VMNET) = struct
   let get_stats_counters t = t.stats
   let reset_stats_counters t = Mirage_net.Stats.reset t.stats
 
-  let of_fd ~client_macaddr_of_uuid:_ ~server_macaddr:_ ~mtu:_ =
+  let of_fd ~connect_client_fn:_ ~server_macaddr:_ ~mtu:_ =
     failwith "Filter.of_fd unimplemented"
 
   let get_client_uuid _ =

--- a/src/hostnet/sig.ml
+++ b/src/hostnet/sig.ml
@@ -209,7 +209,7 @@ module type VMNET = sig
   type fd
 
   val of_fd:
-    connect_client_fn:(Uuidm.t -> Ipaddr.V4.t option -> Macaddr.t Lwt.t) ->
+    connect_client_fn:(Uuidm.t -> Ipaddr.V4.t option -> (Macaddr.t, [`Msg of string]) result Lwt.t) ->
     server_macaddr:Macaddr.t ->
     mtu:int ->
     fd -> (t, [`Msg of string]) result Lwt.t

--- a/src/hostnet/sig.ml
+++ b/src/hostnet/sig.ml
@@ -209,7 +209,7 @@ module type VMNET = sig
   type fd
 
   val of_fd:
-    client_macaddr_of_uuid:(Uuidm.t -> Macaddr.t Lwt.t) ->
+    connect_client_fn:(Uuidm.t -> Ipaddr.V4.t option -> Macaddr.t Lwt.t) ->
     server_macaddr:Macaddr.t ->
     mtu:int ->
     fd -> (t, [`Msg of string]) result Lwt.t

--- a/src/hostnet/vmnet.ml
+++ b/src/hostnet/vmnet.ml
@@ -25,7 +25,7 @@ module Init = struct
 
   let default = {
     magic = "VMN3T";
-    version = 1l;
+    version = 2l;
     commit = "0123456789012345678901234567890123456789";
   }
 
@@ -47,14 +47,17 @@ module Command = struct
 
   type t =
     | Ethernet of Uuidm.t (* 36 bytes *)
+    | Preferred_ipv4 of Uuidm.t (* 36 bytes *) * Ipaddr.V4.t
     | Bind_ipv4 of Ipaddr.V4.t * int * bool
 
   let to_string = function
   | Ethernet x -> Fmt.strf "Ethernet %a" Uuidm.pp x
+  | Preferred_ipv4 (uuid, ip) ->
+    Fmt.strf "Preferred_ipv4 %a %a" Uuidm.pp uuid Ipaddr.V4.pp_hum ip
   | Bind_ipv4 (ip, port, tcp) ->
     Fmt.strf "Bind_ipv4 %a %d %b" Ipaddr.V4.pp_hum ip port tcp
 
-  let sizeof = 1 + 36
+  let sizeof = 1 + 36 + 4
 
   let marshal t rest = match t with
   | Ethernet uuid ->
@@ -63,6 +66,14 @@ module Command = struct
     let uuid_str = Uuidm.to_string uuid in
     Cstruct.blit_from_string uuid_str 0 rest 0 (String.length uuid_str);
     Cstruct.shift rest (String.length uuid_str)
+  | Preferred_ipv4 (uuid, ip) ->
+    Cstruct.set_uint8 rest 0 2;
+    let rest = Cstruct.shift rest 1 in
+    let uuid_str = Uuidm.to_string uuid in
+    Cstruct.blit_from_string uuid_str 0 rest 0 (String.length uuid_str);
+    let rest = Cstruct.shift rest (String.length uuid_str) in
+    Cstruct.LE.set_uint32 rest 0 (Ipaddr.V4.to_int32 ip);
+    Cstruct.shift rest 4
   | Bind_ipv4 (ip, port, stream) ->
     Cstruct.set_uint8 rest 0 6;
     let rest = Cstruct.shift rest 1 in
@@ -74,10 +85,7 @@ module Command = struct
     Cstruct.shift rest 1
 
   let unmarshal rest =
-    match Cstruct.get_uint8 rest 0 with
-    | 1 ->
-      let uuid_str = Cstruct.(to_string (sub rest 1 36)) in
-      let rest = Cstruct.shift rest 37 in
+    let process_uuid uuid_str =
       if (Bytes.compare (Bytes.make 36 '\000') uuid_str) = 0 then
         begin
           let random_uuid = (Uuidm.v `V4) in
@@ -85,15 +93,25 @@ module Command = struct
               f "Generated UUID on behalf of client: %a" Uuidm.pp random_uuid);
           (* generate random uuid on behalf of client if client sent
              array of \0 *)
-          Ok (Ethernet random_uuid, rest)
-        end else  begin
-        let result = match (Uuidm.of_string uuid_str) with
-        (* parse uuid from client *)
-        | Some uuid -> Ok (Ethernet uuid, rest)
-        | None      -> Error (`Msg (Printf.sprintf "Invalid UUID: %s" uuid_str))
-        in
-        result
-      end
+          Some random_uuid
+        end else
+          Uuidm.of_string uuid_str
+    in
+    match Cstruct.get_uint8 rest 0 with
+    | 1 ->
+      let uuid_str = Cstruct.(to_string (sub rest 1 36)) in
+      let rest = Cstruct.shift rest 37 in
+      (match process_uuid uuid_str with
+       | Some uuid -> Ok (Ethernet uuid, rest)
+       | None -> Error (`Msg (Printf.sprintf "Invalid UUID: %s" uuid_str)))
+    | 2 ->
+      let uuid_str = Cstruct.(to_string (sub rest 1 36)) in
+      let rest = Cstruct.shift rest 37 in
+      let ip = Ipaddr.V4.of_int32 (Cstruct.LE.get_uint32 rest 0) in
+      let rest = Cstruct.shift rest 4 in
+      (match process_uuid uuid_str with
+      | Some uuid -> Ok (Preferred_ipv4 (uuid, ip), rest)
+      | None -> Error (`Msg (Printf.sprintf "Invalid UUID: %s" uuid_str)))
     | n -> Error (`Msg (Printf.sprintf "Unknown command: %d" n))
 
 end
@@ -214,32 +232,51 @@ module Make(C: Sig.CONN) = struct
   let server_log_prefix = "Vmnet.Server"
   let client_log_prefix = "Vmnet.Client"
 
-  let server_negotiate ~fd ~client_macaddr_of_uuid ~mtu =
+  let server_negotiate ~fd ~connect_client_fn ~mtu =
     with_read (Channel.read_exactly ~len:Init.sizeof fd) @@ fun bufs ->
     let buf = Cstruct.concat bufs in
     let init, _ = Init.unmarshal buf in
     Log.info (fun f -> f "%s.negotiate: received %s" server_log_prefix (Init.to_string init));
-    let (_: Cstruct.t) = Init.marshal Init.default buf in
-    Channel.write_buffer fd buf;
-    with_flush (Channel.flush fd) @@ fun () ->
-    with_read (Channel.read_exactly ~len:Command.sizeof fd) @@ fun bufs ->
-    let buf = Cstruct.concat bufs in
-    with_msg (Command.unmarshal buf) @@ fun (command, _) ->
-    Log.info (fun f ->
-        f "%s.negotiate: received %s" server_log_prefix (Command.to_string command));
-    match command with
-    | Command.Bind_ipv4 _ -> failf "%s.negotiate: unsupported command Bind_ipv4" server_log_prefix
-    | Command.Ethernet uuid ->
-      client_macaddr_of_uuid uuid >>= fun client_macaddr ->
-      let vif = Vif.create client_macaddr mtu () in
-      let buf = Cstruct.create Vif.sizeof in
-      let (_: Cstruct.t) = Vif.marshal vif buf in
-      Log.info (fun f -> f "%s.negotiate: sending %s" server_log_prefix (Vif.to_string vif));
+    match init.version with
+    | 2l -> begin
+        let (_: Cstruct.t) = Init.marshal Init.default buf in
+        Channel.write_buffer fd buf;
+        with_flush (Channel.flush fd) @@ fun () ->
+        with_read (Channel.read_exactly ~len:Command.sizeof fd) @@ fun bufs ->
+        let buf = Cstruct.concat bufs in
+        with_msg (Command.unmarshal buf) @@ fun (command, _) ->
+        Log.info (fun f ->
+            f "%s.negotiate: received %s" server_log_prefix (Command.to_string command));
+        match command with
+        | Command.Bind_ipv4 _ -> failf "%s.negotiate: unsupported command Bind_ipv4" server_log_prefix
+        | Command.Ethernet uuid ->
+          connect_client_fn uuid None >>= fun client_macaddr ->
+          let vif = Vif.create client_macaddr mtu () in
+          let buf = Cstruct.create Vif.sizeof in
+          let (_: Cstruct.t) = Vif.marshal vif buf in
+          Log.info (fun f -> f "%s.negotiate: sending %s" server_log_prefix (Vif.to_string vif));
+          Channel.write_buffer fd buf;
+          with_flush (Channel.flush fd) @@ fun () ->
+          Lwt_result.return (uuid, client_macaddr)
+        | Command.Preferred_ipv4 (uuid, ip) ->
+          connect_client_fn uuid (Some ip) >>= fun client_macaddr ->
+          let vif = Vif.create client_macaddr mtu () in
+          let buf = Cstruct.create Vif.sizeof in
+          let (_: Cstruct.t) = Vif.marshal vif buf in
+          Log.info (fun f -> f "%s.negotiate: sending %s" server_log_prefix (Vif.to_string vif));
+          Channel.write_buffer fd buf;
+          with_flush (Channel.flush fd) @@ fun () ->
+          Lwt_result.return (uuid, client_macaddr)
+      end
+    | x -> 
+      let (_: Cstruct.t) = Init.marshal Init.default buf in (* write our version before disconnecting *)
       Channel.write_buffer fd buf;
       with_flush (Channel.flush fd) @@ fun () ->
-      Lwt_result.return (uuid, client_macaddr)
+      Log.err (fun f -> f "%s: Client requested protocol version %s, server only supports version %s" server_log_prefix (Int32.to_string x) (Int32.to_string Init.default.version));
+      Lwt_result.fail (`Msg "Client requested unsupported protocol version")
 
-  let client_negotiate ~uuid ~fd =
+
+  let client_negotiate ~uuid ?preferred_ip ~fd =
     let buf = Cstruct.create Init.sizeof in
     let (_: Cstruct.t) = Init.marshal Init.default buf in
     Channel.write_buffer fd buf;
@@ -248,16 +285,24 @@ module Make(C: Sig.CONN) = struct
     let buf = Cstruct.concat bufs in
     let init, _ = Init.unmarshal buf in
     Log.info (fun f -> f "%s.negotiate: received %s" client_log_prefix (Init.to_string init));
-    let buf = Cstruct.create Command.sizeof in
-    let (_: Cstruct.t) = Command.marshal (Command.Ethernet uuid) buf in
-    Channel.write_buffer fd buf;
-    with_flush (Channel.flush fd) @@ fun () ->
-    with_read (Channel.read_exactly ~len:Vif.sizeof fd) @@ fun bufs ->
-    let buf = Cstruct.concat bufs in
-    let open Lwt_result.Infix in
-    Lwt.return (Vif.unmarshal buf) >>= fun (vif, _) ->
-    Log.debug (fun f -> f "%s.negotiate: vif %s" client_log_prefix (Vif.to_string vif));
-    Lwt_result.return (vif)
+    match init.version with
+    | 2l -> 
+        let buf = Cstruct.create Command.sizeof in
+        let (_: Cstruct.t) = match preferred_ip with
+          | None -> Command.marshal (Command.Ethernet uuid) buf
+          | Some ip -> Command.marshal (Command.Preferred_ipv4 (uuid, ip)) buf
+        in
+        Channel.write_buffer fd buf;
+        with_flush (Channel.flush fd) @@ fun () ->
+        with_read (Channel.read_exactly ~len:Vif.sizeof fd) @@ fun bufs ->
+        let buf = Cstruct.concat bufs in
+        let open Lwt_result.Infix in
+        Lwt.return (Vif.unmarshal buf) >>= fun (vif, _) ->
+        Log.debug (fun f -> f "%s.negotiate: vif %s" client_log_prefix (Vif.to_string vif));
+        Lwt_result.return (vif)
+    | x -> 
+        Log.err (fun f -> f "%s: Server requires protocol version %s, we have %s" client_log_prefix (Int32.to_string x) (Int32.to_string Init.default.version));
+        Lwt_result.fail (`Msg "Server does not support our version of the protocol")
 
   (* Use blocking I/O here so we can avoid Using Lwt_unix or Uwt. Ideally we
      would use a FLOW handle referencing a file/stream. *)
@@ -325,19 +370,19 @@ module Make(C: Sig.CONN) = struct
 
   type fd = C.flow
 
-  let of_fd ~client_macaddr_of_uuid ~server_macaddr ~mtu flow =
+  let of_fd ~connect_client_fn ~server_macaddr ~mtu flow =
     let open Lwt_result.Infix in
     let channel = Channel.create flow in
-    server_negotiate ~fd:channel ~client_macaddr_of_uuid ~mtu
+    server_negotiate ~fd:channel ~connect_client_fn ~mtu
     >>= fun (client_uuid, client_macaddr) ->
     let t = make ~client_macaddr ~server_macaddr ~mtu ~client_uuid
         ~log_prefix:server_log_prefix channel in
     Lwt_result.return t
 
-  let client_of_fd ~uuid ~server_macaddr flow =
+  let client_of_fd ~uuid ?preferred_ip ~server_macaddr flow =
     let open Lwt_result.Infix in
     let channel = Channel.create flow in
-    client_negotiate ~uuid ~fd:channel
+    client_negotiate ~uuid ?preferred_ip ~fd:channel
     >>= fun vif ->
     let t =
       make ~client_macaddr:server_macaddr

--- a/src/hostnet/vmnet.mli
+++ b/src/hostnet/vmnet.mli
@@ -13,7 +13,7 @@ module Make(C: Sig.CONN): sig
   val add_listener: t -> (Cstruct.t -> unit Lwt.t) -> unit
 
   val of_fd:
-    connect_client_fn:(Uuidm.t -> Ipaddr.V4.t option -> Macaddr.t Lwt.t) ->
+    connect_client_fn:(Uuidm.t -> Ipaddr.V4.t option -> (Macaddr.t, [`Msg of string]) result Lwt.t) ->
     server_macaddr:Macaddr.t -> mtu:int -> C.flow ->
     (t, [`Msg of string]) result Lwt.t
   (** [of_fd ~connect_client_fn ~server_macaddr ~mtu fd]

--- a/src/hostnet/vmnet.mli
+++ b/src/hostnet/vmnet.mli
@@ -68,3 +68,4 @@ module Command : sig
   val marshal: t -> Cstruct.t -> Cstruct.t
   val unmarshal: Cstruct.t -> (t * Cstruct.t, [ `Msg of string ]) result
 end
+

--- a/src/hostnet/vmnet.mli
+++ b/src/hostnet/vmnet.mli
@@ -13,18 +13,19 @@ module Make(C: Sig.CONN): sig
   val add_listener: t -> (Cstruct.t -> unit Lwt.t) -> unit
 
   val of_fd:
-    client_macaddr_of_uuid:(Uuidm.t -> Macaddr.t Lwt.t) ->
+    connect_client_fn:(Uuidm.t -> Ipaddr.V4.t option -> Macaddr.t Lwt.t) ->
     server_macaddr:Macaddr.t -> mtu:int -> C.flow ->
     (t, [`Msg of string]) result Lwt.t
-  (** [of_fd ~client_macaddr_of_uuid ~server_macaddr ~mtu fd]
+  (** [of_fd ~connect_client_fn ~server_macaddr ~mtu fd]
       negotiates with the client over [fd]. The server uses
-      [client_macaddr_of_uuid] to create a source address for the
+      [connect_client_fn] to create a source address for the
       client's ethernet frames based on a uuid supplied by the
-      client. The server uses [server_macaddr] as the source address
-      of all its ethernet frames and sets the MTU to [mtu]. *)
+      client and an optional preferred IP address. The server uses
+      [server_macaddr] as the source address of all its ethernet frames and
+      sets the MTU to [mtu]. *)
 
-  val client_of_fd: uuid:Uuidm.t -> server_macaddr:Macaddr.t -> C.flow ->
-    (t, [`Msg of string]) result Lwt.t
+  val client_of_fd: uuid:Uuidm.t -> ?preferred_ip:Ipaddr.V4.t ->
+      server_macaddr:Macaddr.t -> C.flow -> (t, [`Msg of string]) result Lwt.t
 
   val start_capture: t -> ?size_limit:int64 -> string -> unit Lwt.t
   (** [start_capture t ?size_limit filename] closes any existing pcap
@@ -58,6 +59,7 @@ module Command : sig
 
   type t =
     | Ethernet of Uuidm.t (* 36 bytes *)
+    | Preferred_ipv4 of Uuidm.t (* 36 bytes *) * Ipaddr.V4.t
     | Bind_ipv4 of Ipaddr.V4.t * int * bool
 
   val to_string: t -> string

--- a/src/hostnet_test/suite.ml
+++ b/src/hostnet_test/suite.ml
@@ -385,7 +385,7 @@ let tests =
   Hosts_test.tests @ Forwarding.tests @ test_dhcp
   @ (test_dns true) @ (test_dns false)
   @ test_tcp @ Test_nat.tests @ Test_http.tests @ Test_http.Exclude.tests
-  @ Test_half_close.tests @ Test_ping.tests
+  @ Test_half_close.tests
 
 let scalability = [
   "1026conns",

--- a/src/hostnet_test/suite.ml
+++ b/src/hostnet_test/suite.ml
@@ -385,7 +385,8 @@ let tests =
   Hosts_test.tests @ Forwarding.tests @ test_dhcp
   @ (test_dns true) @ (test_dns false)
   @ test_tcp @ Test_nat.tests @ Test_http.tests @ Test_http.Exclude.tests
-  @ Test_half_close.tests
+  @ Test_half_close.tests @ Test_ping.tests
+  @ Test_bridge.tests
 
 let scalability = [
   "1026conns",

--- a/src/hostnet_test/test_bridge.ml
+++ b/src/hostnet_test/test_bridge.ml
@@ -1,0 +1,99 @@
+open Lwt.Infix
+open Slirp_stack
+
+let src =
+  let src = Logs.Src.create "vnet" ~doc:"Test the virtual network" in
+  Logs.Src.set_level src (Some Logs.Debug);
+  src
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+(* Open multiple connections and verify that the connection succeeds and MAC and IP changes *)
+let test_connect n () =
+    Host.Main.run begin
+        let rec loop x used_ips used_macs =
+            match x, used_ips, used_macs with 
+            | 0, _, _ -> Lwt.return_unit
+            | x, used_ips, used_macs -> 
+                let uuid = (Uuidm.v `V4) in
+                with_stack ~uuid (fun _ client_stack ->
+                    (* Same IP should not appear twice *)
+                    let ips = Client.IPV4.get_ip (Client.ipv4 client_stack.t) in
+                    assert(List.length ips == 1);
+                    let ip = List.hd ips in
+                    assert((List.mem ip used_ips) == false);
+
+                    (* Same MAC should not appear twice *)
+                    let mac = (VMNET.mac client_stack.netif) in
+                    assert((List.mem mac used_macs) == false);
+
+                    Lwt.return (ip, mac)
+                ) >>= fun (ip, mac) -> 
+                Log.info (fun f -> f "Stack %d got IP %s and MAC %s" x (Ipaddr.V4.to_string ip) (Macaddr.to_string mac));
+                loop (x - 1) ([ip] @ used_ips) ([mac] @ used_macs)
+        in
+        loop n [] []
+    end
+
+(* Connect twice with the same UUID and verify that MAC and IP are the same *)
+let test_reconnect () =
+    Host.Main.run begin
+        let uuid = (Uuidm.v `V4) in
+        Log.info (fun f -> f "Using UUID %s" (Uuidm.to_string uuid));
+        with_stack ~uuid (fun _ client_stack ->
+            let ips = Client.IPV4.get_ip (Client.ipv4 client_stack.t) in
+            let ip = List.hd ips in
+            let mac = (VMNET.mac client_stack.netif) in
+            Lwt.return (ip, mac)
+        ) >>= fun (ip, mac) -> 
+        Log.info (fun f -> f "First connection got IP %s and MAC %s" (Ipaddr.V4.to_string ip) (Macaddr.to_string mac));
+        with_stack ~uuid (fun _ client_stack ->
+            let ips = Client.IPV4.get_ip (Client.ipv4 client_stack.t) in
+            let ip = List.hd ips in
+            let mac = (VMNET.mac client_stack.netif) in
+            Lwt.return (ip, mac)
+        ) >>= fun (reconnect_ip, reconnect_mac) -> 
+        Log.info (fun f -> f "Reconnect got IP %s and MAC %s" (Ipaddr.V4.to_string reconnect_ip) (Macaddr.to_string reconnect_mac));
+        assert(Ipaddr.V4.compare ip reconnect_ip == 0);
+        assert(Macaddr.compare mac reconnect_mac == 0);
+        Lwt.return ()
+   end
+
+(* Connect with random UUID and request an unused IP *)
+let test_connect_preferred_ipv4 preferred_ip () =
+    Host.Main.run begin
+        let uuid = (Uuidm.v `V4) in
+        Log.info (fun f -> f "Using UUID %s, requesting IP %s" (Uuidm.to_string uuid) (Ipaddr.V4.to_string preferred_ip));
+        with_stack ~uuid ~preferred_ip (fun _ client_stack ->
+            let ips = Client.IPV4.get_ip (Client.ipv4 client_stack.t) in
+            let ip = List.hd ips in
+            let mac = (VMNET.mac client_stack.netif) in
+            Lwt.return (ip, mac)
+        ) >>= fun (ip, mac) -> 
+        (* Verify that we got the IP we requested *)
+        assert(Ipaddr.V4.compare ip preferred_ip == 0);
+        Log.info (fun f -> f "First connection got IP %s and MAC %s" (Ipaddr.V4.to_string ip) (Macaddr.to_string mac));
+        with_stack ~uuid ~preferred_ip (fun _ client_stack ->
+            let ips = Client.IPV4.get_ip (Client.ipv4 client_stack.t) in
+            let ip = List.hd ips in
+            let mac = (VMNET.mac client_stack.netif) in
+            Lwt.return (ip, mac)
+        ) >>= fun (reconnect_ip, reconnect_mac) -> 
+        Log.info (fun f -> f "Reconnect got IP %s and MAC %s" (Ipaddr.V4.to_string reconnect_ip) (Macaddr.to_string reconnect_mac));
+        (* Verify that we got the same IP and MAC when reconnecting with the same UUID *)
+        assert(Ipaddr.V4.compare ip reconnect_ip == 0);
+        assert(Macaddr.compare mac reconnect_mac == 0);
+        Lwt.return ()
+   end
+
+
+let tests = 
+    [ "Vnet bridge", 
+      [ ("connect 2 nodes", `Quick, (test_connect 2)) ;
+        ("connect 10 nodes", `Quick, (test_connect 10)) ;
+        ("reconnect node", `Quick, test_reconnect) ;
+        ("preferred_ipv4", `Quick, (test_connect_preferred_ipv4 preferred_ip1));
+      ]
+    ]
+
+


### PR DESCRIPTION
This updates the protocol from v1 to v22. The new features are:

- New Preferred_ipv4 command may be used to request a specific IP which will be assigned to the UUID. The UUID can then be reused to get the same IP in the future. This replaces the old mechanism that encoded the requested IP in the UUID itself.
- New Response message returned for Ethernet and Preferred_ipv4 commands. The Response message either contains a Vif structure on success or a Disconnect with a reason message on failure. This allows errors to be reported back to the client, such as when the preferred IP address is already in use.

This PR also adds test for the bridge and the Preferred_ipv4 command. See individual commits for more details.

These changes are not backwards compatible. Other libraries that use VPNKit have to be updated or they will be disconnected by the server. I'll make PRs to Hyperkit, Linuxkit and Docker for Desktop when this passes initial review.

Related to #209 and linuxkit/linuxkit#1970