### PR TITLE
Disable Nagle's algorithm

### DIFF
--- a/src/hostnet/host.ml
+++ b/src/hostnet/host.ml
@@ -430,6 +430,12 @@ module Sockets = struct
                 f "Uwt.Tcp.enable_keepalive failed with: %s"
                   (Uwt.strerror @@ Uwt.Int_result.to_error error))
               end;
+              let error = Uwt.Tcp.nodelay fd true in
+              if Uwt.Int_result.is_error error then begin
+                Log.warn (fun f ->
+                f "Uwt.Tcp.nodelay failed with: %s"
+                  (Uwt.strerror @@ Uwt.Int_result.to_error error))
+              end;
               of_fd ~idx ~label ~read_buffer_size ~description fd
               |> Lwt_result.return
             ) (fun e ->
@@ -673,6 +679,12 @@ module Sockets = struct
                     if Uwt.Int_result.is_error error then begin
                       Log.warn (fun f ->
                       f "Uwt.Tcp.enable_keepalive failed with: %s"
+                        (Uwt.strerror @@ Uwt.Int_result.to_error error))
+                    end;
+                    let error = Uwt.Tcp.nodelay client true in
+                    if Uwt.Int_result.is_error error then begin
+                      Log.warn (fun f ->
+                      f "Uwt.Tcp.nodelay failed with: %s"
                         (Uwt.strerror @@ Uwt.Int_result.to_error error))
                     end;
                     let label, description =

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -126,6 +126,8 @@ struct
          what you say. *)
       Lwt.return ()
     let shutdown_write = close
+    (* Disable Nagle's algorithm *)
+    let write = write_nodelay
   end
 
   module Dns_forwarder =


### PR DESCRIPTION
Disable Nagle on both the external connections (via `Uwt.Tcp.nodelay`)
and on the internal connections (by using `write_nodelay` instead of
`write`)

Signed-off-by: David Scott <dave.scott@docker.com>