### PR TITLE
Improve UDP receive

### DIFF
--- a/src/hostnet/host.ml
+++ b/src/hostnet/host.ml
@@ -177,7 +177,7 @@ module Sockets = struct
             >>= fun recv ->
             if recv.Uwt.Udp.is_partial then begin
               Log.err (fun f ->
-                  f "Socket.%s.recvfrom: dropping partial response (buffer \
+                  f "Socket.%s.read: dropping partial response (buffer \
                      was %d bytes)" t.label (Cstruct.len buf));
               read t
             end else
@@ -188,7 +188,7 @@ module Sockets = struct
             Lwt.return (Ok `Eof)
           | e ->
             Log.err (fun f ->
-                f "Socket.%s.recvfrom: %s caught %s returning Eof"
+                f "Socket.%s.read: %s caught %s returning Eof"
                   t.label
                   (string_of_flow t)
                   (Printexc.to_string e)

--- a/src/hostnet/host.ml
+++ b/src/hostnet/host.ml
@@ -44,7 +44,7 @@ module Common = struct
   let ip_port_of_sockaddr sockaddr =
     try match sockaddr with
     | Unix.ADDR_INET(ip, port) ->
-      Some (Ipaddr.of_string @@ Unix.string_of_inet_addr ip, port)
+      Some (Ipaddr.of_string_exn @@ Unix.string_of_inet_addr ip, port)
     | _ -> None
     with _ -> None
 end
@@ -271,7 +271,7 @@ module Sockets = struct
           let label, description = match Uwt.Udp.getsockname fd with
           | Uwt.Ok sockaddr ->
             begin match ip_port_of_sockaddr sockaddr with
-            | Some (Some ip, port) ->
+            | Some (ip, port) ->
               Fmt.strf "udp:%a:%d" Ipaddr.pp_hum ip port,
               begin match ip with
               | Ipaddr.V4 _ -> "UDPv4"
@@ -667,7 +667,7 @@ module Sockets = struct
                       match Uwt.Tcp.getpeername client with
                       | Uwt.Ok sockaddr ->
                         begin match ip_port_of_sockaddr sockaddr with
-                        | Some (Some ip, port) ->
+                        | Some (ip, port) ->
                           Fmt.strf "tcp:%s:%d" (Ipaddr.to_string ip) port,
                           begin match ip with
                           | Ipaddr.V4 _ -> "TCPv4"


### PR DESCRIPTION
- in `read`: emulate a connected socket by dropping all incoming traffic that doesn't strictly match the address we have `connect`ed to
- in `recvfrom`: drop packets with an invalid from address but don't fail the thread

Note that the UDP NAT implementation uses `recvfrom` (not `read`). Previously the failed `recvfrom` would cause the NAT rule to be shutdown. It's not clear whether this missing `sockaddr` condition can be triggered easily, but it's suspicious that `libuv` permits a `NULL` which gets translated into a `None` by `uwt`.