### PR TITLE
test: record .pcap traces, one per test

### DIFF
--- a/src/hostnet_test/test_bridge.ml
+++ b/src/hostnet_test/test_bridge.ml
@@ -18,7 +18,7 @@ let test_connect n () =
             | 0, _, _ -> Lwt.return_unit
             | x, used_ips, used_macs -> 
                 let uuid = (Uuidm.v `V4) in
-                with_stack ~uuid (fun _ client_stack ->
+                with_stack ~uuid ~pcap:"test_connect.pcap" (fun _ client_stack ->
                     (* Same IP should not appear twice *)
                     let ips = Client.IPV4.get_ip (Client.ipv4 client_stack.t) in
                     assert(List.length ips == 1);
@@ -42,14 +42,14 @@ let test_reconnect () =
     Host.Main.run begin
         let uuid = (Uuidm.v `V4) in
         Log.info (fun f -> f "Using UUID %s" (Uuidm.to_string uuid));
-        with_stack ~uuid (fun _ client_stack ->
+        with_stack ~uuid ~pcap:"test_reconnect.pcap" (fun _ client_stack ->
             let ips = Client.IPV4.get_ip (Client.ipv4 client_stack.t) in
             let ip = List.hd ips in
             let mac = (VMNET.mac client_stack.netif) in
             Lwt.return (ip, mac)
         ) >>= fun (ip, mac) -> 
         Log.info (fun f -> f "First connection got IP %s and MAC %s" (Ipaddr.V4.to_string ip) (Macaddr.to_string mac));
-        with_stack ~uuid (fun _ client_stack ->
+        with_stack ~uuid ~pcap:"test_reconnect.2.pcap" (fun _ client_stack ->
             let ips = Client.IPV4.get_ip (Client.ipv4 client_stack.t) in
             let ip = List.hd ips in
             let mac = (VMNET.mac client_stack.netif) in
@@ -66,7 +66,7 @@ let test_connect_preferred_ipv4 preferred_ip () =
     Host.Main.run begin
         let uuid = (Uuidm.v `V4) in
         Log.info (fun f -> f "Using UUID %s, requesting IP %s" (Uuidm.to_string uuid) (Ipaddr.V4.to_string preferred_ip));
-        with_stack ~uuid ~preferred_ip (fun _ client_stack ->
+        with_stack ~uuid ~preferred_ip ~pcap:"test_connect_preferred_ipv4.pcap" (fun _ client_stack ->
             let ips = Client.IPV4.get_ip (Client.ipv4 client_stack.t) in
             let ip = List.hd ips in
             let mac = (VMNET.mac client_stack.netif) in
@@ -75,7 +75,7 @@ let test_connect_preferred_ipv4 preferred_ip () =
         (* Verify that we got the IP we requested *)
         assert(Ipaddr.V4.compare ip preferred_ip == 0);
         Log.info (fun f -> f "First connection got IP %s and MAC %s" (Ipaddr.V4.to_string ip) (Macaddr.to_string mac));
-        with_stack ~uuid ~preferred_ip (fun _ client_stack ->
+        with_stack ~uuid ~preferred_ip ~pcap:"test_connect_preferred_ipv4.2.pcap" (fun _ client_stack ->
             let ips = Client.IPV4.get_ip (Client.ipv4 client_stack.t) in
             let ip = List.hd ips in
             let mac = (VMNET.mac client_stack.netif) in
@@ -88,7 +88,7 @@ let test_connect_preferred_ipv4 preferred_ip () =
         (* Try to reconnect with the same UUID, but request a different IP (this should fail) *)
         let different_ip = Ipaddr.V4.of_int32 (Int32.succ (Ipaddr.V4.to_int32 preferred_ip)) in
         Lwt.catch (fun () ->
-            with_stack ~uuid ~preferred_ip:different_ip (fun _ client_stack ->
+            with_stack ~uuid ~preferred_ip:different_ip ~pcap:"test_connect_preferred_ipv4.3.pcap" (fun _ client_stack ->
                 let ips = Client.IPV4.get_ip (Client.ipv4 client_stack.t) in
                 let ip = List.hd ips in
                 let mac = (VMNET.mac client_stack.netif) in
@@ -102,7 +102,7 @@ let test_connect_preferred_ipv4 preferred_ip () =
         (* Try to reconnect with a different UUID, but request a used IP (this should fail) *)
         Lwt.catch (fun () ->
             let uuid = (Uuidm.v `V4) in
-            with_stack ~uuid ~preferred_ip (fun _ client_stack ->
+            with_stack ~uuid ~preferred_ip ~pcap:"test_connect_preferred_ipv4.4.pcap" (fun _ client_stack ->
                 let ips = Client.IPV4.get_ip (Client.ipv4 client_stack.t) in
                 let ip = List.hd ips in
                 let mac = (VMNET.mac client_stack.netif) in

--- a/src/hostnet_test/test_half_close.ml
+++ b/src/hostnet_test/test_half_close.ml
@@ -60,7 +60,7 @@ let flow ip port = function
 let test_mirage_half_close () =
   Host.Main.run begin
     let forwarded, forwarded_u = Lwt.task () in
-    Slirp_stack.with_stack (fun _ stack -> with_server (fun flow ->
+    Slirp_stack.with_stack ~pcap:"test_mirage_half_close.pcap" (fun _ stack -> with_server (fun flow ->
         (* Read the request until EOF *)
         let ic = Incoming.C.create flow in
         Incoming.C.read_line ic >|= data >>= fun bufs ->
@@ -116,7 +116,7 @@ let test_mirage_half_close () =
 let test_host_half_close () =
   Host.Main.run begin
     let forwarded, forwarded_u = Lwt.task () in
-    Slirp_stack.with_stack (fun _ stack -> with_server (fun flow ->
+    Slirp_stack.with_stack ~pcap:"test_host_half_close.pcap" (fun _ stack -> with_server (fun flow ->
         (* Write a request *)
         let ic = Incoming.C.create flow in
         Incoming.C.write_line ic request;

--- a/src/hostnet_test/test_nat.ml
+++ b/src/hostnet_test/test_nat.ml
@@ -106,7 +106,7 @@ let err_udp e = Fmt.kstrf failwith "%a" Client.UDPV4.pp_error e
    a response *)
 let test_udp () =
   let t = EchoServer.with_server (fun { EchoServer.local_port; _ } ->
-      with_stack (fun _ stack ->
+      with_stack ~pcap:"test_udp.pcap"  (fun _ stack ->
           let buffer = Cstruct.create 1024 in
           (* Send '1' *)
           Cstruct.set_uint8 buffer 0 1;
@@ -140,7 +140,7 @@ let test_udp () =
    another source port, expect responses to *both* source ports. *)
 let test_udp_2 () =
   let t = EchoServer.with_server (fun { EchoServer.local_port; _ } ->
-      with_stack  (fun _ stack ->
+      with_stack ~pcap:"test_udp_2.pcap"  (fun _ stack ->
           let buffer = Cstruct.create 1024 in
           (* Send '1' *)
           Cstruct.set_uint8 buffer 0 1;
@@ -204,7 +204,7 @@ let test_udp_2 () =
    can traverse the NAT *)
 let test_nat_punch () =
   let t = EchoServer.with_server (fun echoserver ->
-      with_stack (fun _ stack ->
+      with_stack ~pcap:"test_nat_punch.pcap" (fun _ stack ->
           let buffer = Cstruct.create 1024 in
           (* Send '1' *)
           Cstruct.set_uint8 buffer 0 1;
@@ -265,7 +265,7 @@ let test_nat_punch () =
    we have only a single NAT rule *)
 let test_shared_nat_rule () =
   let t = EchoServer.with_server (fun { EchoServer.local_port; _ } ->
-      with_stack (fun slirp_server stack ->
+      with_stack ~pcap:"test_shared_nat_rule.pcap" (fun slirp_server stack ->
           let buffer = Cstruct.create 1024 in
           (* Send '1' *)
           Cstruct.set_uint8 buffer 0 1;
@@ -333,7 +333,7 @@ let test_source_ports () =
       (fun { EchoServer.local_port = local_port1; _ } ->
          EchoServer.with_server
            (fun { EchoServer.local_port = local_port2; _ } ->
-              with_stack (fun _ stack ->
+              with_stack ~pcap:"test_source_ports.pcap" (fun _ stack ->
                   let buffer = Cstruct.create 1024 in
                   let udpv4 = Client.udpv4 stack.t in
                   (* This is the port we shall send from *)

--- a/src/hostnet_test/test_ping.ml
+++ b/src/hostnet_test/test_ping.ml
@@ -27,7 +27,7 @@ let test_ping () =
   let id = 0x1234 in
   Queue.clear Slirp_stack.Client.Icmpv41.packets;
   Host.Main.run begin
-    Slirp_stack.with_stack (fun _ stack ->
+    Slirp_stack.with_stack ~pcap:"test_ping.pcap" (fun _ stack ->
       let rec loop seq =
         if Queue.length Slirp_stack.Client.Icmpv41.packets > 0
         then Lwt.return_unit
@@ -49,7 +49,7 @@ let test_ping () =
 let test_two_pings () =
   Queue.clear Slirp_stack.Client.Icmpv41.packets;
   Host.Main.run begin
-    Slirp_stack.with_stack (fun _ stack ->
+    Slirp_stack.with_stack ~pcap:"test_two_pings.pcap" (fun _ stack ->
       let rec loop seq =
         let id_1 = 0x1234 in
         let id_2 = 0x4321 in


### PR DESCRIPTION
This makes debugging test failures a lot easier.

Signed-off-by: David Scott <dave.scott@docker.com>