### PR TITLE
Add post_push hooks for vpnkit-{tap-vsockd,9pmount-vsock}

### DIFF
--- a/c/vpnkit-9pmount-vsock/hooks/post_push
+++ b/c/vpnkit-9pmount-vsock/hooks/post_push
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo hooks/post_push: attempting to compute the tree SHA of the current directory
+pwd
+CURDIR=$(pwd)
+# The git ls-tree HEAD ../<foo> fails on Docker Cloud's hook environment.
+# It works fine from the parent directory.
+cd ..
+
+HASH=$(git ls-tree HEAD -- $(basename ${CURDIR}) | awk '{print $3}')
+
+echo Tagging "${IMAGE_NAME}" with "${DOCKER_REPO}:${HASH}"
+docker tag "${IMAGE_NAME}" "${DOCKER_REPO}:${HASH}"
+docker push "${DOCKER_REPO}:${HASH}"

--- a/c/vpnkit-tap-vsockd/hooks/post_push
+++ b/c/vpnkit-tap-vsockd/hooks/post_push
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo hooks/post_push: attempting to compute the tree SHA of the current directory
+pwd
+CURDIR=$(pwd)
+# The git ls-tree HEAD ../<foo> fails on Docker Cloud's hook environment.
+# It works fine from the parent directory.
+cd ..
+
+HASH=$(git ls-tree HEAD -- $(basename ${CURDIR}) | awk '{print $3}')
+
+echo Tagging "${IMAGE_NAME}" with "${DOCKER_REPO}:${HASH}"
+docker tag "${IMAGE_NAME}" "${DOCKER_REPO}:${HASH}"
+docker push "${DOCKER_REPO}:${HASH}"


### PR DESCRIPTION
These hooks will cause the Docker Cloud autobuilder to tag the images
using the LinuxKit content hash convention.

Signed-off-by: David Scott <dave.scott@docker.com>