### PR TITLE
Remove unnecessary Unix linkage

### DIFF
--- a/repo/darwin/packages/dev/hvsock.1.0.1/descr
+++ b/repo/darwin/packages/dev/hvsock.1.0.1/descr
@@ -1,0 +1,13 @@
+Bindings for Hyper-V AF_VSOCK
+
+[![Build Status (Linux)](https://travis-ci.org/mirage/ocaml-hvsock.svg)](https://travis-ci.org/mirage/ocaml-hvsock)
+[![Build status (Windows)](https://ci.appveyor.com/api/projects/status/974tsg317b4k8xra?svg=true)](https://ci.appveyor.com/project/mirage/ocaml-hvsock/branch/master)
+
+These bindings allow Host <-> VM communication on Hyper-V systems on both Linux
+and Windows.
+
+*Warning*: the `AF_HYPERV` patches for Linux are not yet merged and hence the
+definition of `AF_HYPERV` is not yet stable. If other address families are merged
+before this one then the value of `AF_HYPERV` will change!
+
+Please read [the API documentation](https://djs55.github.io/ocaml-hvsock/index.html).

--- a/repo/darwin/packages/dev/hvsock.1.0.1/opam
+++ b/repo/darwin/packages/dev/hvsock.1.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "1.2"
+maintainer: "dave@recoil.org"
+authors: [ "David Scott" "Rolf Neugebauer" "Anil Madhavapeddy" "Simon Ferquel"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-hvsock"
+dev-repo: "https://github.com/mirage/ocaml-hvsock.git"
+bug-reports: "https://github.com/mirage/ocaml-hvsock/issues"
+doc: "https://mirage.github.io/ocaml-hvsock"
+
+build: [
+  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+
+build-test:[
+  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "runtest" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "base-bytes"
+  "base-threads"
+  "base-unix"
+  "lwt" {>= "2.4.7"}
+  "logs"
+  "fmt"
+  "cmdliner"
+  "mirage-flow-lwt" {>= "1.2.0"}
+  "mirage-time-lwt" {>= "1.0.0"}
+  "cstruct" {>= "2.4.0"}
+  "duration"
+  "bos"
+  "jbuilder" {build & >="1.0+beta10"}
+  "alcotest" {test & >= "0.4.0"}
+]
+
+available: [ ocaml-version >= "4.03.0" ]

--- a/repo/darwin/packages/dev/hvsock.1.0.1/url
+++ b/repo/darwin/packages/dev/hvsock.1.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-hvsock/releases/download/1.0.1/hvsock-1.0.1.tbz"
+checksum: "3da19c12c7fdad73ad337a83f6e0bb2c"

--- a/repo/darwin/packages/dev/protocol-9p.0.11.3/descr
+++ b/repo/darwin/packages/dev/protocol-9p.0.11.3/descr
@@ -1,0 +1,26 @@
+An implementation of the 9P protocol in pure OCaml
+
+[![Build Status](https://travis-ci.org/mirage/ocaml-9p.png?branch=master)](https://travis-ci.org/mirage/ocaml-9p) [![Coverage Status](https://coveralls.io/repos/mirage/ocaml-9p/badge.png?branch=master)](https://coveralls.io/r/mirage/ocaml-9p?branch=master)
+
+ocaml-9p is an implementation of the 9P protocol, written in
+a Mirage-friendly style.
+
+Please read the [API documentation](https://mirage.github.io/ocaml-9p).
+
+Example of the CLI example program:
+```
+o9p ls --username vagrant   /var
+drwxr-xr-x ? root root 4096 Feb 2  2015 lib
+drwxr-xr-x ? root root 4096 Mar 15 2015 cache
+-rwxrwxrwx ? root root 9    May 10 2014 lock
+drwxrwxrwx ? root root 4096 Jul 6  2015 tmp
+drwxr-xr-x ? root root 4096 May 11 2014 spool
+drwxrwxr-x ? root sshd 4096 Sep 28 2015 log
+drwxr-xr-x ? root root 4096 Sep 21 2015 backups
+drwxrwxr-x ? root mail 4096 Apr 16 2014 mail
+drwxr-xr-x ? root root 4096 Apr 16 2014 opt
+drwxrwxr-x ? root 50   4096 Apr 10 2014 local
+-rwxrwxrwx ? root root 4    May 10 2014 run
+```
+
+This library supports the [9P2000.u extension](http://ericvh.github.io/9p-rfc/rfc9p2000.u.html)

--- a/repo/darwin/packages/dev/protocol-9p.0.11.3/opam
+++ b/repo/darwin/packages/dev/protocol-9p.0.11.3/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+maintainer:   "dave@recoil.org"
+authors:      [ "David Scott" "David Sheets" "Thomas Leonard" ]
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-9p"
+dev-repo:     "https://github.com/mirage/ocaml-9p.git"
+bug-reports:  "https://github.com/mirage/ocaml-9p/issues"
+doc:          "https://mirage.github.io/ocaml-9p/"
+
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta10"}
+  "base-bytes"
+  "cstruct" {>= "3.0.0"}
+  "sexplib" {> "113.00.00"}
+  "result"
+  "rresult"
+  "mirage-flow-lwt"
+  "mirage-kv-lwt"
+  "mirage-channel-lwt"
+  "lwt" {>= "3.0.0"}
+  "cmdliner"
+  "astring"
+  "named-pipe" {>= "0.4.0"}
+  "fmt"
+  "logs" {>= "0.5.0"}
+  "win-error"
+  "ppx_deriving" {build}
+  "ppx_sexp_conv" {build}
+  "ppx_tools" {build}
+  "alcotest" {test & >= "0.4.0"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/repo/darwin/packages/dev/protocol-9p.0.11.3/url
+++ b/repo/darwin/packages/dev/protocol-9p.0.11.3/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-9p/releases/download/v0.11.3/protocol-9p-0.11.3.tbz"
+checksum: "3560e6fa51c89a9c591042df3ad57ace"

--- a/repo/win32/packages/dev/hvsock.1.0.1
+++ b/repo/win32/packages/dev/hvsock.1.0.1
@@ -1,0 +1,1 @@
+../../../darwin/packages/dev/hvsock.1.0.1

--- a/repo/win32/packages/dev/protocol-9p.0.11.3
+++ b/repo/win32/packages/dev/protocol-9p.0.11.3
@@ -1,0 +1,1 @@
+../../../darwin/packages/dev/protocol-9p.0.11.3

--- a/src/bin/jbuild
+++ b/src/bin/jbuild
@@ -3,7 +3,7 @@
 (executable
   ((name main)
    (libraries   (
-     cmdliner ofs logs.fmt hostnet hvsock hvsock.lwt-unix
+     cmdliner ofs logs.fmt hostnet hvsock hvsock.lwt
      datakit-server-9p win-eventlog asl fd-send-recv duration
      mirage-clock-unix mirage-random
    ))

--- a/src/hostnet/jbuild
+++ b/src/hostnet/jbuild
@@ -3,14 +3,14 @@
 (library
   ((name        hostnet)
    (libraries (
-    cstruct lwt.unix logs ipaddr mirage-flow-lwt
-    ppx_sexp_conv pcap-format mirage-console-unix tcpip.ethif
+    cstruct logs ipaddr mirage-flow-lwt
+    ppx_sexp_conv pcap-format tcpip.ethif
     tcpip.arpv4 tcpip.ipv4 tcpip.icmpv4 tcpip.udp tcpip.tcp tcpip.stack-direct
     charrua-core.server dns dns-lwt ofs uwt uwt.ext uwt.preemptive
-    lwt.preemptive threads astring datakit-server dns-forward tar mirage-vnetif
+    threads astring datakit-server dns-forward tar mirage-vnetif
     dnssd uuidm cohttp-lwt mirage-channel ezjsonm
     mirage-protocols-lwt duration mirage-time-lwt mirage-clock-lwt
-    mirage-time-unix mirage-random tcpip.unix
+    mirage-random tcpip.unix
    ))
    (c_names (stubs_utils))
    (wrapped false)))

--- a/src/hostnet_test/jbuild
+++ b/src/hostnet_test/jbuild
@@ -3,8 +3,8 @@
 (executable
   ((name main)
    (libraries (
-     hostnet cmdliner alcotest lwt.unix logs.fmt protocol-9p
-     mirage-dns lwt.preemptive uwt.preemptive mirage-clock-unix
+     hostnet cmdliner alcotest logs.fmt protocol-9p
+     mirage-dns uwt.preemptive mirage-clock-unix
      charrua-client-mirage
    ))
    (preprocess no_preprocessing)))

--- a/src/ofs/jbuild
+++ b/src/ofs/jbuild
@@ -2,7 +2,7 @@
 
 (library
   ((name      ofs)
-   (libraries (protocol-9p protocol-9p-unix cstruct cstruct-lwt lwt.unix
-               io-page-unix logs astring named-pipe.lwt
+   (libraries (protocol-9p cstruct
+               io-page-unix logs astring
                mirage-time-lwt mirage-flow-lwt duration))
    (wrapped   false)))

--- a/vpnkit.opam
+++ b/vpnkit.opam
@@ -43,8 +43,7 @@ depends: [
   "cmdliner"
   "charrua-core" {>= "0.9"}
   "charrua-client-mirage" {test}
-  "named-pipe" {>= "0.4.0"}
-  "hvsock" {>= "0.13.0"}
+  "hvsock" {>= "1.0.1"}
   "asl"
   "win-eventlog"
   "fd-send-recv" {>= "1.0.3"}
@@ -53,14 +52,11 @@ depends: [
   "astring"
   "mirage-flow-lwt" {>= "1.4.0"}
   "mirage-time-lwt" {>= "1.1.0"}
-  "mirage-time-unix"
   "mirage-protocols" {>= "1.1.0"}
   "mirage-channel" {>= "3.0.1"}
-  "mirage-console-unix"
-  "mirage-clock-unix"
   "cohttp-lwt" {>= "0.99.0"}
   "mirage-dns"
-  "protocol-9p-unix" {>= "0.11.2"}
+  "protocol-9p" {>= "0.11.3"}
   "mirage-vnetif" {>= "0.4.0"}
   "uuidm"
   "ezjsonm"


### PR DESCRIPTION
Previously strange things happened when we linked both `uwt` and `lwt.unix`, `lwt.preemptive` at the same time. Obviously the `lwt.unix` functions won't work if used, but I suspect there may be module-level initialisation that conflicts (or could conflict) with `uwt`. Some extra linkage happened during the recent backend refactor *and* the versions of `uwt` and `lwt` were both upgraded.

Related to #286 but this is a good change anyway.