### PR TITLE
go: add binding for Preferred_ipv4

### DIFF
--- a/go/cmd/vpnkit-register-uuid/main.go
+++ b/go/cmd/vpnkit-register-uuid/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"log"
+	"net"
 	"os"
 
 	"github.com/google/uuid"
@@ -15,6 +16,7 @@ import (
 func main() {
 	path := flag.String("vpnkit", os.Getenv("HOME")+"/Library/Containers/com.docker.docker/Data/s50", "path to vpnkit's ethernet socket")
 	u := flag.String("uuid", "", "UUID for the network interface")
+	IP := flag.String("ip", "", "the IP we would like to use")
 	flag.Parse()
 
 	Uuid, err := uuid.Parse(*u)
@@ -30,9 +32,21 @@ func main() {
 	}
 	defer vmnet.Close()
 
-	vif, err := vmnet.ConnectVif(Uuid)
-	if err != nil {
-		log.Fatal(err)
+	var vif *vpnkit.Vif
+	if *IP == "" {
+		vif, err = vmnet.ConnectVif(Uuid)
+		if err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		ip := net.ParseIP(*IP)
+		if ip == nil {
+			log.Fatal("Failed to parse IP address")
+		}
+		vif, err = vmnet.ConnectVifIP(Uuid, ip)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 	log.Printf("VIF has MAC %s", vif.ClientMAC.String())
 	log.Printf("VIF has IP %s", vif.IP.String())


### PR DESCRIPTION
This allows Go programs to check that a UUID <-> IP mapping exists and to create one (provided the UUID and IP are free)

Signed-off-by: David Scott <dave.scott@docker.com>