### PR TITLE
Add /bin/mount to vpnkit-9pmount-vsock container

### DIFF
--- a/c/vpnkit-9pmount-vsock/Dockerfile
+++ b/c/vpnkit-9pmount-vsock/Dockerfile
@@ -4,7 +4,8 @@ RUN apk add --no-cache go musl-dev build-base linux-headers
 COPY . /build
 RUN make -C /build sbin/vpnkit-9pmount-vsock
 
-FROM scratch
+# Can't use scratch as we need /bin/mount
+FROM alpine:3.6
 ENTRYPOINT []
 CMD []
 WORKDIR /

--- a/c/vpnkit-9pmount-vsock/Makefile
+++ b/c/vpnkit-9pmount-vsock/Makefile
@@ -6,7 +6,7 @@ HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
 all: sbin/vpnkit-9pmount-vsock
 
 build-in-container:
-	docker build --network none -t vpnkit-9pmount-vsock:$(HASH) -f Dockerfile .
+	docker build -t vpnkit-9pmount-vsock:$(HASH) -f Dockerfile .
 
 sbin/vpnkit-9pmount-vsock: $(DEPS)
 	mkdir -p sbin


### PR DESCRIPTION
The container was built from scratch, but vpnkit-9pmount-vsock calls
/bin/mount to set up the mount point after opening the fd.

Also allow networking in container build.

Signed-off-by: Magnus Skjegstad <magnus@skjegstad.com>