### PR TITLE
Improve support for configuration via the command-line

### DIFF
--- a/src/bin/logging.ml
+++ b/src/bin/logging.ml
@@ -1,0 +1,34 @@
+(* Based on https://github.com/moby/datakit/blob/master/src/datakit-log/datakit_log.ml *)
+
+type t =
+  | Quiet
+  | Eventlog
+  | ASL
+
+open Cmdliner
+
+let mk = Arg.enum [
+    "quiet"    , Quiet;
+    "eventlog" , Eventlog;
+    "asl"      , ASL
+  ]
+
+let setup log_destination level =
+  Logs.set_level level;
+  match log_destination with
+  | Quiet    -> Logs.set_reporter (Logs_fmt.reporter ())
+  | Eventlog ->
+    let eventlog = Eventlog.register "Docker.exe" in
+    Logs.set_reporter (Log_eventlog.reporter ~eventlog ())
+  | ASL ->
+    let facility = Filename.basename Sys.executable_name in
+    let client = Asl.Client.create ~ident:"Docker" ~facility () in
+    Logs.set_reporter (Log_asl.reporter ~client ())
+
+let docs = "LOG OPTIONS"
+
+let log_destination =
+  let doc =
+    Arg.info ~docs ~doc:"Destination for the logs" [ "log-destination" ]
+  in
+  Arg.(value & opt mk Quiet & doc)

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -344,7 +344,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       socket_url port_control_url introspection_url diagnostics_url
       max_connections vsock_path db_path db_branch dns hosts host_names
       listen_backlog port_max_idle_time debug
-      server_macaddr domain allowed_bind_addresses docker
+      server_macaddr domain allowed_bind_addresses docker highest_ip
     =
     let host_names = List.map Dns.Name.of_string @@ Astring.String.cuts ~sep:"," host_names in
     let dns, resolver = match dns with
@@ -360,6 +360,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
     let server_macaddr = Macaddr.of_string_exn server_macaddr in
     let allowed_bind_addresses = Configuration.Parse.ipv4_list [] allowed_bind_addresses in
     let docker = Ipaddr.V4.of_string_exn docker in
+    let highest_ip = Ipaddr.V4.of_string_exn highest_ip in
     let configuration = {
       Configuration.default with
       max_connections;
@@ -371,6 +372,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       domain;
       allowed_bind_addresses;
       docker;
+      highest_ip;
     } in
     match socket_url with
       | None ->
@@ -535,6 +537,14 @@ let docker =
   in
   Arg.(value & opt string (Ipaddr.V4.to_string Configuration.default_docker) doc)
 
+let highest_ip =
+  let doc =
+    Arg.info ~doc:
+      "Highest IP address to hand out by DHCP"
+      [ "highest-dhcp-ip" ]
+  in
+  Arg.(value & opt string (Ipaddr.V4.to_string Configuration.default_highest_ip) doc)
+
 let command =
   let doc = "proxy TCP/IP connections from an ethernet link via sockets" in
   let man =
@@ -546,7 +556,8 @@ let command =
         $ socket $ port_control_path $ introspection_path $ diagnostics_path
         $ max_connections $ vsock_path $ db_path $ db_branch $ dns $ hosts
         $ host_names $ listen_backlog $ port_max_idle_time $ debug
-        $ server_macaddr $ domain $ allowed_bind_addresses $ docker ),
+        $ server_macaddr $ domain $ allowed_bind_addresses $ docker
+        $ highest_ip ),
   Term.info (Filename.basename Sys.argv.(0)) ~version:"%%VERSION%%" ~doc ~man
 
 let () =

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -344,7 +344,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       socket_url port_control_url introspection_url diagnostics_url
       max_connections vsock_path db_path db_branch dns hosts host_names
       listen_backlog port_max_idle_time debug
-      server_macaddr domain allowed_bind_addresses docker highest_ip
+      server_macaddr domain allowed_bind_addresses gateway_ip highest_ip
       mtu
     =
     let host_names = List.map Dns.Name.of_string @@ Astring.String.cuts ~sep:"," host_names in
@@ -360,7 +360,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       { servers; search = []; assume_offline_after_drops = None }, `Upstream in
     let server_macaddr = Macaddr.of_string_exn server_macaddr in
     let allowed_bind_addresses = Configuration.Parse.ipv4_list [] allowed_bind_addresses in
-    let docker = Ipaddr.V4.of_string_exn docker in
+    let gateway_ip = Ipaddr.V4.of_string_exn gateway_ip in
     let highest_ip = Ipaddr.V4.of_string_exn highest_ip in
     let configuration = {
       Configuration.default with
@@ -372,7 +372,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       server_macaddr;
       domain;
       allowed_bind_addresses;
-      docker;
+      gateway_ip;
       highest_ip;
       mtu;
     } in
@@ -531,13 +531,13 @@ let allowed_bind_addresses =
   in
   Arg.(value & opt string "0.0.0.0" doc)
 
-let docker =
+let gateway_ip =
   let doc =
     Arg.info ~doc:
       "IP address of the vpnkit gateway"
       [ "gateway-ip" ]
   in
-  Arg.(value & opt string (Ipaddr.V4.to_string Configuration.default_docker) doc)
+  Arg.(value & opt string (Ipaddr.V4.to_string Configuration.default_gateway_ip) doc)
 
 let highest_ip =
   let doc =
@@ -566,7 +566,7 @@ let command =
         $ socket $ port_control_path $ introspection_path $ diagnostics_path
         $ max_connections $ vsock_path $ db_path $ db_branch $ dns $ hosts
         $ host_names $ listen_backlog $ port_max_idle_time $ debug
-        $ server_macaddr $ domain $ allowed_bind_addresses $ docker
+        $ server_macaddr $ domain $ allowed_bind_addresses $ gateway_ip
         $ highest_ip $ mtu ),
   Term.info (Filename.basename Sys.argv.(0)) ~version:"%%VERSION%%" ~doc ~man
 

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -344,7 +344,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       socket_url port_control_url introspection_url diagnostics_url
       max_connections vsock_path db_path db_branch dns hosts host_names
       listen_backlog port_max_idle_time debug
-      server_macaddr
+      server_macaddr domain
     =
     let host_names = List.map Dns.Name.of_string @@ Astring.String.cuts ~sep:"," host_names in
     let dns, resolver = match dns with
@@ -366,6 +366,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       dns;
       resolver;
       server_macaddr;
+      domain;
     } in
     match socket_url with
       | None ->
@@ -508,6 +509,10 @@ let server_macaddr =
   let doc = "Ethernet MAC for the host to use" in
   Arg.(value & opt string (Macaddr.to_string Configuration.default_server_macaddr) & info [ "server-macaddr" ] ~doc)
 
+let domain =
+  let doc = "Domain name to include in DHCP offers" in
+  Arg.(value & opt string Configuration.default_domain & info [ "domain" ] ~doc)
+
 let command =
   let doc = "proxy TCP/IP connections from an ethernet link via sockets" in
   let man =
@@ -519,7 +524,7 @@ let command =
         $ socket $ port_control_path $ introspection_path $ diagnostics_path
         $ max_connections $ vsock_path $ db_path $ db_branch $ dns $ hosts
         $ host_names $ listen_backlog $ port_max_idle_time $ debug
-        $ server_macaddr ),
+        $ server_macaddr $ domain ),
   Term.info (Filename.basename Sys.argv.(0)) ~version:"%%VERSION%%" ~doc ~man
 
 let () =

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -391,10 +391,14 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       max_connections vsock_path db_path db_branch dns hosts host_names
       listen_backlog port_max_idle_time debug
     =
+    match socket_url with
+      | None ->
+        Printf.fprintf stderr "Please provide an --ethernet argument\n"
+      | Some socket_url ->
     Host.Main.run
       (main_t socket_url port_control_url introspection_url diagnostics_url
          max_connections vsock_path db_path db_branch dns hosts host_names
-         listen_backlog port_max_idle_time debug)
+         listen_backlog port_max_idle_time debug);
 
 open Cmdliner
 
@@ -409,7 +413,7 @@ let socket =
        incoming connections."
       [ "ethernet" ]
   in
-  Arg.(value & opt string "" doc)
+  Arg.(value & opt (some string) None doc)
 
 let port_control_path =
   let doc =
@@ -540,6 +544,4 @@ let command =
 let () =
   Printexc.record_backtrace true;
 
-  match Term.eval command with
-  | `Error _ -> exit 1
-  | _ -> exit 0
+  Term.exit @@ Term.eval command

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -293,33 +293,25 @@ let hvsock_addr_of_uri ~default_serviceid uri =
     let vnet_switch = Vnet.create () in
 
     let hardcoded_configuration =
-      let server_macaddr = Configuration.default_server_macaddr in
-      let peer_ip = Configuration.default_peer in
-      let local_ip = Configuration.default_docker in
-      let highest_ip = Configuration.default_highest_ip in
+      let configuration =
+        { Configuration.default with
+          port_max_idle_time } in
       let client_uuids : Slirp.uuid_table = {
         Slirp.mutex = Lwt_mutex.create ();
         table = Hashtbl.create 50;
       } in
       let global_arp_table : Slirp.arp_table = {
         Slirp.mutex = Lwt_mutex.create ();
-        table = [(local_ip, server_macaddr)];
+        table = [(configuration.Configuration.docker, configuration.Configuration.server_macaddr)];
       } in
       {
-        Slirp.server_macaddr;
-        peer_ip;
-        local_ip;
-        highest_ip;
-        extra_dns_ip = [];
-        get_domain_search = (fun () -> []);
-        get_domain_name = (fun () -> "localdomain");
+        Slirp.configuration;
         global_arp_table;
         client_uuids;
         vnet_switch;
-        mtu = 1500;
         host_names;
-        clock;
-        port_max_idle_time }
+        clock
+      }
     in
 
     let config = match db_path with

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -293,10 +293,10 @@ let hvsock_addr_of_uri ~default_serviceid uri =
     let vnet_switch = Vnet.create () in
 
     let hardcoded_configuration =
-      let server_macaddr = Slirp.default_server_macaddr in
-      let peer_ip = Ipaddr.V4.of_string_exn "192.168.65.2" in
-      let local_ip = Ipaddr.V4.of_string_exn "192.168.65.1" in
-      let highest_ip = Ipaddr.V4.of_string_exn "192.168.65.254" in
+      let server_macaddr = Configuration.default_server_macaddr in
+      let peer_ip = Configuration.default_peer in
+      let local_ip = Configuration.default_docker in
+      let highest_ip = Configuration.default_highest_ip in
       let client_uuids : Slirp.uuid_table = {
         Slirp.mutex = Lwt_mutex.create ();
         table = Hashtbl.create 50;

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -345,6 +345,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       max_connections vsock_path db_path db_branch dns hosts host_names
       listen_backlog port_max_idle_time debug
       server_macaddr domain allowed_bind_addresses docker highest_ip
+      mtu
     =
     let host_names = List.map Dns.Name.of_string @@ Astring.String.cuts ~sep:"," host_names in
     let dns, resolver = match dns with
@@ -373,6 +374,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       allowed_bind_addresses;
       docker;
       highest_ip;
+      mtu;
     } in
     match socket_url with
       | None ->
@@ -545,6 +547,14 @@ let highest_ip =
   in
   Arg.(value & opt string (Ipaddr.V4.to_string Configuration.default_highest_ip) doc)
 
+let mtu =
+  let doc =
+    Arg.info ~doc:
+      "Maximum Transfer Unit of the ethernet links"
+      [ "mtu" ]
+  in
+  Arg.(value & opt int Configuration.default_mtu doc)
+
 let command =
   let doc = "proxy TCP/IP connections from an ethernet link via sockets" in
   let man =
@@ -557,7 +567,7 @@ let command =
         $ max_connections $ vsock_path $ db_path $ db_branch $ dns $ hosts
         $ host_names $ listen_backlog $ port_max_idle_time $ debug
         $ server_macaddr $ domain $ allowed_bind_addresses $ docker
-        $ highest_ip ),
+        $ highest_ip $ mtu ),
   Term.info (Filename.basename Sys.argv.(0)) ~version:"%%VERSION%%" ~doc ~man
 
 let () =

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -84,7 +84,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
           >>= fun s ->
           Lwt.return (Ok s)
         ) (fun e ->
-          Log.err (fun f -> f "Failed to call Stream.Unix.bind %s: %s" path (Printexc.to_string e));
+          Log.err (fun f -> f "Failed to call Stream.Unix.bind \"%s\": %s" path (Printexc.to_string e));
           Lwt.return (Error (`Msg  "Failed to bind to Unix domain socket"))
         )
   let hvsock_connect_forever url sockaddr callback =
@@ -181,7 +181,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
 
   let start_port_forwarding port_control_url max_connections vsock_path =
     Log.info (fun f ->
-        f "Starting port forwarding server on port_control_url:%s vsock_path:%s"
+        f "Starting port forwarding server on port_control_url:\"%s\" vsock_path:\"%s\""
           port_control_url vsock_path);
     (* Start the 9P port forwarding server *)
     Connect_unix.vsock_path := vsock_path;

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -339,7 +339,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
 
   let main
       socket_url port_control_url introspection_url diagnostics_url
-      max_connections vsock_path db_path db_branch dns hosts host_names
+      max_connections vsock_path db_path db_branch dns http hosts host_names
       listen_backlog port_max_idle_time debug
       server_macaddr domain allowed_bind_addresses gateway_ip highest_ip
       mtu log_destination
@@ -367,6 +367,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       host_names;
       dns = Configuration.no_dns_servers;
       dns_path;
+      http_intercept_path = http;
       resolver;
       server_macaddr;
       domain;
@@ -489,6 +490,21 @@ let dns =
   in
   Arg.(value & opt (some string) None doc)
 
+let http =
+  let doc =
+    Arg.info ~doc:
+      "File containing transparent HTTP redirection configuration.\
+      If this argument is given, then outgoing connections to port 80 (HTTP) \
+      and 443 (HTTPS) are transparently redirected to the proxies mentioned \
+      in the configuration file. The configuration file is in .json format as \
+      follows: `{\"http\": \"host:3128\",\
+        \"https\": \"host:3128\",\
+        \"exclude\": \"*.local\"\
+      }`\
+      " ["http"]
+  in
+  Arg.(value & opt (some string) None doc)
+
 let hosts =
   let doc =
     Arg.info ~doc:
@@ -568,7 +584,7 @@ let command =
   in
   Term.(pure main
         $ socket $ port_control_path $ introspection_path $ diagnostics_path
-        $ max_connections $ vsock_path $ db_path $ db_branch $ dns $ hosts
+        $ max_connections $ vsock_path $ db_path $ db_branch $ dns $ http $ hosts
         $ host_names $ listen_backlog $ port_max_idle_time $ debug
         $ server_macaddr $ domain $ allowed_bind_addresses $ gateway_ip
         $ highest_ip $ mtu $ Logging.log_destination),

--- a/src/hostnet/configuration.ml
+++ b/src/hostnet/configuration.ml
@@ -100,8 +100,8 @@ module Parse = struct
       Log.err (fun f ->
           f "Failed to parse IPv4 address list '%s', using default of %s" x
             (String.concat "," (List.map Ipaddr.V4.to_string default)));
-      Lwt.return default
-    end else Lwt.return some
+      default
+    end else some
 
   let int = function
   | None -> Lwt.return None

--- a/src/hostnet/configuration.ml
+++ b/src/hostnet/configuration.ml
@@ -12,7 +12,7 @@ type t = {
   resolver: [ `Host | `Upstream ];
   domain: string;
   allowed_bind_addresses: Ipaddr.V4.t list;
-  docker: Ipaddr.V4.t;
+  gateway_ip: Ipaddr.V4.t;
   (* TODO: remove this from the record since it is not constant across all clients *)
   peer: Ipaddr.V4.t;
   highest_ip: Ipaddr.V4.t;
@@ -24,14 +24,14 @@ type t = {
 }
 
 let to_string t =
-  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; docker = %s; peer = %s; highest_ip = %s; extra_dns = %s; mtu = %d; http_intercept = %s; port_max_idle_time = %s; host_names = %s"
+  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; gateway_ip = %s; peer = %s; highest_ip = %s; extra_dns = %s; mtu = %d; http_intercept = %s; port_max_idle_time = %s; host_names = %s"
     (Macaddr.to_string t.server_macaddr)
     (match t.max_connections with None -> "None" | Some x -> string_of_int x)
     (Dns_forward.Config.to_string t.dns)
     (match t.resolver with `Host -> "Host" | `Upstream -> "Upstream")
     t.domain
     (String.concat ", " (List.map Ipaddr.V4.to_string t.allowed_bind_addresses))
-    (Ipaddr.V4.to_string t.docker)
+    (Ipaddr.V4.to_string t.gateway_ip)
     (Ipaddr.V4.to_string t.peer)
     (Ipaddr.V4.to_string t.highest_ip)
     (String.concat ", " (List.map Ipaddr.V4.to_string t.extra_dns))
@@ -44,7 +44,7 @@ let no_dns_servers =
   Dns_forward.Config.({ servers = Server.Set.empty; search = []; assume_offline_after_drops = None })
 
 let default_peer = Ipaddr.V4.of_string_exn "192.168.65.2"
-let default_docker = Ipaddr.V4.of_string_exn "192.168.65.1" (* was host *)
+let default_gateway_ip = Ipaddr.V4.of_string_exn "192.168.65.1"
 let default_highest_ip = Ipaddr.V4.of_string_exn "192.168.65.254"
 let default_extra_dns = []
 (* The default MTU is limited by the maximum message size on a Hyper-V
@@ -65,7 +65,7 @@ let default = {
   resolver = default_resolver;
   domain = default_domain;
   allowed_bind_addresses = [];
-  docker = default_docker;
+  gateway_ip = default_gateway_ip;
   peer = default_peer;
   highest_ip = default_highest_ip;
   extra_dns = default_extra_dns;

--- a/src/hostnet/configuration.ml
+++ b/src/hostnet/configuration.ml
@@ -9,6 +9,7 @@ type t = {
   server_macaddr: Macaddr.t;
   max_connections: int option;
   dns: Dns_forward.Config.t;
+  dns_path: string option;
   resolver: [ `Host | `Upstream ];
   domain: string;
   allowed_bind_addresses: Ipaddr.V4.t list;
@@ -24,9 +25,10 @@ type t = {
 }
 
 let to_string t =
-  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; gateway_ip = %s; peer = %s; highest_ip = %s; extra_dns = %s; mtu = %d; http_intercept = %s; port_max_idle_time = %s; host_names = %s"
+  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns_path = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; gateway_ip = %s; peer = %s; highest_ip = %s; extra_dns = %s; mtu = %d; http_intercept = %s; port_max_idle_time = %s; host_names = %s"
     (Macaddr.to_string t.server_macaddr)
     (match t.max_connections with None -> "None" | Some x -> string_of_int x)
+    (match t.dns_path with None -> "None" | Some x -> x)
     (Dns_forward.Config.to_string t.dns)
     (match t.resolver with `Host -> "Host" | `Upstream -> "Upstream")
     t.domain
@@ -62,6 +64,7 @@ let default = {
   server_macaddr = default_server_macaddr;
   max_connections = None;
   dns = no_dns_servers;
+  dns_path = None;
   resolver = default_resolver;
   domain = default_domain;
   allowed_bind_addresses = [];

--- a/src/hostnet/configuration.ml
+++ b/src/hostnet/configuration.ml
@@ -56,13 +56,14 @@ let default_port_max_idle_time = 300
 let default_server_macaddr = Macaddr.of_string_exn "F6:16:36:BC:F9:C6"
 let default_host_names = [ Dns.Name.of_string "vpnkit.host" ]
 let default_resolver = `Host
+let default_domain = "localdomain"
 
 let default = {
   server_macaddr = default_server_macaddr;
   max_connections = None;
   dns = no_dns_servers;
   resolver = default_resolver;
-  domain = "localdomain";
+  domain = default_domain;
   allowed_bind_addresses = [];
   docker = default_docker;
   peer = default_peer;

--- a/src/hostnet/configuration.ml
+++ b/src/hostnet/configuration.ml
@@ -55,12 +55,13 @@ let default_port_max_idle_time = 300
 (* random MAC from https://www.hellion.org.uk/cgi-bin/randmac.pl *)
 let default_server_macaddr = Macaddr.of_string_exn "F6:16:36:BC:F9:C6"
 let default_host_names = [ Dns.Name.of_string "vpnkit.host" ]
+let default_resolver = `Host
 
 let default = {
   server_macaddr = default_server_macaddr;
   max_connections = None;
   dns = no_dns_servers;
-  resolver = `Host;
+  resolver = default_resolver;
   domain = "localdomain";
   allowed_bind_addresses = [];
   docker = default_docker;

--- a/src/hostnet/configuration.ml
+++ b/src/hostnet/configuration.ml
@@ -13,6 +13,7 @@ type t = {
   domain: string;
   allowed_bind_addresses: Ipaddr.V4.t list;
   docker: Ipaddr.V4.t;
+  (* TODO: remove this from the record since it is not constant across all clients *)
   peer: Ipaddr.V4.t;
   highest_ip: Ipaddr.V4.t;
   extra_dns: Ipaddr.V4.t list;

--- a/src/hostnet/configuration.ml
+++ b/src/hostnet/configuration.ml
@@ -20,10 +20,11 @@ type t = {
   mtu: int;
   http_intercept: Ezjsonm.value option;
   port_max_idle_time: int;
+  host_names: Dns.Name.t list;
 }
 
 let to_string t =
-  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; docker = %s; peer = %s; highest_ip = %s; extra_dns = %s; mtu = %d; http_intercept = %s; port_max_idle_time = %s"
+  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; docker = %s; peer = %s; highest_ip = %s; extra_dns = %s; mtu = %d; http_intercept = %s; port_max_idle_time = %s; host_names = %s"
     (Macaddr.to_string t.server_macaddr)
     (match t.max_connections with None -> "None" | Some x -> string_of_int x)
     (Dns_forward.Config.to_string t.dns)
@@ -37,6 +38,7 @@ let to_string t =
     t.mtu
     (match t.http_intercept with None -> "None" | Some x -> Ezjsonm.(to_string @@ wrap x))
     (string_of_int t.port_max_idle_time)
+    (String.concat ", " (List.map Dns.Name.to_string t.host_names))
 
 let no_dns_servers =
   Dns_forward.Config.({ servers = Server.Set.empty; search = []; assume_offline_after_drops = None })
@@ -52,6 +54,7 @@ let default_mtu = 1500 (* used for the virtual ethernet link *)
 let default_port_max_idle_time = 300
 (* random MAC from https://www.hellion.org.uk/cgi-bin/randmac.pl *)
 let default_server_macaddr = Macaddr.of_string_exn "F6:16:36:BC:F9:C6"
+let default_host_names = [ Dns.Name.of_string "vpnkit.host" ]
 
 let default = {
   server_macaddr = default_server_macaddr;
@@ -67,6 +70,7 @@ let default = {
   mtu = default_mtu;
   http_intercept = None;
   port_max_idle_time = default_port_max_idle_time;
+  host_names = default_host_names;
 }
 
 module Parse = struct

--- a/src/hostnet/configuration.ml
+++ b/src/hostnet/configuration.ml
@@ -6,6 +6,7 @@ let src =
 module Log = (val Logs.src_log src : Logs.LOG)
 
 type t = {
+  server_macaddr: Macaddr.t;
   max_connections: int option;
   dns: Dns_forward.Config.t;
   resolver: [ `Host | `Upstream ];
@@ -21,7 +22,8 @@ type t = {
 }
 
 let to_string t =
-  Printf.sprintf "max_connection = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; docker = %s; peer = %s; highest_ip = %s; extra_dns = %s; mtu = %d; http_intercept = %s; port_max_idle_time = %s"
+  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; docker = %s; peer = %s; highest_ip = %s; extra_dns = %s; mtu = %d; http_intercept = %s; port_max_idle_time = %s"
+    (Macaddr.to_string t.server_macaddr)
     (match t.max_connections with None -> "None" | Some x -> string_of_int x)
     (Dns_forward.Config.to_string t.dns)
     (match t.resolver with `Host -> "Host" | `Upstream -> "Upstream")
@@ -47,8 +49,11 @@ let default_extra_dns = []
    below 8192 bytes *)
 let default_mtu = 1500 (* used for the virtual ethernet link *)
 let default_port_max_idle_time = 300
+(* random MAC from https://www.hellion.org.uk/cgi-bin/randmac.pl *)
+let default_server_macaddr = Macaddr.of_string_exn "F6:16:36:BC:F9:C6"
 
 let default = {
+  server_macaddr = default_server_macaddr;
   max_connections = None;
   dns = no_dns_servers;
   resolver = `Host;

--- a/src/hostnet/configuration.ml
+++ b/src/hostnet/configuration.ml
@@ -20,12 +20,13 @@ type t = {
   extra_dns: Ipaddr.V4.t list;
   mtu: int;
   http_intercept: Ezjsonm.value option;
+  http_intercept_path: string option;
   port_max_idle_time: int;
   host_names: Dns.Name.t list;
 }
 
 let to_string t =
-  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns_path = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; gateway_ip = %s; peer = %s; highest_ip = %s; extra_dns = %s; mtu = %d; http_intercept = %s; port_max_idle_time = %s; host_names = %s"
+  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns_path = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; gateway_ip = %s; peer = %s; highest_ip = %s; extra_dns = %s; mtu = %d; http_intercept = %s; http_intercept_path = %s; port_max_idle_time = %s; host_names = %s"
     (Macaddr.to_string t.server_macaddr)
     (match t.max_connections with None -> "None" | Some x -> string_of_int x)
     (match t.dns_path with None -> "None" | Some x -> x)
@@ -39,6 +40,7 @@ let to_string t =
     (String.concat ", " (List.map Ipaddr.V4.to_string t.extra_dns))
     t.mtu
     (match t.http_intercept with None -> "None" | Some x -> Ezjsonm.(to_string @@ wrap x))
+    (match t.http_intercept_path with None -> "None" | Some x -> x)
     (string_of_int t.port_max_idle_time)
     (String.concat ", " (List.map Dns.Name.to_string t.host_names))
 
@@ -74,6 +76,7 @@ let default = {
   extra_dns = default_extra_dns;
   mtu = default_mtu;
   http_intercept = None;
+  http_intercept_path = None;
   port_max_idle_time = default_port_max_idle_time;
   host_names = default_host_names;
 }

--- a/src/hostnet/dhcp.ml
+++ b/src/hostnet/dhcp.ml
@@ -40,11 +40,11 @@ module Make (Clock: Mirage_clock_lwt.MCLOCK) (Netif: Mirage_net_lwt.S) = struct
        resolved in the future *)
     let low_ip, high_ip =
       let open Ipaddr.V4 in
-      let all_static_ips = c.Configuration.docker :: c.Configuration.peer :: c.Configuration.extra_dns in
+      let all_static_ips = c.Configuration.gateway_ip :: c.Configuration.peer :: c.Configuration.extra_dns in
       let highest = maximum_ip all_static_ips in
       let i32 = to_int32 highest in
       of_int32 @@ Int32.succ i32, of_int32 @@ Int32.succ @@ Int32.succ i32 in
-    let ip_list = [ c.Configuration.docker; low_ip; high_ip; c.Configuration.highest_ip ] in
+    let ip_list = [ c.Configuration.gateway_ip; low_ip; high_ip; c.Configuration.highest_ip ] in
     let prefix = smallest_prefix c.Configuration.peer ip_list 32 in
     let domain_search = c.dns.Dns_forward.Config.search in
 
@@ -59,9 +59,9 @@ module Make (Clock: Mirage_clock_lwt.MCLOCK) (Netif: Mirage_net_lwt.S) = struct
         Cstruct.(to_string (sub buffer 0 n)) in
       let domain_name = c.Configuration.domain in
       let options = [
-        Dhcp_wire.Routers [ c.Configuration.docker ];
-        Dhcp_wire.Dns_servers (c.Configuration.docker :: c.Configuration.extra_dns);
-        Dhcp_wire.Ntp_servers [ c.Configuration.docker ];
+        Dhcp_wire.Routers [ c.Configuration.gateway_ip ];
+        Dhcp_wire.Dns_servers (c.Configuration.gateway_ip :: c.Configuration.extra_dns);
+        Dhcp_wire.Ntp_servers [ c.Configuration.gateway_ip ];
         Dhcp_wire.Broadcast_addr (Ipaddr.V4.Prefix.broadcast prefix);
         Dhcp_wire.Subnet_mask (Ipaddr.V4.Prefix.netmask prefix);
       ] in
@@ -79,7 +79,7 @@ module Make (Clock: Mirage_clock_lwt.MCLOCK) (Netif: Mirage_net_lwt.S) = struct
         default_lease_time = Int32.of_int (60 * 60 * 2);
         (* 24 hours, from charrua defaults *)
         max_lease_time = Int32.of_int (60 * 60 * 24) ;
-        ip_addr = c.Configuration.docker;
+        ip_addr = c.Configuration.gateway_ip;
         mac_addr = c.Configuration.server_macaddr;
         network = prefix;
         (* FIXME: this needs https://github.com/haesbaert/charrua-core/pull/31 *)

--- a/src/hostnet/dhcp.mli
+++ b/src/hostnet/dhcp.mli
@@ -1,12 +1,7 @@
 module Make  (Clock: Mirage_clock_lwt.MCLOCK) (Netif: Mirage_net_lwt.S): sig
   type t
 
-  val make: server_macaddr:Macaddr.t
-    -> peer_ip: Ipaddr.V4.t -> highest_peer_ip: Ipaddr.V4.t option
-    -> local_ip:Ipaddr.V4.t
-    -> extra_dns_ip:Ipaddr.V4.t list -> get_domain_search:(unit -> string list)
-    -> get_domain_name:(unit -> string)
-    -> Clock.t -> Netif.t -> t
+  val make: configuration:Configuration.t -> Clock.t -> Netif.t -> t
 
   val callback: t -> Cstruct.t -> unit Lwt.t
 end

--- a/src/hostnet/host.ml
+++ b/src/hostnet/host.ml
@@ -53,7 +53,12 @@ module Sockets = struct
 
   let max_connections = ref None
 
-  let set_max_connections x = max_connections := x
+  let set_max_connections x =
+    begin match x with
+      | None -> Log.info (fun f -> f "removed connection limit")
+      | Some limit -> Log.info (fun f -> f "updated connection limit to %d" limit)
+    end;
+    max_connections := x
 
   let next_connection_idx =
     let idx = ref 0 in

--- a/src/hostnet/host.ml
+++ b/src/hostnet/host.ml
@@ -55,8 +55,8 @@ module Sockets = struct
 
   let set_max_connections x =
     begin match x with
-      | None -> Log.info (fun f -> f "removed connection limit")
-      | Some limit -> Log.info (fun f -> f "updated connection limit to %d" limit)
+      | None -> Log.info (fun f -> f "Removed connection limit")
+      | Some limit -> Log.info (fun f -> f "Updated connection limit to %d" limit)
     end;
     max_connections := x
 
@@ -89,7 +89,7 @@ module Sockets = struct
       if (now -. !last_error_log) > 30. then begin
         (* Avoid hammering the logging system *)
         Log.warn (fun f ->
-            f "exceeded maximum number of forwarded connections (%d)" m);
+            f "Exceeded maximum number of forwarded connections (%d)" m);
         last_error_log := now;
       end;
       Lwt.fail Too_many_connections
@@ -102,7 +102,7 @@ module Sockets = struct
 
   let deregister_connection idx =
     if not(Hashtbl.mem connection_table idx) then begin
-      Log.warn (fun f -> f "deregistered connection %d more than once" idx)
+      Log.warn (fun f -> f "Deregistered connection %d more than once" idx)
     end;
     Hashtbl.remove connection_table idx
 
@@ -662,7 +662,7 @@ module Sockets = struct
             || Ipaddr.compare ip (Ipaddr.V4 Ipaddr.V4.any) = 0
             then begin
               Log.debug (fun f ->
-                  f "attempting a best-effort bind of ::1:%d" local_port);
+                  f "Attempting a best-effort bind of ::1:%d" local_port);
               bind_one (Ipaddr.(V6 V6.localhost), local_port)
               >>= fun (idx, _, fd) ->
               Lwt.return [ idx, fd ]
@@ -670,7 +670,7 @@ module Sockets = struct
               Lwt.return []
           ) (fun e ->
             Log.debug (fun f ->
-                f "ignoring failed bind to ::1:%d (%a)" local_port Fmt.exn e);
+                f "Ignoring failed bind to ::1:%d (%a)" local_port Fmt.exn e);
             Lwt.return []
           )
         >|= fun extra ->

--- a/src/hostnet/hostnet_dns.ml
+++ b/src/hostnet/hostnet_dns.ml
@@ -274,9 +274,10 @@ struct
   let create ~local_address ~host_names =
     let local_ip = local_address.Dns_forward.Config.Address.ip in
     Log.info (fun f ->
-        f "DNS names %s will map to local IP %s"
-          (String.concat ", " @@ List.map Dns.Name.to_string host_names)
-          (Ipaddr.to_string local_ip));
+      let prefix = match host_names with
+        | [] -> "No DNS names"
+        | _ -> Printf.sprintf "DNS names [ %s ]" (String.concat ", " @@ List.map Dns.Name.to_string host_names) in
+      f "%s will map to local IP %s" prefix (Ipaddr.to_string local_ip));
     fun clock -> function
     | `Upstream config ->
       let open Dns_forward.Config.Address in

--- a/src/hostnet/hosts.ml
+++ b/src/hostnet/hosts.ml
@@ -58,7 +58,8 @@ module Make(Files: Sig.FILES) = struct
         | Ok txt ->
           etc_hosts := of_string txt;
           Log.info (fun f ->
-              f "hosts file has bindings for %s"
+              f "%s file has bindings for %s"
+                filename
                 (String.concat " " @@ List.map fst !etc_hosts))
       )
 

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -1086,7 +1086,7 @@ struct
     | `Host, _ -> `Host
     in
     Log.info (fun f ->
-        f "updating resolvers to %s" (Hostnet_dns.Config.to_string config));
+        f "Updating resolvers to %s" (Hostnet_dns.Config.to_string config));
     !dns >>= Dns_forwarder.destroy >|= fun () ->
     Dns_policy.remove ~priority:3;
     Dns_policy.add ~priority:3 ~config;
@@ -1110,7 +1110,7 @@ struct
       | Ok t ->
         http := Some t;
         Log.info (fun f ->
-          f "updating transparent HTTP redirection: %s" (Http_forwarder.to_string t)
+          f "Updating transparent HTTP redirection: %s" (Http_forwarder.to_string t)
         );
         Lwt.return_unit
 

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -1135,8 +1135,6 @@ struct
     ( match c.dns_path with
       | None -> Lwt.return_unit
       | Some path ->
-        read_dns_file path
-        >>= fun () ->
         begin match Host.Files.watch_file path
           (fun () ->
             Log.info (fun f -> f "DNS configuration file %s has changed" path);
@@ -1173,8 +1171,6 @@ struct
     ( match c.http_intercept_path with
     | None -> Lwt.return_unit
     | Some path ->
-      read_http_intercept_file path
-      >>= fun () ->
       begin match Host.Files.watch_file path
         (fun () ->
           Log.info (fun f -> f "Transparent HTTP redirection configuration file %s has changed" path);

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -50,14 +50,6 @@ type uuid_table = {
   table: (Uuidm.t, Ipaddr.V4.t * int) Hashtbl.t;
 }
 
-type ('a, 'b) config = {
-  configuration: Configuration.t;
-  global_arp_table: arp_table;
-  client_uuids: uuid_table;
-  vnet_switch: 'b;
-  clock: 'a;
-}
-
 module Make
     (Config: Active_config.S)
     (Vmnet: Sig.VMNET)
@@ -70,6 +62,14 @@ module Make
     (Vnet : Vnetif.BACKEND with type macaddr = Macaddr.t) =
 struct
   (* module Tcpip_stack = Tcpip_stack.Make(Vmnet)(Host.Time) *)
+
+  type stack = {
+    configuration: Configuration.t;
+    global_arp_table: arp_table;
+    client_uuids: uuid_table;
+    vnet_switch: Vnet.t;
+    clock: Clock.t;
+  }
 
   module Filteredif = Filter.Make(Vmnet)
   module Netif = Capture.Make(Filteredif)
@@ -412,7 +412,7 @@ struct
       Stack_ipv4.writev t.ipv4 ethernet_ip_hdr [ reply ];
   end
 
-  type t = {
+  type connection = {
     vnet_client_id: Vnet.id;
     after_disconnect: unit Lwt.t;
     interface: Netif.t;

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -1180,7 +1180,7 @@ struct
       extra_dns_ips_path
     >>= fun string_extra_dns_ips ->
     Active_config.map
-      (Configuration.Parse.ipv4_list (List.map Ipaddr.V4.of_string_exn Configuration.default_extra_dns))
+      (fun x -> Lwt.return @@ Configuration.Parse.ipv4_list (List.map Ipaddr.V4.of_string_exn Configuration.default_extra_dns) x)
       string_extra_dns_ips
     >>= fun extra_dns_ips ->
     on_change extra_dns_ips (fun extra_dns -> update (fun c -> { c with extra_dns }));
@@ -1197,7 +1197,7 @@ struct
     let bind_path = driver @ [ "allowed-bind-address" ] in
     Config.string ~default:"" config bind_path
     >>= fun string_allowed_bind_address ->
-    Active_config.map (Configuration.Parse.ipv4_list []) string_allowed_bind_address
+    Active_config.map (fun x -> Lwt.return @@ Configuration.Parse.ipv4_list [] x) string_allowed_bind_address
     >>= fun allowed_bind_address ->
     on_change allowed_bind_address (fun allowed_bind_addresses -> update (fun c -> { c with allowed_bind_addresses }));
     let mtu_path = driver @ [ "slirp"; "mtu" ] in

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -9,9 +9,6 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 module IPMap = Map.Make(Ipaddr.V4)
 
-(* random MAC from https://www.hellion.org.uk/cgi-bin/randmac.pl *)
-let default_server_macaddr = Macaddr.of_string_exn "F6:16:36:BC:F9:C6"
-
 (* When forwarding TCP, the connection is proxied so the MTU/MSS is
    link-local.  When forwarding UDP, the datagram on the internal link
    is the same size as the corresponding datagram on the external
@@ -1229,8 +1226,7 @@ struct
     >>= fun port_max_idle_times ->
     on_change port_max_idle_times (fun port_max_idle_time -> update (fun c -> { c with port_max_idle_time }));
 
-    (* TODO Don't hardcode this *)
-    let server_macaddr = default_server_macaddr in
+    let server_macaddr = (!c).server_macaddr in
     let peer_ip = (!c).docker in
     let local_ip = (!c).peer in
     let highest_ip = (!c).highest_ip in

--- a/src/hostnet/slirp.mli
+++ b/src/hostnet/slirp.mli
@@ -17,14 +17,7 @@ type uuid_table = {
 (** A slirp TCP/IP stack ready to accept connections *)
 
 
-type ('clock, 'vnet_switch) config = {
-  configuration: Configuration.t;
-  global_arp_table: arp_table;
-  client_uuids: uuid_table;
-  vnet_switch: 'vnet_switch;
-  host_names: Dns.Name.t list;
-  clock: 'clock;
-}
+type ('clock, 'vnet_switch) config
 
 module Make
     (Config: Active_config.S)
@@ -38,9 +31,14 @@ module Make
     (Vnet : Vnetif.BACKEND with type macaddr = Macaddr.t) :
 sig
 
-  val create: ?host_names:Dns.Name.t list -> Clock.t -> Vnet.t -> Config.t ->
+  val create_static: Clock.t -> Vnet.t -> Configuration.t ->
+  (Clock.t, Vnet.t) config Lwt.t
+  (** Initialise a TCP/IP stack, with a static configuration *)
+
+  val create_from_active_config: Clock.t -> Vnet.t -> Configuration.t -> Config.t ->
     (Clock.t, Vnet.t) config Lwt.t
-  (** Initialise a TCP/IP stack, taking configuration from the Config.t *)
+  (** Initialise a TCP/IP stack, allowing the dynamic Config.t to override
+      the static Configuration.t *)
 
   type t
 

--- a/src/hostnet/slirp.mli
+++ b/src/hostnet/slirp.mli
@@ -4,8 +4,6 @@ type pcap = (string * int64 option) option
     file will grow without bound; otherwise the file will be closed when it is
     bigger than the given limit. *)
 
-type ('clock, 'vnet_switch) config
-
 module Make
     (Config: Active_config.S)
     (Vmnet: Sig.VMNET)
@@ -18,32 +16,34 @@ module Make
     (Vnet : Vnetif.BACKEND with type macaddr = Macaddr.t) :
 sig
 
-  val create_static: Clock.t -> Vnet.t -> Configuration.t ->
-  (Clock.t, Vnet.t) config Lwt.t
+  type stack
+  (** A TCP/IP stack which may talk to multiple ethernet clients *)
+
+  val create_static: Clock.t -> Vnet.t -> Configuration.t -> stack Lwt.t
   (** Initialise a TCP/IP stack, with a static configuration *)
 
-  val create_from_active_config: Clock.t -> Vnet.t -> Configuration.t -> Config.t ->
-    (Clock.t, Vnet.t) config Lwt.t
+  val create_from_active_config: Clock.t -> Vnet.t -> Configuration.t -> Config.t -> stack Lwt.t
   (** Initialise a TCP/IP stack, allowing the dynamic Config.t to override
       the static Configuration.t *)
 
-  type t
+  type connection
+  (** An ethernet connection to a stack *)
 
-  val connect: (Clock.t, Vnet.t) config -> Vmnet.fd -> t Lwt.t
+  val connect: stack -> Vmnet.fd -> connection Lwt.t
   (** Read and write ethernet frames on the given fd, connected to the
       specified Vnetif backend *)
 
-  val after_disconnect: t -> unit Lwt.t
+  val after_disconnect: connection -> unit Lwt.t
   (** Waits until the stack has been disconnected *)
 
-  val filesystem: t -> Vfs.Dir.t
+  val filesystem: connection -> Vfs.Dir.t
   (** A virtual filesystem which exposes internal state for debugging *)
 
-  val diagnostics: t -> Host.Sockets.Stream.Unix.flow -> unit Lwt.t
+  val diagnostics: connection -> Host.Sockets.Stream.Unix.flow -> unit Lwt.t
   (** Output diagnostics in .tar format over a local Unix socket or named pipe *)
 
   module Debug: sig
-    val get_nat_table_size: t -> int
+    val get_nat_table_size: connection -> int
     (** Return the number of active NAT table entries *)
 
     val update_dns: ?local_ip:Ipaddr.t -> ?host_names:Dns.Name.t list ->

--- a/src/hostnet/slirp.mli
+++ b/src/hostnet/slirp.mli
@@ -84,5 +84,3 @@ sig
 end
 
 val print_pcap: pcap -> string
-
-val default_server_macaddr: Macaddr.t

--- a/src/hostnet/slirp.mli
+++ b/src/hostnet/slirp.mli
@@ -18,20 +18,12 @@ type uuid_table = {
 
 
 type ('clock, 'vnet_switch) config = {
-  server_macaddr: Macaddr.t;
-  peer_ip: Ipaddr.V4.t;
-  local_ip: Ipaddr.V4.t;
-  highest_ip: Ipaddr.V4.t;
-  extra_dns_ip: Ipaddr.V4.t list;
-  get_domain_search: unit -> string list;
-  get_domain_name: unit -> string;
+  configuration: Configuration.t;
   global_arp_table: arp_table;
   client_uuids: uuid_table;
   vnet_switch: 'vnet_switch;
-  mtu: int;
   host_names: Dns.Name.t list;
   clock: 'clock;
-  port_max_idle_time: int;
 }
 
 module Make

--- a/src/hostnet/slirp.mli
+++ b/src/hostnet/slirp.mli
@@ -4,19 +4,6 @@ type pcap = (string * int64 option) option
     file will grow without bound; otherwise the file will be closed when it is
     bigger than the given limit. *)
 
-type arp_table = {
-  mutex: Lwt_mutex.t;
-  mutable table: (Ipaddr.V4.t * Macaddr.t) list;
-}
-
-type uuid_table = {
-  mutex: Lwt_mutex.t;
-  table: (Uuidm.t, Ipaddr.V4.t * int) Hashtbl.t;
-}
-
-(** A slirp TCP/IP stack ready to accept connections *)
-
-
 type ('clock, 'vnet_switch) config
 
 module Make

--- a/src/hostnet/stubs_utils.c
+++ b/src/hostnet/stubs_utils.c
@@ -17,7 +17,6 @@
 #endif
 
 CAMLprim value stub_get_SOMAXCONN(value unit){
-  fprintf(stderr, "SOMAXCONN = %d\n", SOMAXCONN);
   return (Val_int (SOMAXCONN));
 }
 

--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -157,15 +157,9 @@ let config =
     extra_dns = extra_dns_ip;
     domain = "local";
   } in
-  Mclock.connect () >|= fun clock ->
-  {
-    Slirp.configuration;
-    client_uuids;
-    vnet_switch = Vnet.create ();
-    global_arp_table;
-    host_names = [];
-    clock;
-  }
+  Mclock.connect () >>= fun clock ->
+  let vnet = Vnet.create () in
+  Slirp_stack.create_static clock vnet configuration
 
 (* This is a hacky way to get a hancle to the server side of the stack. *)
 let slirp_stack = ref None

--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -141,16 +141,6 @@ let extra_dns_ip = List.map Ipaddr.V4.of_string_exn [
 
 let preferred_ip1 = Ipaddr.V4.of_string_exn "192.168.65.250"
 
-let global_arp_table : Slirp.arp_table =
-  { Slirp.mutex = Lwt_mutex.create ();
-    table = [(Configuration.default_docker, Configuration.default_server_macaddr)]
-  }
-
-let client_uuids : Slirp.uuid_table =
-  { Slirp.mutex = Lwt_mutex.create ();
-    table = Hashtbl.create 50;
-  }
-
 let config =
   let configuration = {
     Configuration.default with


### PR DESCRIPTION
Previously everything could be configured via the database but only some options could be configured via the command-line. This PR completes the command-line support.

In particular:
- `--dns <filename>` names a file which will be watched for changes. It is re-read on change and used to dynamically reconfigure the upstream DNS servers
- `--http <filename>` names a file which will be watched for changes. It is re-read on change and used to dynamically reconfigure transparent HTTP redirection.
- `--log-destination <destination>` allows the logging to be configured

The PR also improves the logging by
- defaulting to writing to the terminal (see `--log-destination`) rather than failing silently
- printing an error message if `--ethernet` is not provided