### PR TITLE
Fix ICMP and UDP traceroute

### DIFF
--- a/src/hostnet/frame.ml
+++ b/src/hostnet/frame.ml
@@ -1,10 +1,26 @@
-type t =
+let src =
+  let src = Logs.Src.create "FRAME" ~doc:"Ethernet frame parser" in
+  Logs.Src.set_level src (Some Logs.Info);
+  src
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+type icmp =
+  | Echo:     { seq: int; id: int; payload: Cstruct.t } -> icmp
+  | Time_exceeded: { ipv4: (ipv4, [ `Msg of string ]) result } -> icmp
+  | Unknown_icmp: icmp
+
+and ipv4 = {
+  src: Ipaddr.V4.t; dst: Ipaddr.V4.t;
+  dnf: bool; ihl: int;
+  ttl: int; raw: Cstruct.t; payload: t
+}
+
+and t =
   | Ethernet: { src: Macaddr.t; dst: Macaddr.t; payload: t } -> t
   | Arp:      { op: [ `Request | `Reply | `Unknown ] } -> t
-  | Icmp:     { ty: int; code: int; seq: int; id: int;
-                raw: Cstruct.t; payload: t } -> t
-  | Ipv4:     { src: Ipaddr.V4.t; dst: Ipaddr.V4.t; dnf: bool; ihl: int;
-                ttl: int; raw: Cstruct.t; payload: t } -> t
+  | Icmp:     { ty: int; code: int; raw: Cstruct.t; icmp: icmp } -> t
+  | Ipv4:     ipv4 -> t
   | Udp:      { src: int; dst: int; len: int; payload: t } -> t
   | Tcp:      { src: int; dst: int; syn: bool; raw: Cstruct.t; payload: t } -> t
   | Payload:  Cstruct.t -> t
@@ -21,6 +37,76 @@ let need_space_for bufs n description =
   then errorf "buffer is too short for %s: needed %d bytes but only have %d"
       description n (Cstructs.len bufs)
   else Ok ()
+
+let rec ipv4 inner =
+  need_space_for inner 16 "IP datagram"
+  >>= fun () ->
+  let vihl  = Cstructs.get_uint8     inner 0 in
+  let len   = Cstructs.BE.get_uint16 inner (1 + 1) in
+  let off   = Cstructs.BE.get_uint16 inner (1 + 1 + 2 + 2) in
+  let ttl   = Cstructs.get_uint8     inner (1 + 1 + 2 + 2 + 2) in
+  let proto = Cstructs.get_uint8     inner (1 + 1 + 2 + 2 + 2 + 1) in
+  let src   = Cstructs.BE.get_uint32 inner (1 + 1 + 2 + 2 + 2 + 1 + 1 + 2)
+              |> Ipaddr.V4.of_int32 in
+  let dst   = Cstructs.BE.get_uint32 inner (1 + 1 + 2 + 2 + 2 + 1 + 1 + 2 + 4)
+              |> Ipaddr.V4.of_int32 in
+  let dnf = ((off lsr 8) land 0x40) <> 0 in
+  let ihl = vihl land 0xf in
+  let raw = Cstructs.to_cstruct inner in
+  need_space_for inner (4 * ihl) "IP options"
+  >>= fun () ->
+  let after_header = Cstructs.shift inner (4 * ihl) in
+  (* Trim the packet to the size given in the length field. Note the received
+     data can be truncated too. *)
+  let inner = Cstructs.sub after_header 0 (min (len - 4 * ihl) (Cstructs.len after_header)) in
+  ( match proto with
+  | 1 ->
+    let raw = Cstructs.to_cstruct inner in
+    need_space_for inner 8 "ICMP message"
+    >>= fun () ->
+    let ty     = Cstructs.get_uint8     inner 0 in
+    let code   = Cstructs.get_uint8     inner 1 in
+    let _csum   = Cstructs.BE.get_uint16 inner 2 in
+    ( match ty with
+      | 0 | 8 ->
+        let id     = Cstructs.BE.get_uint16 inner 4 in
+        let seq    = Cstructs.BE.get_uint16 inner 6 in
+        let payload = Cstructs.shift         inner 8 |> Cstructs.to_cstruct in
+        Ok (Icmp { ty; code; raw; icmp = Echo { id; seq; payload } })
+      | 11 ->
+        let nested_ip = Cstructs.shift inner 8 in
+        let ipv4 = ipv4 nested_ip in (* truncated so might not parse correctly *)
+        Ok (Icmp { ty; code; raw; icmp = Time_exceeded { ipv4 }})
+      | _ ->
+        Ok (Icmp { ty; code; raw; icmp = Unknown_icmp })
+    )
+  | 6 ->
+    need_space_for inner 14 "TCP header"
+    >>= fun () ->
+    let src     = Cstructs.BE.get_uint16 inner 0 in
+    let dst     = Cstructs.BE.get_uint16 inner 2 in
+    let offres  = Cstructs.get_uint8     inner (2 + 2 + 4 + 4) in
+    let flags   = Cstructs.get_uint8     inner (2 + 2 + 4 + 4 + 1) in
+    need_space_for inner ((offres lsr 4) * 4) "TCP options"
+    >>= fun () ->
+    let payload = Cstructs.shift         inner ((offres lsr 4) * 4)
+                  |> Cstructs.to_cstruct in
+    let syn = (flags land (1 lsl 1)) > 0 in
+    Ok (Tcp { src; dst; syn; raw = Cstructs.to_cstruct inner;
+              payload = Payload payload })
+  | 17 ->
+    need_space_for inner 8 "UDP header"
+    >>= fun () ->
+    let src     = Cstructs.BE.get_uint16 inner 0 in
+    let dst     = Cstructs.BE.get_uint16 inner 2 in
+    let len     = Cstructs.BE.get_uint16 inner 4 in
+    let payload = Cstructs.shift         inner 8 |> Cstructs.to_cstruct in
+    let len = len - 8 in (* subtract header length *)
+    Ok (Udp { src; dst; len; payload = Payload payload })
+  | _ ->
+    Ok Unknown )
+  >>= fun payload ->
+  Ok ({ src; dst; dnf; ihl; ttl; raw; payload })
 
 let parse bufs =
   try
@@ -40,61 +126,9 @@ let parse bufs =
       let inner = Cstructs.shift bufs 14 in
       ( match ethertype with
       | 0x0800 ->
-        need_space_for inner 16 "IP datagram"
-        >>= fun () ->
-        let vihl  = Cstructs.get_uint8     inner 0 in
-        let len   = Cstructs.BE.get_uint16 inner (1 + 1) in
-        let off   = Cstructs.BE.get_uint16 inner (1 + 1 + 2 + 2) in
-        let ttl   = Cstructs.get_uint8     inner (1 + 1 + 2 + 2 + 2) in
-        let proto = Cstructs.get_uint8     inner (1 + 1 + 2 + 2 + 2 + 1) in
-        let src   = Cstructs.BE.get_uint32 inner (1 + 1 + 2 + 2 + 2 + 1 + 1 + 2)
-                    |> Ipaddr.V4.of_int32 in
-        let dst   = Cstructs.BE.get_uint32 inner (1 + 1 + 2 + 2 + 2 + 1 + 1 + 2 + 4)
-                    |> Ipaddr.V4.of_int32 in
-        let dnf = ((off lsr 8) land 0x40) <> 0 in
-        let ihl = vihl land 0xf in
-        let raw = Cstructs.to_cstruct inner in
-        need_space_for inner (4 * ihl) "IP options"
-        >>= fun () ->
-        let inner = Cstructs.sub inner (4 * ihl) (len - 4 * ihl) in
-        ( match proto with
-        | 1 ->
-          need_space_for inner 8 "ICMP message"
-          >>= fun () ->
-          let ty     = Cstructs.get_uint8     inner 0 in
-          let code   = Cstructs.get_uint8     inner 1 in
-          let _csum   = Cstructs.BE.get_uint16 inner 2 in
-          let id     = Cstructs.BE.get_uint16 inner 4 in
-          let seq    = Cstructs.BE.get_uint16 inner 6 in
-          let payload = Cstructs.shift         inner 8 |> Cstructs.to_cstruct in
-          Ok (Icmp { raw; ty; code; id; seq; payload = Payload payload })
-        | 6 ->
-          need_space_for inner 14 "TCP header"
-          >>= fun () ->
-          let src     = Cstructs.BE.get_uint16 inner 0 in
-          let dst     = Cstructs.BE.get_uint16 inner 2 in
-          let offres  = Cstructs.get_uint8     inner (2 + 2 + 4 + 4) in
-          let flags   = Cstructs.get_uint8     inner (2 + 2 + 4 + 4 + 1) in
-          need_space_for inner ((offres lsr 4) * 4) "TCP options"
-          >>= fun () ->
-          let payload = Cstructs.shift         inner ((offres lsr 4) * 4)
-                        |> Cstructs.to_cstruct in
-          let syn = (flags land (1 lsl 1)) > 0 in
-          Ok (Tcp { src; dst; syn; raw = Cstructs.to_cstruct inner;
-                    payload = Payload payload })
-        | 17 ->
-          need_space_for inner 8 "UDP header"
-          >>= fun () ->
-          let src     = Cstructs.BE.get_uint16 inner 0 in
-          let dst     = Cstructs.BE.get_uint16 inner 2 in
-          let len     = Cstructs.BE.get_uint16 inner 4 in
-          let payload = Cstructs.shift         inner 8 |> Cstructs.to_cstruct in
-          let len = len - 8 in (* subtract header length *)
-          Ok (Udp { src; dst; len; payload = Payload payload })
-        | _ ->
-          Ok Unknown )
-        >>= fun payload ->
-        Ok (Ipv4 { src; dst; dnf; ihl; ttl; raw; payload })
+        ( match ipv4 inner with
+          | Error x -> Error x
+          | Ok ipv4 -> Ok (Ipv4 ipv4) )
       | 0x0806 ->
         need_space_for inner 2 "ARP header"
         >>= fun () ->

--- a/src/hostnet/frame.mli
+++ b/src/hostnet/frame.mli
@@ -4,7 +4,7 @@ type t =
   | Icmp:     { ty: int; code: int; seq: int; id: int;
                 raw: Cstruct.t; payload: t } -> t
   | Ipv4:     { src: Ipaddr.V4.t; dst: Ipaddr.V4.t; dnf: bool; ihl: int;
-                raw: Cstruct.t; payload: t } -> t
+                ttl: int; raw: Cstruct.t; payload: t } -> t
   | Udp:      { src: int; dst: int; len: int; payload: t } -> t
   | Tcp:      { src: int; dst: int; syn: bool; raw: Cstruct.t; payload: t } -> t
   | Payload:  Cstruct.t -> t

--- a/src/hostnet/frame.mli
+++ b/src/hostnet/frame.mli
@@ -1,7 +1,8 @@
 type icmp =
   | Echo:     { seq: int; id: int; payload: Cstruct.t } -> icmp
   | Time_exceeded: { ipv4: (ipv4, [ `Msg of string ]) result } -> icmp
-  | Unknown_icmp: icmp
+  | Destination_unreachable: { ipv4: (ipv4, [ `Msg of string ]) result } -> icmp
+  | Unknown_icmp: { ty: int } -> icmp
 
 and ipv4 = {
   src: Ipaddr.V4.t; dst: Ipaddr.V4.t;

--- a/src/hostnet/frame.mli
+++ b/src/hostnet/frame.mli
@@ -1,14 +1,26 @@
-type t =
+type icmp =
+  | Echo:     { seq: int; id: int; payload: Cstruct.t } -> icmp
+  | Time_exceeded: { ipv4: (ipv4, [ `Msg of string ]) result } -> icmp
+  | Unknown_icmp: icmp
+
+and ipv4 = {
+  src: Ipaddr.V4.t; dst: Ipaddr.V4.t;
+  dnf: bool; ihl: int;
+  ttl: int; raw: Cstruct.t; payload: t
+}
+
+and t =
   | Ethernet: { src: Macaddr.t; dst: Macaddr.t; payload: t } -> t
   | Arp:      { op: [ `Request | `Reply | `Unknown ] } -> t
-  | Icmp:     { ty: int; code: int; seq: int; id: int;
-                raw: Cstruct.t; payload: t } -> t
-  | Ipv4:     { src: Ipaddr.V4.t; dst: Ipaddr.V4.t; dnf: bool; ihl: int;
-                ttl: int; raw: Cstruct.t; payload: t } -> t
+  | Icmp:     { ty: int; code: int; raw: Cstruct.t; icmp: icmp } -> t
+  | Ipv4:     ipv4 -> t
   | Udp:      { src: int; dst: int; len: int; payload: t } -> t
   | Tcp:      { src: int; dst: int; syn: bool; raw: Cstruct.t; payload: t } -> t
   | Payload:  Cstruct.t -> t
   | Unknown:  t
+
+val ipv4: Cstructs.t -> (ipv4, [ `Msg of string ]) result
+(** [ipv4 buffers] parses the IPv4 frame in [buffers] *)
 
 val parse: Cstructs.t -> (t, [ `Msg of string]) result
 (** [parse buffers] parses the frame in [buffers] *)

--- a/src/hostnet/frame.mli
+++ b/src/hostnet/frame.mli
@@ -14,7 +14,7 @@ and t =
   | Arp:      { op: [ `Request | `Reply | `Unknown ] } -> t
   | Icmp:     { ty: int; code: int; raw: Cstruct.t; icmp: icmp } -> t
   | Ipv4:     ipv4 -> t
-  | Udp:      { src: int; dst: int; len: int; payload: t } -> t
+  | Udp:      { src: int; dst: int; len: int; raw: Cstruct.t; payload: t } -> t
   | Tcp:      { src: int; dst: int; syn: bool; raw: Cstruct.t; payload: t } -> t
   | Payload:  Cstruct.t -> t
   | Unknown:  t

--- a/src/hostnet/hostnet_icmp.mli
+++ b/src/hostnet/hostnet_icmp.mli
@@ -34,7 +34,7 @@ module Make
   (** Register a reply callback which will be used to send datagrams to the
       NAT client. *)
 
-  val input: t:t -> datagram:datagram -> unit -> unit Lwt.t
+  val input: t:t -> datagram:datagram -> ttl:int -> unit -> unit Lwt.t
   (** Process an incoming datagram, forwarding it over the Sockets implementation
       and set up a listening rule to catch replies. *)
 

--- a/src/hostnet/hostnet_udp.ml
+++ b/src/hostnet/hostnet_udp.ml
@@ -121,7 +121,7 @@ struct
       Lwt.return ()
     | true -> loop t server d buf
 
-  let input ~t ~datagram () =
+  let input ~t ~datagram ~ttl () =
     let d = description datagram in
     (if Hashtbl.mem t.table datagram.src then begin
         Lwt.return (Some (Hashtbl.find t.table datagram.src))
@@ -151,7 +151,7 @@ struct
     | None -> Lwt.return ()
     | Some flow ->
       Lwt.catch (fun () ->
-          Udp.sendto flow.server datagram.dst datagram.payload >|= fun () ->
+          Udp.sendto flow.server datagram.dst ~ttl datagram.payload >|= fun () ->
           flow.last_use <- Clock.elapsed_ns t.clock;
         ) (fun e ->
           Log.err (fun f ->

--- a/src/hostnet/hostnet_udp.mli
+++ b/src/hostnet/hostnet_udp.mli
@@ -31,7 +31,7 @@ sig
   (** Register a reply callback which will be used to send datagrams to the
       NAT client. *)
 
-  val input: t:t -> datagram:datagram -> unit -> unit Lwt.t
+  val input: t:t -> datagram:datagram -> ttl:int -> unit -> unit Lwt.t
   (** Process an incoming datagram, forwarding it over the Sockets implementation
       and set up a listening rule to catch replies. *)
 

--- a/src/hostnet/hostnet_udp.mli
+++ b/src/hostnet/hostnet_udp.mli
@@ -38,3 +38,6 @@ sig
   val get_nat_table_size: t -> int
   (** Return the current number of allocated NAT table entries *)
 end
+
+val external_to_internal: (int, address) Hashtbl.t
+(** A mapping of external (host) port to internal address *)

--- a/src/hostnet/sig.ml
+++ b/src/hostnet/sig.ml
@@ -91,7 +91,7 @@ module type SOCKETS = sig
 
       val recvfrom: server -> Cstruct.t -> (int * address) Lwt.t
 
-      val sendto: server -> address -> Cstruct.t -> unit Lwt.t
+      val sendto: server -> address -> ?ttl:int -> Cstruct.t -> unit Lwt.t
     end
   end
   module Stream: sig

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -609,14 +609,14 @@ struct
     let input_ipv4 t ipv4 = match ipv4 with
 
     (* Respond to ICMP *)
-    | Ipv4 { src; dst; payload = Icmp { ty; code; seq; id; payload = Payload p; _ }; _ } ->
+    | Ipv4 { src; dst; ttl; payload = Icmp { ty; code; seq; id; payload = Payload p; _ }; _ } ->
       let datagram = {
         Hostnet_icmp.src = src; dst = dst;
         ty; code; seq; id; payload = p
       } in
       ( match t.icmp_nat with
         | Some icmp_nat ->
-          Icmp_nat.input ~t:icmp_nat ~datagram ()
+          Icmp_nat.input ~t:icmp_nat ~datagram ~ttl ()
           >|= ok
         | None ->
           Lwt.return (Ok ()) )

--- a/src/hostnet/utils.ml
+++ b/src/hostnet/utils.ml
@@ -5,3 +5,4 @@ let somaxconn = ref (get_SOMAXCONN ())
 
 external rtlGenRandom: int -> bytes option = "stub_RtlGenRandom"
 
+external setSocketTTL: Unix.file_descr -> int -> unit = "stub_setSocketTTL"

--- a/src/hostnet/utils.mli
+++ b/src/hostnet/utils.mli
@@ -4,3 +4,6 @@ val somaxconn: int ref (* can be overriden by the command-line *)
 val rtlGenRandom: int -> bytes option
 (** [rtlGenRandom len] returns [len] bytes of secure random data on Windows.
     Returns None if called on non-Windows platforms *)
+
+val setSocketTTL: Unix.file_descr -> int -> unit
+(** [setSocketTTL s ttl] sets the TTL on the socket [s] to [ttl] *)


### PR DESCRIPTION
This PR fixes ICMP and UDP traceroute (on Mac) by:

- setting the TTL on outgoing ICMP and UDP
- forwarding ICMP Destination unreachable and TTL exceeded messages

On windows we don't receive the ICMP messages for an unknown reason.

Fixes #193 
Fixes #194 