### PR TITLE
go: use uint16 for ports

### DIFF
--- a/go/pkg/vpnkit/port.go
+++ b/go/pkg/vpnkit/port.go
@@ -18,14 +18,14 @@ type Port struct {
 	client  *datakit.Client
 	proto   string
 	outIP   net.IP
-	outPort int16
+	outPort uint16
 	inIP    net.IP
-	inPort  int16
+	inPort  uint16
 	handle  *datakit.File
 }
 
 // NewPort constructs an instance of Port
-func NewPort(connection *Connection, proto string, outIP net.IP, outPort int16, inIP net.IP, inPort int16) *Port {
+func NewPort(connection *Connection, proto string, outIP net.IP, outPort uint16, inIP net.IP, inPort uint16) *Port {
 	return &Port{connection.client, proto, outIP, outPort, inIP, inPort, nil}
 }
 
@@ -69,20 +69,20 @@ func parse(name string) (*Port, error) {
 	}
 	outProto := bits[0]
 	outIP := net.ParseIP(bits[1])
-	outPort, err := strconv.ParseInt(bits[2], 10, 16)
+	outPort, err := strconv.ParseUint(bits[2], 10, 16)
 	if err != nil {
 		return nil, err
 	}
 	inProto := bits[3]
 	inIP := net.ParseIP(bits[4])
-	inPort, err := strconv.ParseInt(bits[5], 10, 16)
+	inPort, err := strconv.ParseUint(bits[5], 10, 16)
 	if err != nil {
 		return nil, err
 	}
 	if outProto != inProto {
 		return nil, errors.New("Failed to parse port: external proto is " + outProto + " but internal proto is " + inProto)
 	}
-	return &Port{nil, outProto, outIP, int16(outPort), inIP, int16(inPort), nil}, nil
+	return &Port{nil, outProto, outIP, uint16(outPort), inIP, uint16(inPort), nil}, nil
 }
 
 // Expose asks vpnkit to expose the port
@@ -183,7 +183,7 @@ func (p *Port) OutIP() net.IP {
 }
 
 // OutPort returns the public port number
-func (p *Port) OutPort() int16 {
+func (p *Port) OutPort() uint16 {
 	return p.outPort
 }
 
@@ -193,7 +193,7 @@ func (p *Port) InIP() net.IP {
 }
 
 // InPort returns the private port number
-func (p *Port) InPort() int16 {
+func (p *Port) InPort() uint16 {
 	return p.inPort
 }
 

--- a/go/pkg/vpnkit/port_test.go
+++ b/go/pkg/vpnkit/port_test.go
@@ -1,0 +1,19 @@
+package vpnkit
+
+import "testing"
+
+func TestParseRoundTrip(t *testing.T) {
+	specs := []string{
+		"tcp:192.168.0.1:8080:tcp:192.168.0.2:8081",
+		"tcp:192.168.0.1:8080:tcp:192.168.0.2:65000",
+	}
+	for _, spec := range specs {
+		port, err := parse(spec)
+		if err != nil {
+			t.Fatalf("Cannot parse port spec: %s", err)
+		}
+		if spec != port.spec() {
+			t.Fatalf("Expected %s but has %s", spec, port.spec())
+		}
+	}
+}


### PR DESCRIPTION
Using int16 caused large ports to be negative.

For example, the original port was 44134.
```
$ ./vpnkit-list-ports
2017/11/07 11:26:02 Dialling unix /Users/guillaumerose/Library/Containers/com.docker.docker/Data/s51
tcp forward from 0.0.0.0:-21402 to 10.111.24.47:-21402
```
