### PR TITLE
Add command-line `--lowest-ip`

### DIFF
--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -341,7 +341,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       socket_url port_control_url introspection_url diagnostics_url
       max_connections vsock_path db_path db_branch dns http hosts host_names
       listen_backlog port_max_idle_time debug
-      server_macaddr domain allowed_bind_addresses gateway_ip highest_ip
+      server_macaddr domain allowed_bind_addresses gateway_ip lowest_ip highest_ip
       mtu log_destination
     =
     let level =
@@ -359,6 +359,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
     let server_macaddr = Macaddr.of_string_exn server_macaddr in
     let allowed_bind_addresses = Configuration.Parse.ipv4_list [] allowed_bind_addresses in
     let gateway_ip = Ipaddr.V4.of_string_exn gateway_ip in
+    let lowest_ip = Ipaddr.V4.of_string_exn lowest_ip in
     let highest_ip = Ipaddr.V4.of_string_exn highest_ip in
     let configuration = {
       Configuration.default with
@@ -373,6 +374,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       domain;
       allowed_bind_addresses;
       gateway_ip;
+      lowest_ip;
       highest_ip;
       mtu;
     } in
@@ -559,6 +561,14 @@ let gateway_ip =
   in
   Arg.(value & opt string (Ipaddr.V4.to_string Configuration.default_gateway_ip) doc)
 
+let lowest_ip =
+  let doc =
+    Arg.info ~doc:
+      "Lowest IP address to hand out by DHCP"
+      [ "peer-ip" ]
+  in
+  Arg.(value & opt string (Ipaddr.V4.to_string Configuration.default_lowest_ip) doc)
+
 let highest_ip =
   let doc =
     Arg.info ~doc:
@@ -587,7 +597,7 @@ let command =
         $ max_connections $ vsock_path $ db_path $ db_branch $ dns $ http $ hosts
         $ host_names $ listen_backlog $ port_max_idle_time $ debug
         $ server_macaddr $ domain $ allowed_bind_addresses $ gateway_ip
-        $ highest_ip $ mtu $ Logging.log_destination),
+        $ lowest_ip $ highest_ip $ mtu $ Logging.log_destination),
   Term.info (Filename.basename Sys.argv.(0)) ~version:"%%VERSION%%" ~doc ~man
 
 let () =

--- a/src/hostnet/configuration.ml
+++ b/src/hostnet/configuration.ml
@@ -15,7 +15,7 @@ type t = {
   allowed_bind_addresses: Ipaddr.V4.t list;
   gateway_ip: Ipaddr.V4.t;
   (* TODO: remove this from the record since it is not constant across all clients *)
-  peer: Ipaddr.V4.t;
+  lowest_ip: Ipaddr.V4.t;
   highest_ip: Ipaddr.V4.t;
   extra_dns: Ipaddr.V4.t list;
   mtu: int;
@@ -26,7 +26,7 @@ type t = {
 }
 
 let to_string t =
-  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns_path = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; gateway_ip = %s; peer = %s; highest_ip = %s; extra_dns = %s; mtu = %d; http_intercept = %s; http_intercept_path = %s; port_max_idle_time = %s; host_names = %s"
+  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns_path = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; gateway_ip = %s; lowest_ip = %s; highest_ip = %s; extra_dns = %s; mtu = %d; http_intercept = %s; http_intercept_path = %s; port_max_idle_time = %s; host_names = %s"
     (Macaddr.to_string t.server_macaddr)
     (match t.max_connections with None -> "None" | Some x -> string_of_int x)
     (match t.dns_path with None -> "None" | Some x -> x)
@@ -35,7 +35,7 @@ let to_string t =
     t.domain
     (String.concat ", " (List.map Ipaddr.V4.to_string t.allowed_bind_addresses))
     (Ipaddr.V4.to_string t.gateway_ip)
-    (Ipaddr.V4.to_string t.peer)
+    (Ipaddr.V4.to_string t.lowest_ip)
     (Ipaddr.V4.to_string t.highest_ip)
     (String.concat ", " (List.map Ipaddr.V4.to_string t.extra_dns))
     t.mtu
@@ -47,7 +47,7 @@ let to_string t =
 let no_dns_servers =
   Dns_forward.Config.({ servers = Server.Set.empty; search = []; assume_offline_after_drops = None })
 
-let default_peer = Ipaddr.V4.of_string_exn "192.168.65.2"
+let default_lowest_ip = Ipaddr.V4.of_string_exn "192.168.65.2"
 let default_gateway_ip = Ipaddr.V4.of_string_exn "192.168.65.1"
 let default_highest_ip = Ipaddr.V4.of_string_exn "192.168.65.254"
 let default_extra_dns = []
@@ -71,7 +71,7 @@ let default = {
   domain = default_domain;
   allowed_bind_addresses = [];
   gateway_ip = default_gateway_ip;
-  peer = default_peer;
+  lowest_ip = default_lowest_ip;
   highest_ip = default_highest_ip;
   extra_dns = default_extra_dns;
   mtu = default_mtu;

--- a/src/hostnet/dhcp.ml
+++ b/src/hostnet/dhcp.ml
@@ -40,12 +40,12 @@ module Make (Clock: Mirage_clock_lwt.MCLOCK) (Netif: Mirage_net_lwt.S) = struct
        resolved in the future *)
     let low_ip, high_ip =
       let open Ipaddr.V4 in
-      let all_static_ips = c.Configuration.gateway_ip :: c.Configuration.peer :: c.Configuration.extra_dns in
+      let all_static_ips = c.Configuration.gateway_ip :: c.Configuration.lowest_ip :: c.Configuration.extra_dns in
       let highest = maximum_ip all_static_ips in
       let i32 = to_int32 highest in
       of_int32 @@ Int32.succ i32, of_int32 @@ Int32.succ @@ Int32.succ i32 in
     let ip_list = [ c.Configuration.gateway_ip; low_ip; high_ip; c.Configuration.highest_ip ] in
-    let prefix = smallest_prefix c.Configuration.peer ip_list 32 in
+    let prefix = smallest_prefix c.Configuration.lowest_ip ip_list 32 in
     let domain_search = c.dns.Dns_forward.Config.search in
 
     let get_dhcp_configuration () : Dhcp_server.Config.t =
@@ -83,7 +83,7 @@ module Make (Clock: Mirage_clock_lwt.MCLOCK) (Netif: Mirage_net_lwt.S) = struct
         mac_addr = c.Configuration.server_macaddr;
         network = prefix;
         (* FIXME: this needs https://github.com/haesbaert/charrua-core/pull/31 *)
-        range = Some (c.Configuration.peer, c.Configuration.peer); (* allow one dynamic client *)
+        range = Some (c.Configuration.lowest_ip, c.Configuration.lowest_ip); (* allow one dynamic client *)
       } in
     { clock; netif; server_macaddr = c.Configuration.server_macaddr; get_dhcp_configuration }
 

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -849,7 +849,7 @@ struct
 
     (* Serve a static ARP table *)
     let local_arp_table = [
-      c.Configuration.peer, client_macaddr;
+      c.Configuration.lowest_ip, client_macaddr;
       c.Configuration.gateway_ip, c.Configuration.server_macaddr;
     ] @ (List.map (fun ip -> ip, c.Configuration.server_macaddr) c.Configuration.extra_dns) in
     Global_arp_ethif.connect switch
@@ -1232,13 +1232,13 @@ struct
     Active_config.map Configuration.Parse.int string_max_connections
     >>= fun max_connections ->
     on_change max_connections (fun max_connections -> update (fun c -> { c with max_connections }));
-    let peer_ips_path = driver @ [ "slirp"; "docker" ] in
-    Config.string config ~default:"" peer_ips_path
-    >>= fun string_peer_ips ->
-    Active_config.map (Configuration.Parse.ipv4 Configuration.default_peer)
-      string_peer_ips
-    >>= fun peer_ips ->
-    on_change peer_ips (fun peer -> update (fun c -> { c with peer }));
+    let lowest_ips_path = driver @ [ "slirp"; "docker" ] in
+    Config.string config ~default:"" lowest_ips_path
+    >>= fun string_lowest_ips ->
+    Active_config.map (Configuration.Parse.ipv4 Configuration.default_lowest_ip)
+      string_lowest_ips
+    >>= fun lowest_ips ->
+    on_change lowest_ips (fun lowest_ip -> update (fun c -> { c with lowest_ip }));
     let host_ips_path = driver @ [ "slirp"; "host" ] in
     Config.string config ~default:"" host_ips_path
     >>= fun string_host_ips ->
@@ -1361,7 +1361,7 @@ struct
                       f "Client requested IP %s" (Ipaddr.V4.to_string preferred_ip));
                   let preferred_ip_int32 = Ipaddr.V4.to_int32 preferred_ip in
                   let highest_ip_int32 = Ipaddr.V4.to_int32 t.configuration.Configuration.highest_ip in
-                  let lowest_ip_int32 = Ipaddr.V4.to_int32 t.configuration.Configuration.peer in
+                  let lowest_ip_int32 = Ipaddr.V4.to_int32 t.configuration.Configuration.lowest_ip in
                   if (preferred_ip_int32 > highest_ip_int32)
                   || (preferred_ip_int32 <  lowest_ip_int32)
                   then begin
@@ -1392,7 +1392,7 @@ struct
             in
 
             let client_ip = match preferred_ip with
-            | None    -> next_unique_ip t.configuration.Configuration.peer
+            | None    -> next_unique_ip t.configuration.Configuration.lowest_ip
             | Some ip -> ip
             in
 
@@ -1430,7 +1430,7 @@ struct
       get_client_ip_id t client_uuid
       >>= fun (client_ip, vnet_client_id) ->
       connect x t.vnet_switch vnet_client_id
-        client_macaddr { t.configuration with peer = client_ip }
+        client_macaddr { t.configuration with lowest_ip = client_ip }
         t.global_arp_table t.clock
     end
 


### PR DESCRIPTION
Previously it was possible to configure the `--gateway-ip` and the
(DHCP) `--highest-ip` but not the `--lowest-ip`. This patch completes
the IP address command-line arguments.

Note the configuration binding `peer` is renamed to `lowest_ip` for symmetry
with `highest_ip`

Signed-off-by: David Scott <dave.scott@docker.com>