### PR TITLE
Support a DHCP configuration file

### DIFF
--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -342,7 +342,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       max_connections vsock_path db_path db_branch dns http hosts host_names
       listen_backlog port_max_idle_time debug
       server_macaddr domain allowed_bind_addresses gateway_ip lowest_ip highest_ip
-      mtu log_destination
+      dhcp_json_path mtu log_destination
     =
     let level =
       let env_debug =
@@ -376,6 +376,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       gateway_ip;
       lowest_ip;
       highest_ip;
+      dhcp_json_path;
       mtu;
     } in
     match socket_url with
@@ -541,7 +542,7 @@ let server_macaddr =
 
 let domain =
   let doc = "Domain name to include in DHCP offers" in
-  Arg.(value & opt string Configuration.default_domain & info [ "domain" ] ~doc)
+  Arg.(value & opt (some string) None & info [ "domain" ] ~doc)
 
 let allowed_bind_addresses =
   let doc =
@@ -577,6 +578,14 @@ let highest_ip =
   in
   Arg.(value & opt string (Ipaddr.V4.to_string Configuration.default_highest_ip) doc)
 
+let dhcp_json_path =
+  let doc =
+    Arg.info ~doc:
+      "Path of DHCP configuration file"
+      [ "dhcp-path" ]
+  in
+  Arg.(value & opt (some file) None doc)
+
 let mtu =
   let doc =
     Arg.info ~doc:
@@ -597,7 +606,7 @@ let command =
         $ max_connections $ vsock_path $ db_path $ db_branch $ dns $ http $ hosts
         $ host_names $ listen_backlog $ port_max_idle_time $ debug
         $ server_macaddr $ domain $ allowed_bind_addresses $ gateway_ip
-        $ lowest_ip $ highest_ip $ mtu $ Logging.log_destination),
+        $ lowest_ip $ highest_ip $ dhcp_json_path $ mtu $ Logging.log_destination),
   Term.info (Filename.basename Sys.argv.(0)) ~version:"%%VERSION%%" ~doc ~man
 
 let () =

--- a/src/hostnet/hostnet_dhcp.mli
+++ b/src/hostnet/hostnet_dhcp.mli
@@ -2,6 +2,10 @@ module Make  (Clock: Mirage_clock_lwt.MCLOCK) (Netif: Mirage_net_lwt.S): sig
   type t
 
   val make: configuration:Configuration.t -> Clock.t -> Netif.t -> t
+  (** Create a DHCP server. *)
 
   val callback: t -> Cstruct.t -> unit Lwt.t
 end
+
+val update_global_configuration: Configuration.Dhcp_configuration.t option -> unit
+(** Update the global DHCP configuration: gateway IP, search domains etc *)

--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -145,7 +145,7 @@ let config =
   let configuration = {
     Configuration.default with
     extra_dns = extra_dns_ip;
-    domain = "local";
+    domain = Some "local";
   } in
   Mclock.connect () >>= fun clock ->
   let vnet = Vnet.create () in


### PR DESCRIPTION
This PR adds the command-line option `--dhcp-path <filename>` which names a json-formatted configuration file containing some of the DHCP settings. Eventually it should contain them all, but for now it has:

```
    {"searchDomains":[],"domainName":"cam.docker.com"}
```

The domain name is taken from the command-line `--domain` if present, otherwise it uses this file, failing that it uses `localdomain` as a default. The `--domain` command-line is now deprecated and will be removed.

The search domains are taken from this new file if present, otherwise it uses information in the `--dns` configuration file.
 