### PR TITLE
travis: remove docker-ce version pin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install: # update to 17.05 to get multistage builds
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
   - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) edge"
   - sudo apt-get update
-  - sudo apt-get -y install docker-ce=17.05.0~ce-0~ubuntu-trusty
+  - sudo apt-get -y install docker-ce
 
 script:
   - cd go && make build-in-container


### PR DESCRIPTION
The most recent released docker-ce is 17.11, we need at least 17.05
but this version is now gone from the upstream repo.

Signed-off-by: David Scott <dave.scott@docker.com>