### PR TITLE
Add more HTTP proxy modes

### DIFF
--- a/src/hostnet/hostnet_http.ml
+++ b/src/hostnet/hostnet_http.ml
@@ -601,13 +601,17 @@ module Make
     in
     Lwt.return listeners
 
-  let handle ~dst:(ip, port) ~t =
+  let transparent_proxy_handler ~dst:(ip, port) ~t =
     match port, t.http, t.https with
     | 80, Some h, _ -> Some (http ~dst:ip ~t h)
     | 443, _, Some h ->
       if Exclude.matches ip None t.exclude
       then None
       else Some (https ~dst:ip h)
+    | _, _, _ -> None
+
+  let explicit_proxy_handler ~dst:(ip, port) ~t =
+    match port, t.http, t.https with
     | 3128, Some h, _ -> Some (tcp ~dst:(ip, port) h)
     | 3128, None, _ -> Some (proxy ())
     | _, _, _ -> None

--- a/src/hostnet/hostnet_http.mli
+++ b/src/hostnet/hostnet_http.mli
@@ -34,7 +34,15 @@ sig
   val to_json: t -> Ezjsonm.t
   (** [to_json t] encodes [t] into json *)
 
-  val handle: dst:(Ipaddr.V4.t * int) -> t:t ->
+  val transparent_proxy_handler: dst:(Ipaddr.V4.t * int) -> t:t ->
     (int -> (Tcp.flow -> unit Lwt.t) option) Lwt.t option
+  (** Intercept outgoing HTTP flows and redirect to the upstream proxy
+      if one is defined. *)
+
+  val explicit_proxy_handler: dst:(Ipaddr.V4.t * int) -> t:t ->
+    (int -> (Tcp.flow -> unit Lwt.t) option) Lwt.t option
+  (** Intercept outgoing HTTP proxy flows and if an upstream proxy is
+      defined, redirect to it, otherwise implement the proxy function
+      ourselves. *)
 
 end

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -103,9 +103,9 @@ module Incoming = struct
   module Response = Cohttp.Response.Make(IO)
 end
 
-let send_http_request stack ip request =
+let send_http_request stack (ip, port) request =
   let open Slirp_stack in
-  Client.TCPV4.create_connection (Client.tcpv4 stack) (ip, 80)
+  Client.TCPV4.create_connection (Client.tcpv4 stack) (ip, port)
   >>= function
   | Ok flow ->
     Log.info (fun f -> f "Connected to %s:80" (Ipaddr.V4.to_string ip));
@@ -116,7 +116,7 @@ let send_http_request stack ip request =
     Log.err (fun f -> f "Failed to connect to %s:80" (Ipaddr.V4.to_string ip));
     failwith "http_fetch"
 
-let intercept ~pcap request =
+let intercept ~pcap ?(port = 80) request =
   let forwarded, forwarded_u = Lwt.task () in
   Slirp_stack.with_stack ~pcap (fun _ stack ->
       with_server (fun flow ->
@@ -141,7 +141,7 @@ let intercept ~pcap request =
           >>= function
           | Error (`Msg m) -> failwith ("Failed to enable HTTP proxy: " ^ m)
           | Ok () ->
-            send_http_request stack.t (Ipaddr.V4.of_string_exn "127.0.0.1")
+            send_http_request stack.t (Ipaddr.V4.of_string_exn "127.0.0.1", port)
               request
             >>= fun () ->
             Lwt.pick [
@@ -169,6 +169,32 @@ let test_interception () =
     Log.info (fun f ->
         f "proxied  was: %s"
           (Sexplib.Sexp.to_string_hum (Cohttp.Request.sexp_of_t result)));
+    Alcotest.check Alcotest.string "method"
+      (Cohttp.Code.string_of_method request.Cohttp.Request.meth)
+      (Cohttp.Code.string_of_method result.Cohttp.Request.meth);
+    Alcotest.check Alcotest.string "version"
+      (Cohttp.Code.string_of_version request.Cohttp.Request.version)
+      (Cohttp.Code.string_of_version result.Cohttp.Request.version);
+    Lwt.return ()
+  end
+
+(* Test that port 3128 passes through to an upstream proxy *)
+let test_proxy_passthrough () =
+  Host.Main.run begin
+    let request =
+      Cohttp.Request.make
+        (Uri.make ~scheme:"http" ~host:"dave.recoil.org" ~path:"/" ())
+    in
+    intercept ~pcap:"test_proxy_passthrough.pcap" ~port:3128 request >>= fun result ->
+    Log.info (fun f ->
+        f "original was: %s"
+          (Sexplib.Sexp.to_string_hum (Cohttp.Request.sexp_of_t request)));
+    Log.info (fun f ->
+        f "proxied  was: %s"
+          (Sexplib.Sexp.to_string_hum (Cohttp.Request.sexp_of_t result)));
+    Alcotest.check Alcotest.string "resource"
+      request.Cohttp.Request.resource
+      result.Cohttp.Request.resource;
     Alcotest.check Alcotest.string "method"
       (Cohttp.Code.string_of_method request.Cohttp.Request.meth)
       (Cohttp.Code.string_of_method result.Cohttp.Request.meth);
@@ -331,9 +357,198 @@ let test_http_connect () =
       )
   end
 
+  let test_http_proxy_connect () =
+    let forwarded, forwarded_u = Lwt.task () in
+    Host.Main.run begin
+    Slirp_stack.with_stack ~pcap:"test_http_proxy_connect.pcap" (fun _ stack ->
+        with_server (fun flow ->
+            let ic = Incoming.C.create flow in
+            (* read something *)
+            Incoming.C.read_some ~len:5 ic
+            >>= function
+            | Ok `Eof -> failwith "http_proxy_connect: read_some returned Eof"
+            | Error _ -> failwith "http_proxy_connect: read_some returned Error"
+            | Ok (`Data buf) ->
+              let txt = Cstruct.to_string buf in
+              Alcotest.check Alcotest.string "message" "hello" txt;
+              let response = "there" in
+              (* write something *)
+              Incoming.C.write_string ic response 0 (String.length response);
+              Incoming.C.flush ic
+              >>= function
+              | Error _ -> failwith "http_proxy_connect: flush returned error"
+              | Ok ()   ->
+                Lwt.wakeup_later forwarded_u ();
+                Lwt.return_unit
+          ) (fun server ->
+            let json = Ezjsonm.from_string "{ }" in
+            Slirp_stack.Slirp_stack.Debug.update_http_json json ()
+            >>= function
+            | Error (`Msg m) -> failwith ("Failed to enable HTTP proxy: " ^ m)
+            | Ok () ->
+              let open Slirp_stack in
+              Client.TCPV4.create_connection (Client.tcpv4 stack.t) (Ipaddr.V4.localhost, 3128)
+              >>= function
+              | Error _ ->
+                Log.err (fun f -> f "Failed to connect to localhost:3128");
+                failwith "test_proxy_connect: connect failed"
+              | Ok flow ->
+                Log.info (fun f -> f "Connected to localhost:80");
+                let oc = Outgoing.C.create flow in
+                let request =
+                  let connect = Cohttp.Request.make ~meth:`CONNECT (Uri.make ()) in
+                  let resource = Fmt.strf "localhost:%d" server.Server.port in
+                  { connect with Cohttp.Request.resource }
+                in
+                Outgoing.Request.write ~flush:true (fun _writer -> Lwt.return_unit) request oc
+                >>= fun () ->
+                Outgoing.Response.read oc
+                >>= function
+                | `Eof ->
+                  failwith "test_proxy_connect: EOF on HTTP CONNECT"
+                | `Invalid x ->
+                  failwith ("test_proxy_connect: Invalid HTTP response: " ^ x)
+                | `Ok res ->
+                  if res.Cohttp.Response.status <> `OK
+                  then failwith "test_proxy_connect: HTTP CONNECT failed";
+                  let request = "hello" in
+                  Outgoing.C.write_string oc request 0 (String.length request);
+                  Outgoing.C.flush oc
+                  >>= function
+                  | Error _ -> failwith "http_proxy_connect: client flush returned error"
+                  | Ok ()   ->
+                    Outgoing.C.read_some ~len:5 oc
+                    >>= function
+                    | Ok `Eof -> failwith "http_proxy_connect: client read_some returned Eof"
+                    | Error _ -> failwith "http_proxy_connect: client read_some returned Error"
+                    | Ok (`Data buf) ->
+                      let txt = Cstruct.to_string buf in
+                      Alcotest.check Alcotest.string "message" "there" txt;
+                      Lwt.pick [
+                        (Host.Time.sleep_ns (Duration.of_sec 100) >|= fun () ->
+                        `Timeout);
+                        (forwarded >>= fun x -> Lwt.return (`Result x))
+                      ]
+          )
+        >|= function
+        | `Timeout  -> failwith "HTTP interception failed"
+        | `Result x -> x
+      )
+    end
+
+  let test_http_proxy_connect_fail () =
+    Host.Main.run begin
+      Slirp_stack.with_stack ~pcap:"test_http_proxy_connect_fail.pcap" (fun _ stack ->
+        let open Slirp_stack in
+        Client.TCPV4.create_connection (Client.tcpv4 stack.t) (Ipaddr.V4.localhost, 3128)
+        >>= function
+        | Error _ ->
+          Log.err (fun f -> f "Failed to connect to localhost:3128");
+          failwith "test_proxy_connect_fail: connect failed"
+        | Ok flow ->
+          Log.info (fun f -> f "Connected to localhost:80");
+          let oc = Outgoing.C.create flow in
+          let request =
+            let connect = Cohttp.Request.make ~meth:`CONNECT (Uri.make ()) in
+            (* Assume port 25 (SMTP) is free *)
+            let resource = "localhost:25"  in
+            { connect with Cohttp.Request.resource }
+          in
+          Outgoing.Request.write ~flush:true (fun _writer -> Lwt.return_unit) request oc
+          >>= fun () ->
+          Outgoing.Response.read oc
+          >>= function
+          | `Eof ->
+            failwith "test_proxy_connect_fail: EOF on HTTP CONNECT"
+          | `Invalid x ->
+            failwith ("test_proxy_connect_fail: Invalid HTTP response: " ^ x)
+          | `Ok res ->
+            if res.Cohttp.Response.status = `OK
+            then failwith "test_proxy_connect_fail: HTTP CONNECT succeeded unexpectedly";
+            if res.Cohttp.Response.status <> `Service_unavailable
+            then failwith "test_proxy_connect_fail: HTTP CONNECT failed with an unexpected code";
+            Lwt.return_unit
+        )
+    end
+
+  let test_http_proxy_get_dns () =
+    Host.Main.run begin
+      Slirp_stack.with_stack ~pcap:"test_http_proxy_get_dns.pcap" (fun _ stack ->
+        let open Slirp_stack in
+        Client.TCPV4.create_connection (Client.tcpv4 stack.t) (Ipaddr.V4.localhost, 3128)
+        >>= function
+        | Error _ ->
+          Log.err (fun f -> f "Failed to connect to localhost:3128");
+          failwith "test_proxy_get_dns: connect failed"
+        | Ok flow ->
+          Log.info (fun f -> f "Connected to localhost:80");
+          let oc = Outgoing.C.create flow in
+          let host = "does.not.exist.recoil.org" in
+          let request = Cohttp.Request.make ~meth:`GET (Uri.make ~host ()) in
+          Outgoing.Request.write ~flush:true (fun _writer -> Lwt.return_unit) request oc
+          >>= fun () ->
+          Outgoing.Response.read oc
+          >>= function
+          | `Eof ->
+            failwith "test_proxy_get_dns: EOF on HTTP GET"
+          | `Invalid x ->
+            failwith ("test_proxy_get_dns: Invalid HTTP response: " ^ x)
+          | `Ok res ->
+            if res.Cohttp.Response.status = `OK
+            then failwith "test_proxy_get_dns: HTTP GET to non-existent host succeeded unexpectedly";
+            if res.Cohttp.Response.status <> `Service_unavailable
+            then failwith "test_proxy_get_dns: HTTP GET to non-existent host failed with an unexpected code";
+            Lwt.return_unit
+        )
+    end
+
+  let test_http_proxy_get () =
+    Host.Main.run begin
+      Slirp_stack.with_stack ~pcap:"test_http_proxy_get.pcap" (fun _ stack ->
+        let open Slirp_stack in
+        Client.TCPV4.create_connection (Client.tcpv4 stack.t) (Ipaddr.V4.localhost, 3128)
+        >>= function
+        | Error _ ->
+          Log.err (fun f -> f "Failed to connect to localhost:3128");
+          failwith "test_proxy_get: connect failed"
+        | Ok flow ->
+          Log.info (fun f -> f "Connected to localhost:80");
+          let oc = Outgoing.C.create flow in
+          let host = "bark.recoil.org" in
+          let request = Cohttp.Request.make ~meth:`GET (Uri.make ~host ()) in
+          Outgoing.Request.write ~flush:true (fun _writer -> Lwt.return_unit) request oc
+          >>= fun () ->
+          Outgoing.Response.read oc
+          >>= function
+          | `Eof ->
+            failwith "test_proxy_get: EOF on HTTP GET"
+          | `Invalid x ->
+            failwith ("test_proxy_get: Invalid HTTP response: " ^ x)
+          | `Ok res ->
+            if res.Cohttp.Response.status <> `Not_found
+            then failwith "test_proxy_get: HTTP GET failed unexpectedly";
+            Lwt.return_unit
+        )
+    end
+
 let tests = [
   "HTTP: interception",
   [ "", `Quick, test_interception ];
+
+  "HTTP proxy: pass-through to upstream",
+  [ "check that requests are passed through to upstream proxies", `Quick, test_proxy_passthrough ];
+
+  "HTTP proxy: CONNECT",
+  [ "check that HTTP CONNECT requests through the proxy", `Quick, test_http_proxy_connect ];
+
+  "HTTP proxy: CONNECT fails",
+  [ "check that HTTP CONNECT fails if the port is not found", `Quick, test_http_proxy_connect_fail ];
+
+  "HTTP proxy: GET to bad host",
+  [ "check that HTTP GET fails if the DNS doesn't resolve", `Quick, test_http_proxy_get_dns ];
+
+  "HTTP proxy: GET to good host",
+  [ "check that HTTP GET succeeds normally", `Quick, test_http_proxy_get ];
 
   "HTTP: URI",
   [ "check that relative URIs are rewritten", `Quick, test_uri_relative ];

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -514,7 +514,7 @@ let test_http_connect () =
         | Ok flow ->
           Log.info (fun f -> f "Connected to localhost:80");
           let oc = Outgoing.C.create flow in
-          let host = "bark.recoil.org" in
+          let host = "dave.recoil.org" in
           let request = Cohttp.Request.make ~meth:`GET (Uri.make ~host ()) in
           Outgoing.Request.write ~flush:true (fun _writer -> Lwt.return_unit) request oc
           >>= fun () ->
@@ -525,7 +525,7 @@ let test_http_connect () =
           | `Invalid x ->
             failwith ("test_proxy_get: Invalid HTTP response: " ^ x)
           | `Ok res ->
-            if res.Cohttp.Response.status <> `Not_found
+            if res.Cohttp.Response.status <> `OK
             then failwith "test_proxy_get: HTTP GET failed unexpectedly";
             Lwt.return_unit
         )


### PR DESCRIPTION
Previously we only supported a transparent HTTP proxy, where an HTTP client sends a request as normal but this is intercepted by `vpnkit` at the TCP-level, rewritten and redirected to the upstream proxy. One disadvantage of this approach is that DNS resolution is first performed by the client before the TCP connection is created. Some environments do not have working DNS on end user devices -- instead, they restrict DNS resolution to the proxy only. In transparent mode this fails because the TCP connection is never created.

This PR adds regular, non-transparent HTTP proxy support which works irrespective of whether an upstream proxy is defined:

- if there is an upstream proxy defined, then we proxy requests at the TCP level to it
- if there is no upstream proxy, then we rewrite the request, perform the DNS resolution and `connect` to the server ourselves.

The proxy supports `CONNECT` so allows tunnelling of TLS traffic.

This PR includes a set of test cases which check:
- TCP passthrough to an upstream proxy
- URIs sent to an upstream proxy are absolute
- `CONNECT` to a local server
- `CONNECT` to a missing server
- `GET` when the DNS doesn't resolve
- `GET`