### PR TITLE
Mac: make the DNS more scalable

### DIFF
--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -352,6 +352,11 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       if debug || env_debug then Some Logs.Debug else Some Logs.Info in
     Logging.setup log_destination level;
 
+    if Sys.os_type = "Unix" then begin
+      Log.info (fun f -> f "Increasing preemptive thread pool size to 1024 threads");
+      Uwt_preemptive.set_bounds (0, 1024);
+    end;
+
     let host_names = List.map Dns.Name.of_string @@ Astring.String.cuts ~sep:"," host_names in
     let dns_path, resolver = match dns with
     | None -> None, Configuration.default_resolver

--- a/src/hostnet/host.ml
+++ b/src/hostnet/host.ml
@@ -1134,10 +1134,35 @@ module Dns = struct
   let resolve_dnssd question =
     let open Dns.Packet in
     let query name ty =
-      Uwt_preemptive.detach
-        (fun () ->
-           Dnssd.query (Dns.Name.to_string name) ty
-        ) () in
+      let query = Dnssd.LowLevel.query (Dns.Name.to_string name) ty in
+      let socket = Dnssd.LowLevel.socket query in
+      let t, u = Lwt.task () in
+      match Uwt.Poll.start socket [ Uwt.Poll.Readable ]
+        ~cb:(fun _poll events ->
+          match events with
+          | Error error ->
+            Log.err (fun f -> f "Uwt.Poll callback failed with %s" (Uwt.strerror error))
+          | Ok events ->
+            List.iter (fun event ->
+              if event = Uwt.Poll.Readable then Lwt.wakeup_later u ()
+            ) events
+        ) with
+      | Error error ->
+        Log.err (fun f -> f "Uwt.Poll.start failed with %s" (Uwt.strerror error));
+        Lwt.return (Ok [])
+      | Ok poll ->
+        t >>= fun () ->
+        let result = Uwt.Poll.close poll in
+        if not (Uwt.Int_result.is_ok result) then begin
+          let error = Uwt.Int_result.to_error result in
+          Log.err (fun f -> f "Uwt.Poll.close failed with %s" (Uwt.strerror error));
+          Lwt.return (Ok [])
+        end else begin
+          Uwt_preemptive.detach
+            (fun () ->
+              Dnssd.LowLevel.response query
+            ) ()
+        end in
 
     begin match question with
     | { q_class = Q_IN; q_name; _ } when q_name = localhost_local ->


### PR DESCRIPTION
We use the Mac `DNSServiceRef` API to resolve queries. Previously we used the blocking interface and ran in a worker thread pool with `Uwt_preemptive.detach`. This is unfortunate because

- DNS queries take up to 30s to time out, therefore lots of them can be in the waiting-to-fail state
- the maximum size of the thread pool is 4

This PR
- uses the lower-level `DNSServiceRef` API where we can access a file descriptor and use `Uwt.Poll` to wait for it to become `Readable`. We now only need to use `Uwt_preemptive.detach` when actually reading the result, which should be fast.
- increases the size of the thread pool on Unix systems to 1024.

Unfortunately to use the low-level interface we have to recursively resolve CNAMEs ourselves. This code contains a copy of the function from the low-level library, adapted to use the new interface.