### PR TITLE
Separate the localhost proxy from internal services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,8 @@ vpnkit.exe:
 .PHONY: test
 test:
 	jbuilder build --dev src/hostnet_test/main.exe
-	./_build/default/src/hostnet_test/main.exe
+	# One test requires 1026 file descriptors
+	ulimit -n 1500 && ./_build/default/src/hostnet_test/main.exe
 
 .PHONY: OSS-LICENSES
 OSS-LICENSES:

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -37,8 +37,6 @@ opam install $(ls -1 ${OPAM_REPO}/packages/upstream) -y
 OPAMVERBOSE=1 opam install --deps-only -t vpnkit -y
 
 OPAMVERBOSE=1 make
-# One test requires 1026 file descriptors
-ulimit -n 1500
 OPAMVERBOSE=1 make test
 OPAMVERBOSE=1 make artefacts
 OPAMVERBOSE=1 make OSS-LICENSES

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -341,7 +341,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       socket_url port_control_url introspection_url diagnostics_url
       max_connections vsock_path db_path db_branch dns http hosts host_names
       listen_backlog port_max_idle_time debug
-      server_macaddr domain allowed_bind_addresses gateway_ip lowest_ip highest_ip
+      server_macaddr domain allowed_bind_addresses gateway_ip host_ip lowest_ip highest_ip
       dhcp_json_path mtu log_destination
     =
     let level =
@@ -364,6 +364,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
     let server_macaddr = Macaddr.of_string_exn server_macaddr in
     let allowed_bind_addresses = Configuration.Parse.ipv4_list [] allowed_bind_addresses in
     let gateway_ip = Ipaddr.V4.of_string_exn gateway_ip in
+    let host_ip = Ipaddr.V4.of_string_exn host_ip in
     let lowest_ip = Ipaddr.V4.of_string_exn lowest_ip in
     let highest_ip = Ipaddr.V4.of_string_exn highest_ip in
     let configuration = {
@@ -379,6 +380,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       domain;
       allowed_bind_addresses;
       gateway_ip;
+      host_ip;
       lowest_ip;
       highest_ip;
       dhcp_json_path;
@@ -567,6 +569,14 @@ let gateway_ip =
   in
   Arg.(value & opt string (Ipaddr.V4.to_string Configuration.default_gateway_ip) doc)
 
+let host_ip =
+  let doc =
+    Arg.info ~doc:
+      "IP address which represents the host. Connections to this IP will be forwarded to localhost on the host."
+      [ "host-ip" ]
+  in
+  Arg.(value & opt string (Ipaddr.V4.to_string Configuration.default_host_ip) doc)
+
 let lowest_ip =
   let doc =
     Arg.info ~doc:
@@ -610,7 +620,7 @@ let command =
         $ socket $ port_control_path $ introspection_path $ diagnostics_path
         $ max_connections $ vsock_path $ db_path $ db_branch $ dns $ http $ hosts
         $ host_names $ listen_backlog $ port_max_idle_time $ debug
-        $ server_macaddr $ domain $ allowed_bind_addresses $ gateway_ip
+        $ server_macaddr $ domain $ allowed_bind_addresses $ gateway_ip $ host_ip
         $ lowest_ip $ highest_ip $ dhcp_json_path $ mtu $ Logging.log_destination),
   Term.info (Filename.basename Sys.argv.(0)) ~version:"%%VERSION%%" ~doc ~man
 

--- a/src/hostnet/configuration.ml
+++ b/src/hostnet/configuration.ml
@@ -52,10 +52,11 @@ type t = {
   http_intercept_path: string option;
   port_max_idle_time: int;
   host_names: Dns.Name.t list;
+  gateway_names: Dns.Name.t list;
 }
 
 let to_string t =
-  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns_path = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; gateway_ip = %s; host_ip = %s; lowest_ip = %s; highest_ip = %s; dhcp_json_path = %s; dhcp_configuration = %s; mtu = %d; http_intercept = %s; http_intercept_path = %s; port_max_idle_time = %s; host_names = %s"
+  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns_path = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; gateway_ip = %s; host_ip = %s; lowest_ip = %s; highest_ip = %s; dhcp_json_path = %s; dhcp_configuration = %s; mtu = %d; http_intercept = %s; http_intercept_path = %s; port_max_idle_time = %s; host_names = %s; gateway_name = %s"
     (Macaddr.to_string t.server_macaddr)
     (match t.max_connections with None -> "None" | Some x -> string_of_int x)
     (match t.dns_path with None -> "None" | Some x -> x)
@@ -74,6 +75,7 @@ let to_string t =
     (match t.http_intercept_path with None -> "None" | Some x -> x)
     (string_of_int t.port_max_idle_time)
     (String.concat ", " (List.map Dns.Name.to_string t.host_names))
+    (String.concat ", " (List.map Dns.Name.to_string t.gateway_names))
 
 let no_dns_servers =
   Dns_forward.Config.({ servers = Server.Set.empty; search = []; assume_offline_after_drops = None })
@@ -90,6 +92,8 @@ let default_port_max_idle_time = 300
 (* random MAC from https://www.hellion.org.uk/cgi-bin/randmac.pl *)
 let default_server_macaddr = Macaddr.of_string_exn "F6:16:36:BC:F9:C6"
 let default_host_names = [ Dns.Name.of_string "vpnkit.host" ]
+let default_gateway_names = [ Dns.Name.of_string "gateway.internal" ]
+
 let default_resolver = `Host
 
 let default = {
@@ -111,6 +115,7 @@ let default = {
   http_intercept_path = None;
   port_max_idle_time = default_port_max_idle_time;
   host_names = default_host_names;
+  gateway_names = default_gateway_names;
 }
 
 module Parse = struct

--- a/src/hostnet/configuration.ml
+++ b/src/hostnet/configuration.ml
@@ -41,6 +41,7 @@ type t = {
   domain: string option;
   allowed_bind_addresses: Ipaddr.V4.t list;
   gateway_ip: Ipaddr.V4.t;
+  host_ip: Ipaddr.V4.t;
   (* TODO: remove this from the record since it is not constant across all clients *)
   lowest_ip: Ipaddr.V4.t;
   highest_ip: Ipaddr.V4.t;
@@ -54,7 +55,7 @@ type t = {
 }
 
 let to_string t =
-  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns_path = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; gateway_ip = %s; lowest_ip = %s; highest_ip = %s; dhcp_json_path = %s; dhcp_configuration = %s; mtu = %d; http_intercept = %s; http_intercept_path = %s; port_max_idle_time = %s; host_names = %s"
+  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns_path = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; gateway_ip = %s; host_ip = %s; lowest_ip = %s; highest_ip = %s; dhcp_json_path = %s; dhcp_configuration = %s; mtu = %d; http_intercept = %s; http_intercept_path = %s; port_max_idle_time = %s; host_names = %s"
     (Macaddr.to_string t.server_macaddr)
     (match t.max_connections with None -> "None" | Some x -> string_of_int x)
     (match t.dns_path with None -> "None" | Some x -> x)
@@ -63,6 +64,7 @@ let to_string t =
     (match t.domain with None -> "None" | Some x -> x)
     (String.concat ", " (List.map Ipaddr.V4.to_string t.allowed_bind_addresses))
     (Ipaddr.V4.to_string t.gateway_ip)
+    (Ipaddr.V4.to_string t.host_ip)
     (Ipaddr.V4.to_string t.lowest_ip)
     (Ipaddr.V4.to_string t.highest_ip)
     (match t.dhcp_json_path with None -> "None" | Some x -> x)
@@ -76,8 +78,9 @@ let to_string t =
 let no_dns_servers =
   Dns_forward.Config.({ servers = Server.Set.empty; search = []; assume_offline_after_drops = None })
 
-let default_lowest_ip = Ipaddr.V4.of_string_exn "192.168.65.2"
+let default_lowest_ip = Ipaddr.V4.of_string_exn "192.168.65.3"
 let default_gateway_ip = Ipaddr.V4.of_string_exn "192.168.65.1"
+let default_host_ip = Ipaddr.V4.of_string_exn "192.168.65.2"
 let default_highest_ip = Ipaddr.V4.of_string_exn "192.168.65.254"
 (* The default MTU is limited by the maximum message size on a Hyper-V
    socket. On currently available windows versions, we need to stay
@@ -98,6 +101,7 @@ let default = {
   domain = None;
   allowed_bind_addresses = [];
   gateway_ip = default_gateway_ip;
+  host_ip = default_host_ip;
   lowest_ip = default_lowest_ip;
   highest_ip = default_highest_ip;
   dhcp_json_path = None;

--- a/src/hostnet/configuration.ml
+++ b/src/hostnet/configuration.ml
@@ -44,7 +44,6 @@ type t = {
   (* TODO: remove this from the record since it is not constant across all clients *)
   lowest_ip: Ipaddr.V4.t;
   highest_ip: Ipaddr.V4.t;
-  extra_dns: Ipaddr.V4.t list;
   dhcp_json_path: string option;
   dhcp_configuration: Dhcp_configuration.t option;
   mtu: int;
@@ -55,7 +54,7 @@ type t = {
 }
 
 let to_string t =
-  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns_path = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; gateway_ip = %s; lowest_ip = %s; highest_ip = %s; extra_dns = %s; dhcp_json_path = %s; dhcp_configuration = %s; mtu = %d; http_intercept = %s; http_intercept_path = %s; port_max_idle_time = %s; host_names = %s"
+  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns_path = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; gateway_ip = %s; lowest_ip = %s; highest_ip = %s; dhcp_json_path = %s; dhcp_configuration = %s; mtu = %d; http_intercept = %s; http_intercept_path = %s; port_max_idle_time = %s; host_names = %s"
     (Macaddr.to_string t.server_macaddr)
     (match t.max_connections with None -> "None" | Some x -> string_of_int x)
     (match t.dns_path with None -> "None" | Some x -> x)
@@ -66,7 +65,6 @@ let to_string t =
     (Ipaddr.V4.to_string t.gateway_ip)
     (Ipaddr.V4.to_string t.lowest_ip)
     (Ipaddr.V4.to_string t.highest_ip)
-    (String.concat ", " (List.map Ipaddr.V4.to_string t.extra_dns))
     (match t.dhcp_json_path with None -> "None" | Some x -> x)
     (match t.dhcp_configuration with None -> "None" | Some x -> Dhcp_configuration.to_string x)
     t.mtu
@@ -81,7 +79,6 @@ let no_dns_servers =
 let default_lowest_ip = Ipaddr.V4.of_string_exn "192.168.65.2"
 let default_gateway_ip = Ipaddr.V4.of_string_exn "192.168.65.1"
 let default_highest_ip = Ipaddr.V4.of_string_exn "192.168.65.254"
-let default_extra_dns = []
 (* The default MTU is limited by the maximum message size on a Hyper-V
    socket. On currently available windows versions, we need to stay
    below 8192 bytes *)
@@ -103,7 +100,6 @@ let default = {
   gateway_ip = default_gateway_ip;
   lowest_ip = default_lowest_ip;
   highest_ip = default_highest_ip;
-  extra_dns = default_extra_dns;
   dhcp_json_path = None;
   dhcp_configuration = None;
   mtu = default_mtu;

--- a/src/hostnet/hostnet_dhcp.ml
+++ b/src/hostnet/hostnet_dhcp.ml
@@ -46,7 +46,7 @@ module Make (Clock: Mirage_clock_lwt.MCLOCK) (Netif: Mirage_net_lwt.S) = struct
        resolved in the future *)
     let low_ip, high_ip =
       let open Ipaddr.V4 in
-      let all_static_ips = c.Configuration.gateway_ip :: c.Configuration.lowest_ip :: c.Configuration.extra_dns in
+      let all_static_ips = [ c.Configuration.gateway_ip; c.Configuration.lowest_ip ] in
       let highest = maximum_ip all_static_ips in
       let i32 = to_int32 highest in
       of_int32 @@ Int32.succ i32, of_int32 @@ Int32.succ @@ Int32.succ i32 in
@@ -73,7 +73,7 @@ module Make (Clock: Mirage_clock_lwt.MCLOCK) (Netif: Mirage_net_lwt.S) = struct
         | _, _ -> Configuration.default_domain in
       let options = [
         Dhcp_wire.Routers [ c.Configuration.gateway_ip ];
-        Dhcp_wire.Dns_servers (c.Configuration.gateway_ip :: c.Configuration.extra_dns);
+        Dhcp_wire.Dns_servers [ c.Configuration.gateway_ip ];
         Dhcp_wire.Ntp_servers [ c.Configuration.gateway_ip ];
         Dhcp_wire.Broadcast_addr (Ipaddr.V4.Prefix.broadcast prefix);
         Dhcp_wire.Subnet_mask (Ipaddr.V4.Prefix.netmask prefix);

--- a/src/hostnet/hostnet_dns.mli
+++ b/src/hostnet/hostnet_dns.mli
@@ -26,7 +26,7 @@ sig
 
   val create:
     local_address:Dns_forward.Config.Address.t ->
-    host_names:Dns.Name.t list ->
+    builtin_names:(Dns.Name.t * Ipaddr.t) list ->
     Clock.t -> Config.t -> t Lwt.t
   (** Create a DNS forwarding instance based on the given
       configuration, either [`Upstream config]: send DNS requests to

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -862,12 +862,12 @@ struct
     let local_arp_table = [
       c.Configuration.lowest_ip, client_macaddr;
       c.Configuration.gateway_ip, c.Configuration.server_macaddr;
-    ] @ (List.map (fun ip -> ip, c.Configuration.server_macaddr) c.Configuration.extra_dns) in
+    ] in
     Global_arp_ethif.connect switch
     >>= fun global_arp_ethif ->
 
     (* Listen on local IPs *)
-    let local_ips = c.Configuration.gateway_ip :: c.Configuration.extra_dns in
+    let local_ips = [ c.Configuration.gateway_ip ] in
 
     let dhcp = Dhcp.make ~configuration:c clock switch in
 
@@ -1305,15 +1305,6 @@ struct
     Active_config.map (Configuration.Parse.ipv4 Configuration.default_highest_ip) string_highest_ips
     >>= fun highest_ips ->
     on_change highest_ips (fun highest_ip -> update (fun c -> { c with highest_ip }));
-    let extra_dns_ips_path = driver @ [ "slirp"; "extra_dns" ] in
-    Config.string config ~default:""
-      extra_dns_ips_path
-    >>= fun string_extra_dns_ips ->
-    Active_config.map
-      (fun x -> Lwt.return @@ Configuration.Parse.ipv4_list (List.map Ipaddr.V4.of_string_exn Configuration.default_extra_dns) x)
-      string_extra_dns_ips
-    >>= fun extra_dns_ips ->
-    on_change extra_dns_ips (fun extra_dns -> update (fun c -> { c with extra_dns }));
     let resolver_path = driver @ [ "slirp"; "resolver" ] in
     Config.string_option config resolver_path
     >>= fun string_resolver_settings ->

--- a/src/hostnet/slirp.mli
+++ b/src/hostnet/slirp.mli
@@ -46,7 +46,7 @@ sig
     val get_nat_table_size: connection -> int
     (** Return the number of active NAT table entries *)
 
-    val update_dns: ?local_ip:Ipaddr.t -> ?host_names:Dns.Name.t list ->
+    val update_dns: ?local_ip:Ipaddr.t -> ?builtin_names:(Dns.Name.t * Ipaddr.t) list ->
       Clock.t -> unit
     (** Update the DNS forwarder following a configuration change *)
 

--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -134,17 +134,11 @@ module DNS = Dns_resolver_mirage.Make(Host.Time)(Client)
 
 let primary_dns_ip = Ipaddr.V4.of_string_exn "192.168.65.1"
 
-let extra_dns_ip = List.map Ipaddr.V4.of_string_exn [
-    "192.168.65.3"; "192.168.65.4"; "192.168.65.5"; "192.168.65.6";
-    "192.168.65.7"; "192.168.65.8"; "192.168.65.9"; "192.168.65.10";
-  ]
-
 let preferred_ip1 = Ipaddr.V4.of_string_exn "192.168.65.250"
 
 let config =
   let configuration = {
     Configuration.default with
-    extra_dns = extra_dns_ip;
     domain = Some "local";
   } in
   Mclock.connect () >>= fun clock ->

--- a/src/hostnet_test/suite.ml
+++ b/src/hostnet_test/suite.ml
@@ -28,12 +28,12 @@ let test_dhcp_query () =
   in
   run ~pcap:"test_dhcp_query.pcap" t
 
-let set_dns_policy ?host_names use_host =
+let set_dns_policy ?builtin_names use_host =
   Mclock.connect () >|= fun clock ->
   Dns_policy.remove ~priority:3;
   Dns_policy.add ~priority:3
     ~config:(if use_host then `Host else Dns_policy.google_dns);
-  Slirp_stack.Debug.update_dns ?host_names clock
+  Slirp_stack.Debug.update_dns ?builtin_names clock
 
 let test_dns_query server use_host () =
   let t _ stack =
@@ -51,7 +51,7 @@ let test_dns_query server use_host () =
 let test_builtin_dns_query server use_host () =
   let name = "experimental.host.name.localhost" in
   let t _ stack =
-    set_dns_policy ~host_names:[ Dns.Name.of_string name ] use_host
+    set_dns_policy ~builtin_names:[ Dns.Name.of_string name, Ipaddr.V4 (Ipaddr.V4.localhost) ] use_host
     >>= fun () ->
     let resolver = DNS.create stack.Client.t in
     DNS.gethostbyname ~server resolver name >>= function


### PR DESCRIPTION
Previously we had a single "gateway" IP which
- passes through to `localhost` on the host
- also does NTP
- also does DNS
- and now also does HTTP proxies

As we add more services, the ports for those will mask the ports available for connecting to `localhost`. For example it is not possible to access port 3128 on the host any more, as it is masked by the new HTTP proxy.

This PR separates the local host passthrough from the internal services. The internal services are kept on the gateway ip via `--gateway-ip` and named by `--gateway-names`. The local host passthrough is now on `--host-ip` and named by `--host-names`.

This PR also removes the unused "extra DNS IPs" and simplifies the "make test" target.