### PR TITLE
Allow the system compiler to be used

### DIFF
--- a/repo/darwin/packages/dev/tcpip.dev/url
+++ b/repo/darwin/packages/dev/tcpip.dev/url
@@ -1,1 +1,1 @@
-git: "https://github.com/samoht/mirage-tcpip.git#vpnkit"
+git: "https://github.com/djs55/mirage-tcpip.git#vpnkit"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -13,7 +13,13 @@ export OPAMROOT
 export OPAMYES=1
 export OPAMCOLORS=1
 
-opam init -v -n --comp="${OPAM_COMP}" --switch="${OPAM_COMP}" local "${OPAM_REPO}"
+# if a compiler is specified, use it; otherwise use the system compiler
+if [ -n "${OPAM_COMP}" ]; then
+  OPAM_COMP_ARG="--comp=${OPAM_COMP}"
+  OPAM_SWITCH_ARG="--switch=${OPAM_COMP}"
+fi
+
+opam init -v -n "${OPAM_COMP_ARG}" "${OPAM_SWITCH_ARG}" local "${OPAM_REPO}"
 echo opam configuration is:
 opam config env
 eval $(opam config env)


### PR DESCRIPTION
This is a subset of #314 which allows the system compiler to be used, rather than a compiler built through `opam`. In theory this includes the 4.06.0 compiler, although building this in CI will require an update to the package repository.