### PR TITLE
Backport the HTTP HEAD fix onto the stable branch

### DIFF
--- a/repo/darwin/packages/upstream/menhir.20171013/url
+++ b/repo/darwin/packages/upstream/menhir.20171013/url
@@ -1,2 +1,2 @@
-archive: "http://gallium.inria.fr/~fpottier/menhir/menhir-20171013.tar.gz"
+archive: "http://dave.recoil.org/mirror/menhir-20171013.tar.gz"
 checksum: "620863edea40437390ee5e5bd82fba11"

--- a/repo/win32/packages/upstream/menhir.20171013/url
+++ b/repo/win32/packages/upstream/menhir.20171013/url
@@ -1,2 +1,2 @@
-archive: "http://gallium.inria.fr/~fpottier/menhir/menhir-20171013.tar.gz"
+archive: "http://dave.recoil.org/mirror/menhir-20171013.tar.gz"
 checksum: "620863edea40437390ee5e5bd82fba11"


### PR DESCRIPTION
- backport #325 
- add a mirror of the `menhir` package as the primary website is down