### PR TITLE
Allow to create connections for arbitrary clients

### DIFF
--- a/go/pkg/vpnkit/connection.go
+++ b/go/pkg/vpnkit/connection.go
@@ -18,5 +18,10 @@ func NewConnection(ctx context.Context, path string) (*Connection, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Connection{client}, nil
+	return NewConnectionForClient(client), nil
+}
+
+// NewConnectionForClient returns a connection using given client
+func NewConnectionForClient(client *datakit.Client) *Connection {
+	return &Connection{ client}
 }


### PR DESCRIPTION
In Docker4Windows, we need to create connections using hvsock datakit client instead of linux sockets. 

PR add a new `vpnkit.Connection` constructor function allowing to create connections for arbitrary datakit.Client