### PR TITLE
appveyor: attempt to cache the _build/opam directory

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,9 @@ environment:
   OPAMVERBOSE: 1
   BINDIR: 'C:\projects\vpnkit'
 
+cache:
+  - _build\opam -> repo\win32
+
 install:
   - cmd: git config core.symlinks true
   - cmd: git reset --hard

--- a/circle.yml
+++ b/circle.yml
@@ -21,6 +21,8 @@ dependencies:
   - make artefacts
   - make OSS-LICENSES
   - make COMMIT
+  cache_directories:
+    - _build/opam
 test:
   override:
   - make test


### PR DESCRIPTION
The cache will be invalidated if the repo/win32 directory containing
the package definitions is modified.

Signed-off-by: David Scott <dave.scott@docker.com>