### PR TITLE
HTTP proxy: include the port number in the host header

### DIFF
--- a/src/hostnet/hostnet_http.ml
+++ b/src/hostnet/hostnet_http.ml
@@ -570,8 +570,11 @@ module Make
               | _ ->
                 (* The absolute URI used by the proxy should be converted back into
                    a relative URI and a Host: header *)
+                (* https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23 says that the port
+                   number must be included if it's not 80. *)
+                let host_and_port = host ^ (match Uri.port uri with None -> "" | Some port -> ":" ^ (string_of_int port)) in
                 let req = { req with
-                  Cohttp.Request.headers = Cohttp.Header.replace req.Cohttp.Request.headers "host" host;
+                  Cohttp.Request.headers = Cohttp.Header.replace req.Cohttp.Request.headers "host" host_and_port;
                   resource = Uri.path_and_query uri
                 } in
                 Log.debug (fun f -> f "%s: sending %s"

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -620,10 +620,9 @@ let test_http_connect () =
               Alcotest.check Alcotest.(option string) "URI.host"
                 (Cohttp.Request.uri request |> Uri.host)
                 (Cohttp.Request.uri result |> Uri.host);
-              (* FIXME: check whether the port should be included in the header or not *)
-              Alcotest.check Alcotest.int "number of host headers"
-                (Cohttp.Header.to_list request.Cohttp.Request.headers |> List.filter (fun (x, _) -> x = "host") |> List.length)
-                (Cohttp.Header.to_list result.Cohttp.Request.headers |> List.filter (fun (x, _) -> x = "host") |> List.length);
+              Alcotest.check Alcotest.(list string) "host headers"
+                (Cohttp.Header.to_list request.Cohttp.Request.headers |> List.filter (fun (x, _) -> x = "host") |> List.map snd)
+                (Cohttp.Header.to_list result.Cohttp.Request.headers |> List.filter (fun (x, _) -> x = "host") |> List.map snd);
               Lwt.return_unit
             )
         )


### PR DESCRIPTION
Previously we would omit the port from the host header which is ambiguous. RFC2616 says that the port number has to be included.