### PR TITLE
[stable] HTTP proxy: include the port number in the host header

### DIFF
--- a/src/hostnet/hostnet_http.ml
+++ b/src/hostnet/hostnet_http.ml
@@ -570,8 +570,11 @@ module Make
               | _ ->
                 (* The absolute URI used by the proxy should be converted back into
                    a relative URI and a Host: header *)
+                (* https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23 says that the port
+                   number must be included if it's not 80. *)
+                let host_and_port = host ^ (match Uri.port uri with None -> "" | Some port -> ":" ^ (string_of_int port)) in
                 let req = { req with
-                  Cohttp.Request.headers = Cohttp.Header.replace req.Cohttp.Request.headers "host" host;
+                  Cohttp.Request.headers = Cohttp.Header.replace req.Cohttp.Request.headers "host" host_and_port;
                   resource = Uri.path_and_query uri
                 } in
                 Log.debug (fun f -> f "%s: sending %s"


### PR DESCRIPTION
RFC2616[1] says that if the port number is not 80 (the default) then
the port must be included in the `Host` header.

[1] https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23

Related to https://github.com/docker/for-mac/issues/2392

Signed-off-by: David Scott <dave.scott@docker.com>