### PR TITLE
http: allow excludes to contain IPs as well as IP prefixes

### DIFF
--- a/src/hostnet/hostnet_http.ml
+++ b/src/hostnet/hostnet_http.ml
@@ -68,10 +68,10 @@ module Exclude = struct
       | b :: bs, d :: ds -> Element.matches b d && loop bs ds in
       loop (List.rev bits) (List.rev domains)
 
-    let matches ?ip ~host exclude =
-      (match ip with None -> false | Some ip -> matches_ip ip exclude)
-      ||
-      (matches_host host exclude)
+    let matches thing exclude =
+      match Ipaddr.V4.of_string thing with
+      | None -> matches_host thing exclude
+      | Some ip -> matches_ip ip exclude
   end
 
   type t = One.t list
@@ -89,8 +89,8 @@ module Exclude = struct
 
   let to_string t = String.concat ~sep:" " @@ (List.map One.to_string t)
 
-  let matches ?ip ~host t =
-    List.fold_left (||) false (List.map (One.matches ?ip ~host) t)
+  let matches thing t =
+    List.fold_left (||) false (List.map (One.matches thing) t)
 
 end
 
@@ -508,7 +508,7 @@ module Make
         | None -> Some ((host, port), `Origin)
         (* If a proxy is configured it depends on whether the request matches the excludes *)
         | Some proxy ->
-          if Exclude.matches ~host exclude
+          if Exclude.matches host exclude
           then Some ((host, port), `Origin)
           else Some (proxy, `Proxy) in
       begin match hostport_and_ty with
@@ -685,7 +685,7 @@ module Make
     match port, t.http, t.https with
     | 80, Some proxy, _ -> Some (transparent_http ~dst:ip proxy t.exclude)
     | 443, _, Some proxy ->
-      if Exclude.matches ~ip ~host:(Ipaddr.V4.to_string ip) t.exclude
+      if Exclude.matches (Ipaddr.V4.to_string ip) t.exclude
       then None
       else Some (tunnel_https_over_connect ~dst:ip proxy)
     | _, _, _ -> None

--- a/src/hostnet/hostnet_http.mli
+++ b/src/hostnet/hostnet_http.mli
@@ -5,9 +5,9 @@ module Exclude: sig
   val of_string: string -> t
   val to_string: t -> string
 
-  val matches: ?ip:Ipaddr.V4.t -> host:string -> t -> bool
-  (** True if the request should bypass the proxy. [ip] is the destination
-      IP address (if known) and host is the Host: from the URI or header. *)
+  val matches: string -> t -> bool
+  (** [matches host_or_ip excludes] is true if [host_or_ip] matches
+      the excludes rules and should bypass the proxy. *)
 end
 
 module Make

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -9,6 +9,10 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 module Exclude = struct
 
+  let test_ip_match () =
+    let exclude = Hostnet_http.Exclude.of_string "10.0.0.1" in
+    assert (Hostnet_http.Exclude.matches ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1") ~host:"localhost" exclude)
+
   let test_cidr_match () =
     let exclude = Hostnet_http.Exclude.of_string "10.0.0.0/24" in
     assert (Hostnet_http.Exclude.matches ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1") ~host:"localhost" exclude)
@@ -64,6 +68,7 @@ module Exclude = struct
                   exclude))
 
   let tests = [
+    "HTTP: no_proxy IP match", [ "", `Quick, test_ip_match ];
     "HTTP: no_proxy CIDR match", [ "", `Quick, test_cidr_match ];
     "HTTP: no_proxy CIDR no match", [ "", `Quick, test_cidr_no_match ];
     "HTTP: no_proxy domain match", [ "", `Quick, test_domain_match ];

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -11,60 +11,55 @@ module Exclude = struct
 
   let test_ip_match () =
     let exclude = Hostnet_http.Exclude.of_string "10.0.0.1" in
-    assert (Hostnet_http.Exclude.matches ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1") ~host:"localhost" exclude)
+    assert (Hostnet_http.Exclude.matches "10.0.0.1" exclude)
 
   let test_cidr_match () =
     let exclude = Hostnet_http.Exclude.of_string "10.0.0.0/24" in
-    assert (Hostnet_http.Exclude.matches ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1") ~host:"localhost" exclude)
+    assert (Hostnet_http.Exclude.matches "10.0.0.1" exclude)
 
   let test_cidr_no_match () =
     let exclude = Hostnet_http.Exclude.of_string "10.0.0.0/24" in
     assert (not(Hostnet_http.Exclude.matches
-                  ~ip:(Ipaddr.V4.of_string_exn "192.168.0.1")
-                  ~host:"localhost"
+                  "192.168.0.1"
                   exclude))
 
   let test_domain_match () =
     let exclude = Hostnet_http.Exclude.of_string "mit.edu" in
     assert (Hostnet_http.Exclude.matches
-                  ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1")
-                  ~host:"dave.mit.edu"
+                  "dave.mit.edu"
                   exclude)
 
   let test_domain_star_match () =
     let exclude = Hostnet_http.Exclude.of_string "*.mit.edu" in
     assert (Hostnet_http.Exclude.matches
-                  ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1")
-                  ~host:"dave.mit.edu"
+                  "dave.mit.edu"
                   exclude)
 
   let test_domain_dot_match () =
     let exclude = Hostnet_http.Exclude.of_string ".mit.edu" in
     assert (Hostnet_http.Exclude.matches
-                  ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1")
-                  ~host:"dave.mit.edu"
+                  "dave.mit.edu"
                   exclude)
 
   let test_domain_no_match () =
     let exclude = Hostnet_http.Exclude.of_string "mit.edu" in
     assert (not(Hostnet_http.Exclude.matches
-                  ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1")
-                  ~host:"dave.recoil.org"
+                  "dave.recoil.org"
                   exclude))
 
   let test_list () =
     let exclude = Hostnet_http.Exclude.of_string "*.local, 169.254.0.0/16" in
     assert (Hostnet_http.Exclude.matches
-                  ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1")
-                  ~host:"dave.local"
+                  "dave.local"
                   exclude);
     assert (Hostnet_http.Exclude.matches
-                  ~ip:(Ipaddr.V4.of_string_exn "169.254.0.1")
-                  ~host:"dave.recoil.org"
+                  "169.254.0.1"
                   exclude);
     assert (not(Hostnet_http.Exclude.matches
-                  ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1")
-                  ~host:"dave.recoil.org"
+                  "10.0.0.1"
+                  exclude));
+    assert (not(Hostnet_http.Exclude.matches
+                  "dave.recoil.org"
                   exclude))
 
   let tests = [


### PR DESCRIPTION
Previously we could say `10.0.0.0/16` but not `10.0.0.1`. This patch accepts IP addresses as well as prefixes and subdomains.

Previously the caller of `Excludes.matches` had to take a string which could be a hostname or IP, attempt to convert it to an IP and then call `Excludes.matches ~ip ~host`. This PR simplifies the `Excludes.matches` interface to `string -> t -> bool`, so the caller doesn't have to know that the excludes matches are done both on the basis of IP address ranges and subdomains.

Signed-off-by: David Scott <dave.scott@docker.com>