### PR TITLE
[stable 17.12.x] Backport HTTP proxy fixes

### DIFF
--- a/src/hostnet/hostnet_http.ml
+++ b/src/hostnet/hostnet_http.ml
@@ -389,7 +389,7 @@ module Make
     in
     loop ()
 
-  let https ~dst proxy =
+  let transparent_https ~dst proxy =
     let listeners _port =
       Log.debug (fun f -> f "HTTPS TCP handshake complete");
       let f flow =
@@ -660,7 +660,7 @@ module Make
     | 443, _, Some h ->
       if Exclude.matches ip None t.exclude
       then None
-      else Some (https ~dst:ip h)
+      else Some (transparent_https ~dst:ip h)
     | _, _, _ -> None
 
   let explicit_proxy_handler ~dst:(ip, port) ~t =

--- a/src/hostnet/hostnet_http.ml
+++ b/src/hostnet/hostnet_http.ml
@@ -335,7 +335,7 @@ module Make
             ) (fun () -> Socket.Stream.Tcp.close remote)
         end
 
-  let http ~dst ~t h =
+  let transparent_http ~dst ~t h =
     let listeners _port =
       Log.debug (fun f -> f "HTTP TCP handshake complete");
       let f flow =
@@ -662,7 +662,7 @@ module Make
 
   let transparent_proxy_handler ~dst:(ip, port) ~t =
     match port, t.http, t.https with
-    | 80, Some h, _ -> Some (http ~dst:ip ~t h)
+    | 80, Some h, _ -> Some (transparent_http ~dst:ip ~t h)
     | 443, _, Some h ->
       if Exclude.matches ip None t.exclude
       then None

--- a/src/hostnet/hostnet_http.ml
+++ b/src/hostnet/hostnet_http.ml
@@ -2,7 +2,7 @@ open Lwt.Infix
 open Astring
 
 let src =
-  let src = Logs.Src.create "http" ~doc:"Transparently proxy HTTP" in
+  let src = Logs.Src.create "http" ~doc:"HTTP proxy" in
   Logs.Src.set_level src (Some Logs.Info);
   src
 

--- a/src/hostnet/hostnet_http.ml
+++ b/src/hostnet/hostnet_http.ml
@@ -588,9 +588,10 @@ module Make
             let headers = match proxy with
               | None -> headers
               | Some proxy -> add_proxy_authorization proxy headers in
-            let resource = match ty with
-              | `Origin -> Uri.path_and_query uri
-              | `Proxy -> Uri.with_scheme (Uri.with_host (Uri.with_port uri (Some port)) (Some host)) (Some "http") |> Uri.to_string in
+            let resource = match ty, Cohttp.Request.meth req with
+              | `Origin, _ -> Uri.path_and_query uri
+              | `Proxy, `CONNECT -> host_and_port
+              | `Proxy, _ -> Uri.with_scheme (Uri.with_host (Uri.with_port uri (Some port)) (Some host)) (Some "http") |> Uri.to_string in
             let req = { req with Cohttp.Request.headers; resource } in
             Log.debug (fun f -> f "%s: sending %s"
               (description false)

--- a/src/hostnet/hostnet_http.ml
+++ b/src/hostnet/hostnet_http.ml
@@ -18,7 +18,7 @@ module Exclude = struct
       type t = Any | String of string
 
       let of_string = function
-      | "*" -> Any
+      | "*" | "" -> Any
       | x -> String x
 
       let to_string = function

--- a/src/hostnet/hostnet_http.ml
+++ b/src/hostnet/hostnet_http.ml
@@ -68,10 +68,10 @@ module Exclude = struct
       | b :: bs, d :: ds -> Element.matches b d && loop bs ds in
       loop (List.rev bits) (List.rev domains)
 
-    let matches ?ip ~host exclude =
-      (match ip with None -> false | Some ip -> matches_ip ip exclude)
-      ||
-      (matches_host host exclude)
+    let matches thing exclude =
+      match Ipaddr.V4.of_string thing with
+      | None -> matches_host thing exclude
+      | Some ip -> matches_ip ip exclude
   end
 
   type t = One.t list
@@ -89,8 +89,8 @@ module Exclude = struct
 
   let to_string t = String.concat ~sep:" " @@ (List.map One.to_string t)
 
-  let matches ?ip ~host t =
-    List.fold_left (||) false (List.map (One.matches ?ip ~host) t)
+  let matches thing t =
+    List.fold_left (||) false (List.map (One.matches thing) t)
 
 end
 
@@ -508,7 +508,7 @@ module Make
         | None -> Some ((host, port), `Origin)
         (* If a proxy is configured it depends on whether the request matches the excludes *)
         | Some proxy ->
-          if Exclude.matches ~host exclude
+          if Exclude.matches host exclude
           then Some ((host, port), `Origin)
           else Some (proxy, `Proxy) in
       begin match hostport_and_ty with
@@ -685,7 +685,7 @@ module Make
     match port, t.http, t.https with
     | 80, Some proxy, _ -> Some (transparent_http ~dst:ip proxy t.exclude)
     | 443, _, Some proxy ->
-      if Exclude.matches ~ip ~host:(Ipaddr.V4.to_string ip) t.exclude
+      if Exclude.matches (Ipaddr.V4.to_string ip) t.exclude
       then None
       else Some (tunnel_https_over_connect ~dst:ip proxy)
     | _, _, _ -> None

--- a/src/hostnet/hostnet_http.ml
+++ b/src/hostnet/hostnet_http.ml
@@ -360,7 +360,7 @@ module Make
         (error_html "ERROR: connection refused" msg)
     ) res incoming
 
-  let transparent_https ~dst proxy =
+  let tunnel_https_over_connect ~dst proxy =
     let listeners _port =
       Log.debug (fun f -> f "HTTPS TCP handshake complete");
       let f flow =
@@ -656,7 +656,7 @@ module Make
     | 443, _, Some proxy ->
       if Exclude.matches ~ip ~host:(Ipaddr.V4.to_string ip) t.exclude
       then None
-      else Some (transparent_https ~dst:ip proxy)
+      else Some (tunnel_https_over_connect ~dst:ip proxy)
     | _, _, _ -> None
 
   let explicit_proxy_handler ~dst:(_, port) ~t =

--- a/src/hostnet/hostnet_http.mli
+++ b/src/hostnet/hostnet_http.mli
@@ -5,9 +5,9 @@ module Exclude: sig
   val of_string: string -> t
   val to_string: t -> string
 
-  val matches: ?ip:Ipaddr.V4.t -> host:string -> t -> bool
-  (** True if the request should bypass the proxy. [ip] is the destination
-      IP address (if known) and host is the Host: from the URI or header. *)
+  val matches: string -> t -> bool
+  (** [matches host_or_ip excludes] is true if [host_or_ip] matches
+      the excludes rules and should bypass the proxy. *)
 end
 
 module Make

--- a/src/hostnet/hostnet_http.mli
+++ b/src/hostnet/hostnet_http.mli
@@ -5,8 +5,9 @@ module Exclude: sig
   val of_string: string -> t
   val to_string: t -> string
 
-  val matches: Ipaddr.V4.t -> Cohttp.Request.t option -> t -> bool
-  (** If true, the given request should bypass the proxy *)
+  val matches: ?ip:Ipaddr.V4.t -> host:string -> t -> bool
+  (** True if the request should bypass the proxy. [ip] is the destination
+      IP address (if known) and host is the Host: from the URI or header. *)
 end
 
 module Make

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -620,10 +620,9 @@ let test_http_connect () =
               Alcotest.check Alcotest.(option string) "URI.host"
                 (Cohttp.Request.uri request |> Uri.host)
                 (Cohttp.Request.uri result |> Uri.host);
-              (* FIXME: check whether the port should be included in the header or not *)
-              Alcotest.check Alcotest.int "number of host headers"
-                (Cohttp.Header.to_list request.Cohttp.Request.headers |> List.filter (fun (x, _) -> x = "host") |> List.length)
-                (Cohttp.Header.to_list result.Cohttp.Request.headers |> List.filter (fun (x, _) -> x = "host") |> List.length);
+              Alcotest.check Alcotest.(list string) "host headers"
+                (Cohttp.Header.to_list request.Cohttp.Request.headers |> List.filter (fun (x, _) -> x = "host") |> List.map snd)
+                (Cohttp.Header.to_list result.Cohttp.Request.headers |> List.filter (fun (x, _) -> x = "host") |> List.map snd);
               Lwt.return_unit
             )
         )

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -38,6 +38,14 @@ module Exclude = struct
     assert (Hostnet_http.Exclude.matches (Ipaddr.V4.of_string_exn "10.0.0.1")
               req exclude)
 
+  let test_domain_dot_match () =
+    let exclude = Hostnet_http.Exclude.of_string ".mit.edu" in
+    let req =
+      Some (Cohttp.Request.make (Uri.of_string "http://dave.mit.edu/"))
+    in
+    assert (Hostnet_http.Exclude.matches (Ipaddr.V4.of_string_exn "10.0.0.1")
+              req exclude)
+
   let test_domain_no_match () =
     let exclude = Hostnet_http.Exclude.of_string "mit.edu" in
     let req =
@@ -67,6 +75,7 @@ module Exclude = struct
     "HTTP: no_proxy domain match", [ "", `Quick, test_domain_match ];
     "HTTP: no_proxy domain no match", [ "", `Quick, test_domain_no_match ];
     "HTTP: no_proxy domain star match", [ "", `Quick, test_domain_star_match ];
+    "HTTP: no_proxy domain dot match", [ "", `Quick, test_domain_dot_match ];
     "HTTP: no_proxy list", [ "", `Quick, test_list ];
   ]
 end

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -690,6 +690,11 @@ let test_http_connect proxy () =
         )
     end
 
+let proxy_urls = [
+  "http://127.0.0.1";
+  "http://user:password@127.0.0.1";
+]
+
 let tests = [
 
   "HTTP: interception",
@@ -728,10 +733,7 @@ let tests = [
 ] @ (List.map (fun proxy ->
   "HTTP: CONNECT " ^ proxy,
   [ "check that HTTP CONNECT works for HTTPS with proxy " ^ proxy, `Quick, test_http_connect (Uri.of_string proxy) ]
-) [
-  "http://127.0.0.1";
-  "http://user:password@127.0.0.1";
-]) @ [
+) proxy_urls) @ [
   "HTTP: HEAD",
   [ "check that HTTP HEAD doesn't block the connection", `Quick, test_http_proxy_head ];
 ]

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -134,7 +134,7 @@ let intercept ~pcap ?(port = 80) request =
             Lwt.return_unit
         ) (fun server ->
           let json =
-            Ezjsonm.from_string (" { \"http\": \"127.0.0.1:" ^
+            Ezjsonm.from_string (" { \"http\": \"http://127.0.0.1:" ^
                                  (string_of_int server.Server.port) ^ "\" }")
           in
           Slirp_stack.Slirp_stack.Debug.update_http_json json ()
@@ -292,7 +292,7 @@ let test_proxy_passthrough () =
               Lwt.return_unit
         ) (fun server ->
           let json =
-            Ezjsonm.from_string (" { \"http\": \"127.0.0.1:" ^
+            Ezjsonm.from_string (" { \"http\": \"http://127.0.0.1:" ^
                                 (string_of_int server.Server.port) ^ "\" }")
           in
           Slirp_stack.Slirp_stack.Debug.update_http_json json ()
@@ -371,7 +371,7 @@ let test_http_connect () =
                 | Ok ()   -> ()
           ) (fun server ->
             Slirp_stack.Slirp_stack.Debug.update_http
-              ~https:("127.0.0.1:" ^ (string_of_int server.Server.port)) ()
+              ~https:("http://127.0.0.1:" ^ (string_of_int server.Server.port)) ()
             >>= function
             | Error (`Msg m) -> failwith ("Failed to enable HTTP proxy: " ^ m)
             | Ok () ->

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -358,6 +358,12 @@ let test_http_connect proxy () =
                 (Some (Ipaddr.V4.to_string test_dst_ip)) (Uri.host uri);
               Alcotest.check Alcotest.(option int) "port" (Some 443)
                 (Uri.port uri);
+              Alcotest.check Alcotest.(option string) "host"
+                (Some (Ipaddr.V4.to_string test_dst_ip ^ ":443"))
+                (Cohttp.Header.get req.Cohttp.Request.headers "host");
+              Alcotest.check Alcotest.string "resource"
+                (Ipaddr.V4.to_string test_dst_ip ^ ":443")
+                req.Cohttp.Request.resource;
               (* If the proxy uses auth, then there has to be a Proxy-Authorization
                  header. If theres no auth, there should be no header. *)
               let proxy_authorization = "proxy-authorization" in

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -9,6 +9,10 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 module Exclude = struct
 
+  let test_ip_match () =
+    let exclude = Hostnet_http.Exclude.of_string "10.0.0.1" in
+    assert (Hostnet_http.Exclude.matches ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1") ~host:"localhost" exclude)
+
   let test_cidr_match () =
     let exclude = Hostnet_http.Exclude.of_string "10.0.0.0/24" in
     assert (Hostnet_http.Exclude.matches ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1") ~host:"localhost" exclude)
@@ -64,6 +68,7 @@ module Exclude = struct
                   exclude))
 
   let tests = [
+    "HTTP: no_proxy IP match", [ "", `Quick, test_ip_match ];
     "HTTP: no_proxy CIDR match", [ "", `Quick, test_cidr_match ];
     "HTTP: no_proxy CIDR no match", [ "", `Quick, test_cidr_no_match ];
     "HTTP: no_proxy domain match", [ "", `Quick, test_domain_match ];

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -11,60 +11,55 @@ module Exclude = struct
 
   let test_ip_match () =
     let exclude = Hostnet_http.Exclude.of_string "10.0.0.1" in
-    assert (Hostnet_http.Exclude.matches ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1") ~host:"localhost" exclude)
+    assert (Hostnet_http.Exclude.matches "10.0.0.1" exclude)
 
   let test_cidr_match () =
     let exclude = Hostnet_http.Exclude.of_string "10.0.0.0/24" in
-    assert (Hostnet_http.Exclude.matches ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1") ~host:"localhost" exclude)
+    assert (Hostnet_http.Exclude.matches "10.0.0.1" exclude)
 
   let test_cidr_no_match () =
     let exclude = Hostnet_http.Exclude.of_string "10.0.0.0/24" in
     assert (not(Hostnet_http.Exclude.matches
-                  ~ip:(Ipaddr.V4.of_string_exn "192.168.0.1")
-                  ~host:"localhost"
+                  "192.168.0.1"
                   exclude))
 
   let test_domain_match () =
     let exclude = Hostnet_http.Exclude.of_string "mit.edu" in
     assert (Hostnet_http.Exclude.matches
-                  ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1")
-                  ~host:"dave.mit.edu"
+                  "dave.mit.edu"
                   exclude)
 
   let test_domain_star_match () =
     let exclude = Hostnet_http.Exclude.of_string "*.mit.edu" in
     assert (Hostnet_http.Exclude.matches
-                  ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1")
-                  ~host:"dave.mit.edu"
+                  "dave.mit.edu"
                   exclude)
 
   let test_domain_dot_match () =
     let exclude = Hostnet_http.Exclude.of_string ".mit.edu" in
     assert (Hostnet_http.Exclude.matches
-                  ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1")
-                  ~host:"dave.mit.edu"
+                  "dave.mit.edu"
                   exclude)
 
   let test_domain_no_match () =
     let exclude = Hostnet_http.Exclude.of_string "mit.edu" in
     assert (not(Hostnet_http.Exclude.matches
-                  ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1")
-                  ~host:"dave.recoil.org"
+                  "dave.recoil.org"
                   exclude))
 
   let test_list () =
     let exclude = Hostnet_http.Exclude.of_string "*.local, 169.254.0.0/16" in
     assert (Hostnet_http.Exclude.matches
-                  ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1")
-                  ~host:"dave.local"
+                  "dave.local"
                   exclude);
     assert (Hostnet_http.Exclude.matches
-                  ~ip:(Ipaddr.V4.of_string_exn "169.254.0.1")
-                  ~host:"dave.recoil.org"
+                  "169.254.0.1"
                   exclude);
     assert (not(Hostnet_http.Exclude.matches
-                  ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1")
-                  ~host:"dave.recoil.org"
+                  "10.0.0.1"
+                  exclude));
+    assert (not(Hostnet_http.Exclude.matches
+                  "dave.recoil.org"
                   exclude))
 
   let tests = [

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -11,63 +11,57 @@ module Exclude = struct
 
   let test_cidr_match () =
     let exclude = Hostnet_http.Exclude.of_string "10.0.0.0/24" in
-    let req = Some (Cohttp.Request.make (Uri.of_string "http://localhost")) in
-    assert (Hostnet_http.Exclude.matches (Ipaddr.V4.of_string_exn "10.0.0.1")
-              req exclude)
+    assert (Hostnet_http.Exclude.matches ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1") ~host:"localhost" exclude)
 
   let test_cidr_no_match () =
     let exclude = Hostnet_http.Exclude.of_string "10.0.0.0/24" in
-    let req = Some (Cohttp.Request.make (Uri.of_string "http://localhost")) in
     assert (not(Hostnet_http.Exclude.matches
-                  (Ipaddr.V4.of_string_exn "192.168.0.1")
-                  req exclude))
+                  ~ip:(Ipaddr.V4.of_string_exn "192.168.0.1")
+                  ~host:"localhost"
+                  exclude))
 
   let test_domain_match () =
     let exclude = Hostnet_http.Exclude.of_string "mit.edu" in
-    let req =
-      Some (Cohttp.Request.make (Uri.of_string "http://dave.mit.edu/"))
-    in
-    assert (Hostnet_http.Exclude.matches (Ipaddr.V4.of_string_exn "10.0.0.1")
-              req exclude)
+    assert (Hostnet_http.Exclude.matches
+                  ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1")
+                  ~host:"dave.mit.edu"
+                  exclude)
 
   let test_domain_star_match () =
     let exclude = Hostnet_http.Exclude.of_string "*.mit.edu" in
-    let req =
-      Some (Cohttp.Request.make (Uri.of_string "http://dave.mit.edu/"))
-    in
-    assert (Hostnet_http.Exclude.matches (Ipaddr.V4.of_string_exn "10.0.0.1")
-              req exclude)
+    assert (Hostnet_http.Exclude.matches
+                  ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1")
+                  ~host:"dave.mit.edu"
+                  exclude)
 
   let test_domain_dot_match () =
     let exclude = Hostnet_http.Exclude.of_string ".mit.edu" in
-    let req =
-      Some (Cohttp.Request.make (Uri.of_string "http://dave.mit.edu/"))
-    in
-    assert (Hostnet_http.Exclude.matches (Ipaddr.V4.of_string_exn "10.0.0.1")
-              req exclude)
+    assert (Hostnet_http.Exclude.matches
+                  ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1")
+                  ~host:"dave.mit.edu"
+                  exclude)
 
   let test_domain_no_match () =
     let exclude = Hostnet_http.Exclude.of_string "mit.edu" in
-    let req =
-      Some (Cohttp.Request.make (Uri.of_string "http://dave.recoil.org/"))
-    in
     assert (not(Hostnet_http.Exclude.matches
-                  (Ipaddr.V4.of_string_exn "10.0.0.1")
-                  req exclude))
+                  ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1")
+                  ~host:"dave.recoil.org"
+                  exclude))
 
   let test_list () =
     let exclude = Hostnet_http.Exclude.of_string "*.local, 169.254.0.0/16" in
-    let req = Some (Cohttp.Request.make (Uri.of_string "http://dave.local/")) in
-    assert (Hostnet_http.Exclude.matches (Ipaddr.V4.of_string_exn "10.0.0.1")
-              req exclude);
-    let req' =
-      Some (Cohttp.Request.make (Uri.of_string "http://dave.recoil.org/"))
-    in
-    assert (Hostnet_http.Exclude.matches (Ipaddr.V4.of_string_exn "169.254.0.1")
-              req' exclude);
+    assert (Hostnet_http.Exclude.matches
+                  ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1")
+                  ~host:"dave.local"
+                  exclude);
+    assert (Hostnet_http.Exclude.matches
+                  ~ip:(Ipaddr.V4.of_string_exn "169.254.0.1")
+                  ~host:"dave.recoil.org"
+                  exclude);
     assert (not(Hostnet_http.Exclude.matches
-                  (Ipaddr.V4.of_string_exn "10.0.0.1")
-                  req' exclude))
+                  ~ip:(Ipaddr.V4.of_string_exn "10.0.0.1")
+                  ~host:"dave.recoil.org"
+                  exclude))
 
   let tests = [
     "HTTP: no_proxy CIDR match", [ "", `Quick, test_cidr_match ];

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -333,7 +333,7 @@ let test_proxy_authorization proxy () =
 
 let err_flush e = Fmt.kstrf failwith "%a" Incoming.C.pp_write_error e
 
-let test_http_connect proxy () =
+let test_http_connect_tunnel proxy () =
   let test_dst_ip = Ipaddr.V4.of_string_exn "1.2.3.4" in
   Host.Main.run begin
     Slirp_stack.with_stack ~pcap:"test_http_connect.pcap" (fun _ stack ->
@@ -740,8 +740,8 @@ let tests = [
   "HTTP: proxy-authorization",
   [ "check that proxy-authorization is present when proxy = " ^ proxy, `Quick, test_proxy_authorization proxy ];
 
-  "HTTP: CONNECT " ^ proxy,
-  [ "check that HTTP CONNECT works for HTTPS with proxy " ^ proxy, `Quick, test_http_connect (Uri.of_string proxy) ]
+  "HTTP: CONNECT tunnel though " ^ proxy,
+  [ "check that HTTP CONNECT tunnelling works for HTTPS with proxy " ^ proxy, `Quick, test_http_connect_tunnel (Uri.of_string proxy) ]
 ]) proxy_urls) @ [
   "HTTP: HEAD",
   [ "check that HTTP HEAD doesn't block the connection", `Quick, test_http_proxy_head ];

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -175,6 +175,13 @@ let test_interception proxy () =
     Alcotest.check Alcotest.string "version"
       (Cohttp.Code.string_of_version request.Cohttp.Request.version)
       (Cohttp.Code.string_of_version result.Cohttp.Request.version);
+    (* a request to a proxy must have an absolute URI *)
+    Alcotest.check Alcotest.string "uri"
+      "http://dave.recoil.org:80/"
+      result.Cohttp.Request.resource;
+    Alcotest.check Alcotest.(list(pair string string)) "headers"
+      (Cohttp.Header.to_list request.Cohttp.Request.headers)
+      (Cohttp.Header.to_list result.Cohttp.Request.headers);
     Lwt.return ()
   end
 

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -729,7 +729,7 @@ let tests = [
   [ "check that authorization is preserved", `Quick, test_authorization_preserved proxy ];
 
   "HTTP: proxy-authorization",
-  [ "check that proxy-authorization is present", `Quick, test_proxy_authorization proxy ];
+  [ "check that proxy-authorization is present when proxy = " ^ proxy, `Quick, test_proxy_authorization proxy ];
 
   "HTTP: CONNECT " ^ proxy,
   [ "check that HTTP CONNECT works for HTTPS with proxy " ^ proxy, `Quick, test_http_connect (Uri.of_string proxy) ]


### PR DESCRIPTION
#330 test: check that the HTTP proxy doesn't duplicate host: headers
#332 test: check the HTTP proxy handles HEAD requests
#334 test: strengthen the HTTP proxy host header test
#341 Fix HTTP proxy authentication
#343 allow excludes to contain IPs as well as IP prefixes
#344 dns: return NXDomain for a builtin where we don't have RRs