### PR TITLE
HTTP proxy: fix localhost

### DIFF
--- a/src/hostnet/hostnet_http.mli
+++ b/src/hostnet/hostnet_http.mli
@@ -40,7 +40,8 @@ sig
   (** Intercept outgoing HTTP flows and redirect to the upstream proxy
       if one is defined. *)
 
-  val explicit_proxy_handler: dst:(Ipaddr.V4.t * int) -> t:t ->
+  val explicit_proxy_handler: localhost_names:Dns.Name.t list ->
+    dst:(Ipaddr.V4.t * int) -> t:t ->
     (int -> (Tcp.flow -> unit Lwt.t) option) Lwt.t option
   (** Intercept outgoing HTTP proxy flows and if an upstream proxy is
       defined, redirect to it, otherwise implement the proxy function


### PR DESCRIPTION
 HTTP traffic on port 80 or 443 are dispatched based on destination IP address:
 
- if to "localhost" (e.g. `docker.for.mac.localhost`) they are forwarded to 127.0.0.1
- if to anywhere else they are funnelled through the transparent proxy
    
HTTP traffic sent to vpnkit's gateway IP on port 3128 (the HTTP proxy) but whose final destination is one of the names for the host's localhost is unfortunately routed to the wrong place.

This patch adds a `localhost_names` argument to the HTTP proxy `route` function. If the destination host is one of the `localhost_names` then it is rewritten as `localhost` which will then cause connections to the host's `localhost` as expected.
