### PR TITLE
[stable] more HTTP proxy fixes

### DIFF
--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -198,7 +198,6 @@ let hvsock_addr_of_uri ~default_serviceid uri =
     | Some "hyperv-connect" ->
       let module Ports = Active_list.Make(Forward_hvsock) in
       let fs = Ports.make clock in
-      Ports.set_context fs "";
       let module Server = Protocol_9p.Server.Make(Log9P)(HV)(Ports) in
       let sockaddr = hvsock_addr_of_uri ~default_serviceid:ports_serviceid uri in
       Connect_hvsock.set_port_forward_addr sockaddr;
@@ -212,7 +211,6 @@ let hvsock_addr_of_uri ~default_serviceid uri =
     | _ ->
       let module Ports = Active_list.Make(Forward_unix) in
       let fs = Ports.make clock in
-      Ports.set_context fs vsock_path;
       let module Server =
         Protocol_9p.Server.Make(Log9P)(Host.Sockets.Stream.Unix)(Ports)
       in

--- a/src/hostnet/forward.mli
+++ b/src/hostnet/forward.mli
@@ -12,6 +12,6 @@ module Make
     (Clock: Mirage_clock_lwt.MCLOCK)
     (Connector: Sig.Connector)
     (Socket: Sig.SOCKETS):
-  Active_list.Instance with type context = string and type clock = Clock.t
+  Active_list.Instance with type clock = Clock.t
 
 val set_allowed_addresses: Ipaddr.t list option -> unit

--- a/src/hostnet/hostnet_http.mli
+++ b/src/hostnet/hostnet_http.mli
@@ -40,7 +40,8 @@ sig
   (** Intercept outgoing HTTP flows and redirect to the upstream proxy
       if one is defined. *)
 
-  val explicit_proxy_handler: dst:(Ipaddr.V4.t * int) -> t:t ->
+  val explicit_proxy_handler: localhost_names:Dns.Name.t list ->
+    dst:(Ipaddr.V4.t * int) -> t:t ->
     (int -> (Tcp.flow -> unit Lwt.t) option) Lwt.t option
   (** Intercept outgoing HTTP proxy flows and if an upstream proxy is
       defined, redirect to it, otherwise implement the proxy function

--- a/src/hostnet_test/forwarding.ml
+++ b/src/hostnet_test/forwarding.ml
@@ -90,7 +90,6 @@ module PortsServer = struct
   let with_server f =
     Mclock.connect () >>= fun clock ->
     let ports = Ports.make clock in
-    Ports.set_context ports "";
     Host.Sockets.Stream.Tcp.bind (Ipaddr.V4 localhost, 0)
     >>= fun server ->
     let _, port = Host.Sockets.Stream.Tcp.getsockname server in

--- a/src/ofs/active_list.ml
+++ b/src/ofs/active_list.ml
@@ -39,10 +39,7 @@ module type Instance = sig
 
   val description_of_format: string
 
-  type context
-  (** The context in which a [t] is [start]ed, for example a TCP/IP stack *)
-
-  val start: clock -> context Var.t -> t -> (t, [ `Msg of string ]) result Lwt.t
+  val start: clock -> t -> (t, [ `Msg of string ]) result Lwt.t
 
   val stop: t -> unit Lwt.t
 
@@ -56,15 +53,11 @@ module Make (Instance: Instance) = struct
   open Protocol_9p
 
   type t = {
-    mutable context: Instance.context Var.t;
     clock: Instance.clock;
   }
 
   let make clock =
-    let context = Var.create () in
-    { context; clock }
-
-  let set_context { context; _ } x = Var.fill context x
+    { clock }
 
   (* We manage a list of named entries *)
   type entry = {
@@ -345,7 +338,7 @@ The directory will be deleted and replaced with a file of the same name.
         end else begin match Instance.of_string @@ Cstruct.to_string data with
         | Ok f ->
           let open Lwt.Infix in
-          begin Instance.start connection.t.clock connection.t.context f >>=
+          begin Instance.start connection.t.clock f >>=
             function
             | Ok f' -> (* local_port is resolved *)
               entry.instance <- Some f';


### PR DESCRIPTION
- [moby/vpnkit#346]: fix multiple --port arguments
- [moby/vpnkit#347]: fix proxy for docker.for.mac.http.internal