### PR TITLE
http: handle connections to the "host" IP

### DIFF
--- a/src/hostnet/hostnet_http.mli
+++ b/src/hostnet/hostnet_http.mli
@@ -40,7 +40,9 @@ sig
   (** Intercept outgoing HTTP flows and redirect to the upstream proxy
       if one is defined. *)
 
-  val explicit_proxy_handler: localhost_names:Dns.Name.t list ->
+  val explicit_proxy_handler:
+    localhost_names:Dns.Name.t list ->
+    localhost_ips:Ipaddr.t list ->
     dst:(Ipaddr.V4.t * int) -> t:t ->
     (int -> (Tcp.flow -> unit Lwt.t) option) Lwt.t option
   (** Intercept outgoing HTTP proxy flows and if an upstream proxy is

--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -134,6 +134,8 @@ module DNS = Dns_resolver_mirage.Make(Host.Time)(Client)
 
 let primary_dns_ip = Ipaddr.V4.of_string_exn "192.168.65.1"
 
+let localhost_ip = Ipaddr.V4.of_string_exn "192.168.65.2"
+
 let preferred_ip1 = Ipaddr.V4.of_string_exn "192.168.65.250"
 
 let config =

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -745,7 +745,7 @@ let test_http_connect_tunnel proxy () =
         )
     end
 
-  let test_http_proxy_localhost () =
+  let test_http_proxy_localhost host_or_ip () =
     Host.Main.run begin
       let forwarded, forwarded_u = Lwt.task () in
       Slirp_stack.with_stack ~pcap:"test_http_proxy_localhost.pcap" (fun _ stack ->
@@ -763,7 +763,7 @@ let test_http_connect_tunnel proxy () =
               Lwt.wakeup_later forwarded_u req;
               Lwt.return_unit
           ) (fun server ->
-            let host = "vpnkit.host" in
+            let host = host_or_ip in
             let port = server.Server.port in
             let open Slirp_stack in
             Client.TCPV4.create_connection (Client.tcpv4 stack.t) (primary_dns_ip, 3128)
@@ -877,8 +877,12 @@ let tests = [
   "HTTP proxy: GET has good headers",
   [ "check that HTTP GET headers are correct", `Quick, test_http_proxy_headers ];
 
+  "HTTP proxy: GET to localhost",
+  [ "check that HTTP GET to localhost via hostname", `Quick, test_http_proxy_localhost "vpnkit.host" ];
+
   "HTTP proxy: GET to localhost works",
-  [ "check that HTTP GET to localhost", `Quick, test_http_proxy_localhost ];
+  [ "check that HTTP GET to localhost via IP", `Quick, test_http_proxy_localhost (Ipaddr.V4.to_string Slirp_stack.localhost_ip) ];
+
 
 ] @ (List.concat @@ List.map (fun proxy -> [
   "HTTP: URI",


### PR DESCRIPTION
We already support connections to the "host" name (e.g. `docker.for.mac.http.internal`). This patch adds support for the "host" IP too.

Signed-off-by: David Scott <dave.scott@docker.com>