### PR TITLE
The default port max idle time should be 300s

### DIFF
--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -558,7 +558,7 @@ let listen_backlog =
 
 let port_max_idle_time =
   let doc = "Idle time to wait before timing out and disconnecting switch ports." in
-  Arg.(value & opt int 30 & info [ "port-max-idle-time" ] ~doc)
+  Arg.(value & opt int Configuration.default_port_max_idle_time & info [ "port-max-idle-time" ] ~doc)
 
 let debug =
   let doc = "Verbose debug logging to stdout" in


### PR DESCRIPTION
Previously it was 300s but it got accidentally typo'd to 30s when
we added the extra command-line arguments.

Related to [docker/for-win#1596]

Signed-off-by: David Scott <dave.scott@docker.com>