### PR TITLE
go: set the default control socket path depending on OS

### DIFF
--- a/go/cmd/vpnkit-expose-port/main.go
+++ b/go/cmd/vpnkit-expose-port/main.go
@@ -19,7 +19,7 @@ func main() {
 	hostPort := flag.Int("host-port", -1, "host port")
 	containerIP := flag.String("container-ip", "", "container ip")
 	containerPort := flag.Int("container-port", -1, "container port")
-	path := flag.String("vpnkit", os.Getenv("HOME")+"/Library/Containers/com.docker.docker/Data/s51", "path to vpnkit's control socket")
+	path := flag.String("vpnkit", "", "path to vpnkit's control socket")
 	flag.Parse()
 
 	c, err := vpnkit.NewConnection(context.Background(), *path)

--- a/go/cmd/vpnkit-list-ports/main.go
+++ b/go/cmd/vpnkit-list-ports/main.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"os"
 
 	vpnkit "github.com/moby/vpnkit/go/pkg/vpnkit"
 )
@@ -13,7 +12,7 @@ import (
 // List currently exposed ports
 
 func main() {
-	path := flag.String("vpnkit", os.Getenv("HOME")+"/Library/Containers/com.docker.docker/Data/s51", "path to vpnkit's control socket")
+	path := flag.String("vpnkit", "", "path to vpnkit's control socket")
 	flag.Parse()
 
 	c, err := vpnkit.NewConnection(context.Background(), *path)

--- a/go/pkg/vpnkit/connection_darwin.go
+++ b/go/pkg/vpnkit/connection_darwin.go
@@ -12,8 +12,12 @@ type Connection struct {
 }
 
 // NewConnection connects to a vpnkit Unix domain socket on the given path
-// and returns the connection
+// and returns the connection. If the path is the empty string then the
+// default system path will be used.
 func NewConnection(ctx context.Context, path string) (*Connection, error) {
+	if path == "" {
+		path = os.Getenv("HOME")+"/Library/Containers/com.docker.docker/Data/s51"
+	}
 	client, err := datakit.Dial(ctx, "unix", path)
 	if err != nil {
 		return nil, err

--- a/go/pkg/vpnkit/connection_windows.go
+++ b/go/pkg/vpnkit/connection_windows.go
@@ -1,0 +1,39 @@
+package vpnkit
+
+import (
+	"context"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+	datakit "github.com/moby/datakit/api/go-datakit"
+)
+
+// Connection represents an open control connection to vpnkit
+type Connection struct {
+	client *datakit.Client
+}
+
+// NewConnection connects to a vpnkit Unix domain socket on the given path
+// and returns the connection. If the path is the empty string then the
+// default system path will be used.
+func NewConnection(ctx context.Context, path string) (*Connection, error) {
+	if path == "" {
+		path = "//./pipe/dockerVpnKitControl"
+	}
+	timeout := time.Duration(30 * time.Second)
+	conn, err := winio.DialPipe(path, &timeout)
+	if err != nil {
+		return nil, err
+	}
+	client, err := datakit.NewClient(ctx, conn)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return NewConnectionForClient(client), nil
+}
+
+// NewConnectionForClient returns a connection using given client
+func NewConnectionForClient(client *datakit.Client) *Connection {
+	return &Connection{client}
+}


### PR DESCRIPTION
Darwin and Windows use a different control socket path, so adopt the
convention that if the user doesn't specifiy a path override, we use
the system one.

Signed-off-by: David Scott <dave.scott@docker.com>