### PR TITLE
dns: add names for the VM's IP

### DIFF
--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -399,7 +399,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
   let main
       socket_url port_control_urls introspection_urls diagnostics_urls
       max_connections vsock_path db_path db_branch dns http hosts host_names gateway_names
-      listen_backlog port_max_idle_time debug
+      vm_names listen_backlog port_max_idle_time debug
       server_macaddr domain allowed_bind_addresses gateway_ip host_ip lowest_ip highest_ip
       dhcp_json_path mtu log_destination
     =
@@ -418,6 +418,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
 
     let host_names = List.map Dns.Name.of_string @@ Astring.String.cuts ~sep:"," host_names in
     let gateway_names = List.map Dns.Name.of_string @@ Astring.String.cuts ~sep:"," gateway_names in
+    let vm_names = List.map Dns.Name.of_string @@ Astring.String.cuts ~sep:"," vm_names in
 
     let dns_path, resolver = match dns with
     | None -> None, Configuration.default_resolver
@@ -434,6 +435,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       port_max_idle_time;
       host_names;
       gateway_names;
+      vm_names;
       dns = Configuration.no_dns_servers;
       dns_path;
       http_intercept_path = http;
@@ -606,6 +608,14 @@ let gateway_names =
   in
   Arg.(value & opt string "gateway.internal" doc)
 
+let vm_names =
+  let doc =
+    Arg.info ~doc:
+      "Comma-separated list of DNS names to map to the VM's virtual IP"
+      [ "vm-names" ]
+  in
+  Arg.(value & opt string "vm.internal" doc)
+
 let listen_backlog =
   let doc = "Specify a maximum listen(2) backlog. If no override is specified \
              then we will use SOMAXCONN." in
@@ -695,7 +705,7 @@ let command =
   Term.(pure main
         $ socket $ port_control_urls $ introspection_urls $ diagnostics_urls
         $ max_connections $ vsock_path $ db_path $ db_branch $ dns $ http $ hosts
-        $ host_names $ gateway_names $ listen_backlog $ port_max_idle_time $ debug
+        $ host_names $ gateway_names $ vm_names $ listen_backlog $ port_max_idle_time $ debug
         $ server_macaddr $ domain $ allowed_bind_addresses $ gateway_ip $ host_ip
         $ lowest_ip $ highest_ip $ dhcp_json_path $ mtu $ Logging.log_destination),
   Term.info (Filename.basename Sys.argv.(0)) ~version:"%%VERSION%%" ~doc ~man

--- a/src/hostnet/configuration.ml
+++ b/src/hostnet/configuration.ml
@@ -53,10 +53,11 @@ type t = {
   port_max_idle_time: int;
   host_names: Dns.Name.t list;
   gateway_names: Dns.Name.t list;
+  vm_names: Dns.Name.t list;
 }
 
 let to_string t =
-  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns_path = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; gateway_ip = %s; host_ip = %s; lowest_ip = %s; highest_ip = %s; dhcp_json_path = %s; dhcp_configuration = %s; mtu = %d; http_intercept = %s; http_intercept_path = %s; port_max_idle_time = %s; host_names = %s; gateway_name = %s"
+  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns_path = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; gateway_ip = %s; host_ip = %s; lowest_ip = %s; highest_ip = %s; dhcp_json_path = %s; dhcp_configuration = %s; mtu = %d; http_intercept = %s; http_intercept_path = %s; port_max_idle_time = %s; host_names = %s; gateway_names = %s; vm_names = %s"
     (Macaddr.to_string t.server_macaddr)
     (match t.max_connections with None -> "None" | Some x -> string_of_int x)
     (match t.dns_path with None -> "None" | Some x -> x)
@@ -76,6 +77,7 @@ let to_string t =
     (string_of_int t.port_max_idle_time)
     (String.concat ", " (List.map Dns.Name.to_string t.host_names))
     (String.concat ", " (List.map Dns.Name.to_string t.gateway_names))
+    (String.concat ", " (List.map Dns.Name.to_string t.vm_names))
 
 let no_dns_servers =
   Dns_forward.Config.({ servers = Server.Set.empty; search = []; assume_offline_after_drops = None })
@@ -93,6 +95,7 @@ let default_port_max_idle_time = 300
 let default_server_macaddr = Macaddr.of_string_exn "F6:16:36:BC:F9:C6"
 let default_host_names = [ Dns.Name.of_string "vpnkit.host" ]
 let default_gateway_names = [ Dns.Name.of_string "gateway.internal" ]
+let default_vm_names = [ Dns.Name.of_string "vm.internal" ]
 
 let default_resolver = `Host
 
@@ -116,6 +119,7 @@ let default = {
   port_max_idle_time = default_port_max_idle_time;
   host_names = default_host_names;
   gateway_names = default_gateway_names;
+  vm_names = default_gateway_names;
 }
 
 module Parse = struct

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -1189,7 +1189,10 @@ struct
     in
     let builtin_names =
       (List.map (fun name -> name, Ipaddr.V4 c.Configuration.gateway_ip) c.Configuration.gateway_names)
-      @ (List.map (fun name -> name, Ipaddr.V4 c.Configuration.host_ip) c.Configuration.host_names) in
+      @ (List.map (fun name -> name, Ipaddr.V4 c.Configuration.host_ip) c.Configuration.host_names)
+      (* FIXME: what to do if there are multiple VMs? *)
+      @ (List.map (fun name -> name, Ipaddr.V4 c.Configuration.lowest_ip) c.Configuration.vm_names) in
+
     dns := dns_forwarder ~local_address ~builtin_names clock
 
   let update_dhcp c =


### PR DESCRIPTION
We already have DNS names for the gateway and for the host. This
adds the command-line option `--vm-names` which is a comma-separated
list of DNS names which will be mapped to the VM's IP.

Note this only behaves properly in the common case of 1 VM. All VMs
will map the `--vm-names` to the first VM IP.

Signed-off-by: David Scott <dave.scott@docker.com>