### PR TITLE
Display the sha1 instead of %%VERSION%%

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ LICENSEDIRS=$(REPO_ROOT)/repo/licenses
 BINDIR?=$(shell pwd)
 
 BINARIES := vpnkit.exe
-ARTEFACTS :=
+
+ARTEFACTS = COMMIT OSS-LICENSES
 ifeq ($(OS),Windows_NT)
 	ARTEFACTS += vpnkit.exe
 else
@@ -35,6 +36,7 @@ uninstall:
 		rm -f $$BINARY ; \
 	done
 
+.PHONY: artefacts
 artefacts: $(ARTEFACTS)
 
 vpnkit.tgz: vpnkit.exe
@@ -54,10 +56,10 @@ vpnkit.exe: $(OPAMROOT)
 .PHONY: test
 test: $(OPAMROOT)
 	opam config --root $(OPAMROOT) --switch $(OPAM_COMP) exec -- sh -c 'jbuilder build --dev src/hostnet_test/main.exe'
-	# One test requires 1026 file descriptors
+# One test requires 1026 file descriptors
 	ulimit -n 1500 && ./_build/default/src/hostnet_test/main.exe
 
-# Published as a artifact.
+# Published as an artifact.
 .PHONY: OSS-LICENSES
 OSS-LICENSES:
 	@echo "  GEN     " $@
@@ -67,7 +69,7 @@ OSS-LICENSES:
 	@$(REPO_ROOT)/repo/list-licenses.sh $(LICENSEDIRS) > $@.tmp
 	@mv $@.tmp $@
 
-# Published as a artifact.
+# Published as an artifact.
 .PHONY: COMMIT
 COMMIT:
 	@echo "  GEN     " $@

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,11 @@ vpnkit.exe: $(OPAMROOT)
 	opam config --root $(OPAMROOT) --switch $(OPAM_COMP) exec -- sh -c 'jbuilder build --dev src/bin/main.exe'
 	cp _build/default/src/bin/main.exe vpnkit.exe
 
+%: %.in
+	@echo "  GEN     " $@
+	@sed -e "s/@COMMIT@/$$(git rev-parse HEAD)/" $< >$@.tmp
+	@mv $@.tmp $@
+
 .PHONY: test
 test: $(OPAMROOT)
 	opam config --root $(OPAMROOT) --switch $(OPAM_COMP) exec -- sh -c 'jbuilder build --dev src/hostnet_test/main.exe'

--- a/circle.yml
+++ b/circle.yml
@@ -19,8 +19,6 @@ dependencies:
   - brew install wget opam dylibbundler pkg-config
   - make
   - make artefacts
-  - make OSS-LICENSES
-  - make COMMIT
   cache_directories:
     - _build/opam
 test:

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,5 +1,6 @@
 bin/depends.ml
 bin/depends.tmp
+bin/version.ml
 _tags
 configure
 hostnet/META

--- a/src/bin/jbuild
+++ b/src/bin/jbuild
@@ -9,6 +9,11 @@
    ))
    (preprocess  no_preprocessing)))
 
+(rule
+  ((targets (version.ml))
+   (deps    (version.ml.in ../../Makefile))
+   (action  (chdir ${ROOT} (run make src/bin/version.ml)))))
+
 (install
  ((section bin)
   (package vpnkit)

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -291,7 +291,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
     (try Sys.set_signal Sys.sigpipe Sys.Signal_ignore
     with Invalid_argument _ -> ());
     Log.info (fun f ->
-        f "Version %%VERSION%% from %%VCS_COMMIT_ID%%"
+        f "Version is %s" Version.git
     );
 
     Log.info (fun f -> f "System SOMAXCONN is %d" !Utils.somaxconn);

--- a/src/bin/version.ml.in
+++ b/src/bin/version.ml.in
@@ -1,0 +1,1 @@
+let git = "@COMMIT@"


### PR DESCRIPTION
In Docker for Mac we get logs that try to display the version of vpnkit, but don't.

I usually use the output of `git describe` instead of the raw sha, it is much more convenient, but it seems that the tags are somewhat different and don't allow that, I don't know why.  `git describe --tags` does though.
