### PR TITLE
Handle HTTP proxy on the host's "localhost"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,9 +16,6 @@ environment:
   OPAMVERBOSE: 1
   BINDIR: 'C:\projects\vpnkit'
 
-cache:
-  - _build\opam -> repo\win32
-
 install:
   - cmd: git config core.symlinks true
   - cmd: git reset --hard

--- a/src/hostnet/hostnet_http.mli
+++ b/src/hostnet/hostnet_http.mli
@@ -35,7 +35,10 @@ sig
   val to_json: t -> Ezjsonm.t
   (** [to_json t] encodes [t] into json *)
 
-  val transparent_proxy_handler: dst:(Ipaddr.V4.t * int) -> t:t ->
+  val transparent_proxy_handler:
+    localhost_names:Dns.Name.t list ->
+    localhost_ips:Ipaddr.t list ->
+    dst:(Ipaddr.V4.t * int) -> t:t ->
     (int -> Tcp.listener option) Lwt.t option
   (** Intercept outgoing HTTP flows and redirect to the upstream proxy
       if one is defined. *)


### PR DESCRIPTION
If the HTTP/HTTPS proxy is set to one of the special names for "localhost" (e.g. `docker.for.mac.localhost` on Docker for Mac) then we should connect to `127.0.0.1` in the transparent proxy. Previously we would do a DNS lookup for `docker.for.mac.localhost` which would obviously fail.

This restores the missing symmetry where all 4 combinations of HTTP,HTTPS and transparent,non-transparent inspect the `localhost_names` and `localhost_ips`. It would probably be better to refactor the DNS code to map these names in one central location but this requires a larger refactor.
