### PR TITLE
Add more tests for localhost DNS names

### DIFF
--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -138,10 +138,13 @@ let localhost_ip = Ipaddr.V4.of_string_exn "192.168.65.2"
 
 let preferred_ip1 = Ipaddr.V4.of_string_exn "192.168.65.250"
 
+let names_for_localhost = List.map Dns.Name.of_string [ "name1.for.localhost"; "name2.for.localhost" ]
+
 let config =
   let configuration = {
     Configuration.default with
     domain = Some "local";
+    host_names = names_for_localhost;
   } in
   Mclock.connect () >>= fun clock ->
   let vnet = Vnet.create () in

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -919,7 +919,9 @@ let test_http_connect_tunnel proxy () =
 let proxy_urls = [
   "http://127.0.0.1";
   "http://user:password@127.0.0.1";
-]
+] @ (List.map (fun name ->
+  Printf.sprintf "http://%s" (Dns.Name.to_string name)
+) Slirp_stack.names_for_localhost)
 
 let tests = [
 

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -941,16 +941,18 @@ let tests = [
   "HTTP proxy: GET has good headers",
   [ "check that HTTP GET headers are correct", `Quick, test_http_proxy_headers ];
 
-  "HTTP proxy: GET to localhost",
-  [ "check that HTTP GET to localhost via hostname", `Quick, test_http_proxy_localhost "vpnkit.host" ];
-
   "HTTP proxy: GET to localhost works",
   [ "check that HTTP GET to localhost via IP", `Quick, test_http_proxy_localhost (Ipaddr.V4.to_string Slirp_stack.localhost_ip) ];
 
   "HTTP proxy: transparent proxy respects excludes",
   [ "check that the transparent proxy will inspect and respect the Host: header", `Quick, test_transparent_http_proxy_exclude ];
 
-] @ (List.concat @@ List.map (fun proxy -> [
+] @ (List.map (fun name ->
+    "HTTP proxy: GET to localhost",
+    [ "check that HTTP GET to localhost via hostname", `Quick, test_http_proxy_localhost (Dns.Name.to_string name) ]
+  ) Slirp_stack.names_for_localhost
+) @ (List.concat @@ List.map (fun proxy -> [
+
   "HTTP: URI",
   [ "check that relative URIs are rewritten", `Quick, test_uri_relative proxy ];
 

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -919,6 +919,7 @@ let test_http_connect_tunnel proxy () =
 let proxy_urls = [
   "http://127.0.0.1";
   "http://user:password@127.0.0.1";
+  "http://localhost";
 ] @ (List.map (fun name ->
   Printf.sprintf "http://%s" (Dns.Name.to_string name)
 ) Slirp_stack.names_for_localhost)


### PR DESCRIPTION
- check that an HTTP GET works with all names for `localhost`
- check that the HTTP and HTTPS transparent proxy works with all names for `localhost`

Fixes #363
Tests #362