### PR TITLE
go: add a missing import

### DIFF
--- a/go/pkg/vpnkit/connection_darwin.go
+++ b/go/pkg/vpnkit/connection_darwin.go
@@ -2,6 +2,7 @@ package vpnkit
 
 import (
 	"context"
+	"os"
 
 	datakit "github.com/moby/datakit/api/go-datakit"
 )


### PR DESCRIPTION
The CI is not building the _darwin.go files.

Signed-off-by: David Scott <dave.scott@docker.com>