### PR TITLE
dns: avoid logging when we discover a name in /etc/hosts

### DIFF
--- a/src/hostnet/hostnet_dns.ml
+++ b/src/hostnet/hostnet_dns.ml
@@ -110,9 +110,6 @@ let try_etc_hosts =
       with
       | None -> None
       | Some v4 ->
-        Log.info (fun f ->
-            f "DNS: %s is %a in in /etc/hosts" (Dns.Name.to_string q_name)
-              Ipaddr.V4.pp_hum v4);
         Some [ { name = q_name; cls = RR_IN;
                  flush = false; ttl = 0l; rdata = A v4 } ]
     end
@@ -127,9 +124,6 @@ let try_etc_hosts =
       with
       | None -> None
       | Some v6 ->
-        Log.info (fun f ->
-            f "DNS: %s is %a in in /etc/hosts" (Dns.Name.to_string q_name)
-              Ipaddr.V6.pp_hum v6);
         Some [ { name = q_name; cls = RR_IN; flush = false; ttl = 0l;
                  rdata = AAAA v6 } ]
     end


### PR DESCRIPTION
This isn't particularly interesting information, and triggers a lot
of log spam: see [docker/for-mac#2699]

Signed-off-by: David Scott <dave.scott@docker.com>