### PR TITLE
Add a simple NTP server

### DIFF
--- a/src/hostnet/jbuild
+++ b/src/hostnet/jbuild
@@ -12,5 +12,6 @@
     mirage-protocols-lwt duration mirage-time-lwt mirage-clock-lwt
     mirage-random tcpip.unix
    ))
+   (preprocess (pps (ppx_cstruct)))
    (c_names (stubs_utils))
    (wrapped false)))

--- a/src/hostnet/ntp_server.ml
+++ b/src/hostnet/ntp_server.ml
@@ -8,19 +8,57 @@ module Log = (val Logs.src_log src : Logs.LOG)
 module Make
     (Ip: Mirage_protocols_lwt.IPV4)
     (Udp:Mirage_protocols_lwt.UDPV4)
-    (Clock: Mirage_clock_lwt.MCLOCK) =
+    (Clock: Mirage_clock_lwt.PCLOCK) =
 struct
 
+  (* From RFC2030 LOCL is an
+     > uncalibrated local clock used as a primary reference for
+     > a subnet without external means of synchronization *)
+  let local_reference_identifier =
+    let buf = Cstruct.create 4 in
+    Cstruct.blit_from_string "LOCL" 0 buf 0 4;
+    Cstruct.BE.get_uint32 buf 0
 
-  let reply request = request
+  (* Convert a Mirage PCLOCK (days, picoseconds) into an NTP timestamp *)
+  let timestamp (days, picoseconds) =
+    (* Posix time starts at   1970-01-01 00:00:00 UTC
+       but NTP time starts at 1900-01-01 00:00:00 UTC.
+       There were 17 leap years between 1900 and 1970.
+       Leap seconds started from 1972 so are irrelevant here.
+    *)
+    let days' = days + 70 * 365 + 17 in
+    let seconds = days' * 86400 + Int64.(to_int @@ div picoseconds 1_000_000_000_000L) in
+    let microseconds = Int64.(rem (div picoseconds 1_000_000L) 1_000_000L) in
+    let fraction = Int64.(div (shift_left microseconds 32) 1_000_000L) in
+    { Ntp_wire.timestamp = Int64.(logor (shift_left (of_int seconds) 32) fraction) }
 
-  let handle_udp ~udp ~src ~dst:_ ~src_port buf =
+  let reply request timestamp =
+    let open Ntp_wire in
+    {
+      leap = NoWarning;
+      version = request.version;
+      mode = (if request.mode = Client then Server else SymP);
+      stratum = Primary;
+      poll = request.poll;
+      precision = -20; (* 2 ^ -20 seconds i.e. about a microsecond *)
+      root_delay = { seconds = 0; fraction = 0 };
+      root_dispersion = { seconds = 0; fraction = 0 };
+      refid = local_reference_identifier;
+      reference_ts = timestamp;
+      origin_ts = request.trans_ts;
+      recv_ts = timestamp;
+      trans_ts = timestamp;
+    }
+
+  let handle_udp ~clock ~udp ~src ~dst:_ ~src_port buf =
     match Ntp_wire.pkt_of_buf buf with
     | None ->
       Log.warn (fun f -> f "Failed to parse NTP packet: %a" Cstruct.hexdump_pp buf);
       Lwt.return (Ok ())
     | Some request ->
-      let buf' = Ntp_wire.buf_of_pkt @@ reply request in
+      let now = Clock.now_d_ps clock in
+      let timestamp = timestamp now in
+      let buf' = Ntp_wire.buf_of_pkt @@ reply request timestamp in
       Udp.write ~src_port:123 ~dst:src ~dst_port:src_port udp buf'
 
 end

--- a/src/hostnet/ntp_server.ml
+++ b/src/hostnet/ntp_server.ml
@@ -1,0 +1,26 @@
+let src =
+  let src = Logs.Src.create "ntp" ~doc:"Simple NTP implementation" in
+  Logs.Src.set_level src (Some Logs.Info);
+  src
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+module Make
+    (Ip: Mirage_protocols_lwt.IPV4)
+    (Udp:Mirage_protocols_lwt.UDPV4)
+    (Clock: Mirage_clock_lwt.MCLOCK) =
+struct
+
+
+  let reply request = request
+
+  let handle_udp ~udp ~src ~dst:_ ~src_port buf =
+    match Ntp_wire.pkt_of_buf buf with
+    | None ->
+      Log.warn (fun f -> f "Failed to parse NTP packet: %a" Cstruct.hexdump_pp buf);
+      Lwt.return (Ok ())
+    | Some request ->
+      let buf' = Ntp_wire.buf_of_pkt @@ reply request in
+      Udp.write ~src_port:123 ~dst:src ~dst_port:src_port udp buf'
+
+end

--- a/src/hostnet/ntp_wire.ml
+++ b/src/hostnet/ntp_wire.ml
@@ -1,0 +1,254 @@
+(* the NTP RFCs use both greek letters ("theta") and words ("offset") to refer
+ * to the same things and it is frustrating. here is the correspondence between
+ * the two:
+     * clock offset     = theta
+     * round-trip delay = delta
+     * dispersion       = epsilon
+     * peer jitter      = psi
+ *
+ * variables with _i suffix are samples
+ * variables with _e suffix are estimates/averages
+ * variables beginning with ne_ (near end) are times measured/struck on/by our host
+ * variables beginning with fe_ (far  end) are times measured/struck on/by the server we query
+ *
+ * Therefore, when we create a packet, we strike   ne_transmit
+ * when it arrives at the server,      it strikes  fe_receive
+ * when it sends back a reply,         it strikes  fe_transmit
+ * when we receive the reply,          we strike   ne_receive
+ *
+ *
+ *
+ * The NTP protocol is symmetric and simple and yet the official documentation
+ * tries its best to obscure the simplicity. Every packet sent by a full
+ * implementation contains:
+
+     * a timestamp struck by the sender when the last packet from its interlocutor was received
+        (known as "receive timestamp")
+     * a timestamp struck by the sender when it is created
+        (known as "transmit timestamp")
+     * a copy of what was in the "transmit timestamp" field in the last packet received from its interlocutor
+        (known as "originator timestamp")
+
+ * Due to the symmetry of the NTP wire protocol, ne_transmit is in the
+ * "transmit timestamp" field when we sent a packet but is returned to us in
+ * the "origin timestamp" field.
+ *
+ *
+ * We implement a useful and clean subset (that is not SNTP!) of the NTP
+ * protocol that only permits use of the server and client modes. Nothing in
+ * the NTP wire protocol is asymmetric -- it permits two hosts that are
+ * exchanging NTP packets to each measure the offset and delay between each
+ * other. However, this symmetry is not needed in either the client or server
+ * modes and an implementation without it avoids needless complexity and
+ * obtains exactly the same results.
+ *
+ * Rather, the packets we send when in client mode only have a *single*
+ * timestamp field filled out -- the "transmit timestamp" field, with a
+ * timestamp we strike when we create that packet. We could actually fill it
+ * with a completely random number/nonce and store a nonce->timestamp mapping
+ * table locally, as the server does not process it beyond copying it into the
+ * "originator timestamp" field in its reply.
+ *
+ * We don't fill out the other two timestamp fields in the NTP packet that
+ * would let the server measure our offset/delay, nor do we fill out the
+ * "reference timestamp" field.
+ *
+ * The server will reply with a packet with the same information in the
+ * timestamps as it would for a packet with the "originator" and "receive"
+ * timestamps filled -- indeed, the first packet every NTP client sends to a
+ * server can't have those fields filled.
+ *
+ *)
+
+
+type ts = {
+    timestamp:  Cstruct.uint64 [@printer fun fmt -> fprintf fmt "0x%Lx"];
+}
+[@@deriving show]
+
+let ts_to_int64 ts =
+    ts.timestamp
+
+let int64_to_ts timestamp =
+    {timestamp}
+
+let to_float a =
+    let frac = Int64.of_int32 @@ Int64.to_int32 a.timestamp in   (* I'm so sorry. *)
+    let frac = match (frac < 0x0L) with
+    | true  -> Int64.add frac 0x100000000L                       (* I'm so so sorry *)
+    | false -> frac
+    in
+
+    let seconds = Int64.shift_right_logical a.timestamp 32 in
+
+    (Int64.to_float frac) /. (4294967296.0) +. Int64.to_float seconds
+
+type short_ts = {
+    seconds: Cstruct.uint16;
+    fraction: Cstruct.uint16;
+}
+
+let short_ts_to_int32 ts =
+    Int32.add (Int32.of_int ts.fraction) (Int32.shift_left (Int32.of_int ts.seconds) 16)
+
+let short_ts_to_float a =
+    Int32.to_float (short_ts_to_int32 a)
+
+let int32_to_short_ts i =
+    let seconds =  Int32.to_int(Int32.shift_right_logical i 16) in
+    let fraction = Int32.to_int(Int32.logand (Int32.of_int 0xffff) i) in
+    {seconds; fraction}
+
+type date = {
+    era: Cstruct.uint32;
+    offset: Cstruct.uint32;
+    fraction: Cstruct.uint64;
+}
+
+let log_to_float x =
+    2. ** (float x)
+
+type span    = Span    of int64 (* span represents a monotonic time value as measured by our clock -- what RFC 5905 calls "process time" *)
+type seconds = Seconds of float (* all the statistical calculations are on floats *)
+
+type leap_flavor = NoWarning | Minute61 | Minute59 | Unsync (* leap seconds were a mistake *)
+[@@deriving show]
+
+type version = int
+
+type mode = Reserved | SymA | SymP | Client | Server | Broadcast | Control | Private
+
+let lvm_to_int l v m =
+    let li = match l with
+    | NoWarning -> 0 lsl 6
+    | Minute61  -> 1 lsl 6
+    | Minute59  -> 2 lsl 6
+    | Unsync    -> 3 lsl 6 in
+    let vi = v lsl 3 in
+    let mi = match m with
+    | Reserved  -> 0
+    | SymA      -> 1
+    | SymP      -> 2
+    | Client    -> 3
+    | Server    -> 4
+    | Broadcast -> 5
+    | Control   -> 6
+    | Private   -> 7 in
+
+    li + vi + mi
+
+
+let flags_to_leap       f =
+    match f lsr 6 with
+    | 0 -> NoWarning
+    | 1 -> Minute61
+    | 2 -> Minute59
+    | 3 -> Unsync
+    | _ -> failwith ":("
+
+let flags_to_version    f = (f land 0x38) lsr 3
+let flags_to_mode       f =
+    match (f land 0x07) with
+    | 0 -> Reserved
+    | 1 -> SymA
+    | 2 -> SymP
+    | 3 -> Client
+    | 4 -> Server
+    | 5 -> Broadcast
+    | 6 -> Control
+    | 7 -> Private
+    | _ -> failwith ":("
+
+
+
+type stratum = Invalid | Primary | Secondary of int | Unsynchronized | Reserved of int
+[@@deriving show]
+
+let int_to_stratum (i: Cstruct.uint8) = match i with
+    | 0 -> Invalid
+    | 1 -> Primary
+    | n1 when ((n1 > 1) && (n1 < 16)) -> Secondary n1
+    | 16 -> Unsynchronized
+    | n2  -> Reserved n2
+
+let stratum_to_int s = match s with
+    | Invalid -> 0
+    | Primary -> 1
+    | Secondary n -> n
+    | Unsynchronized -> 16
+    | Reserved n -> n
+
+
+
+[%%cstruct
+type ntp = {
+    flags:              uint8_t;
+    stratum:            uint8_t;
+    poll:               int8_t;
+    precision:          int8_t;
+    root_delay:         uint32_t;
+    root_dispersion:    uint32_t;
+    refid:              uint32_t;
+    reference_ts:       uint64_t;   (* not really an important timestamp *)
+
+    (* the important timestamps *)
+                                    (* the below annotations only apply on a packet we're receiving! *)
+    origin_ts:          uint64_t;   (* T1: client-measured time when request departs *)
+    recv_ts:            uint64_t;   (* T2: server-measured time when request arrives *)
+    trans_ts:           uint64_t;   (* T3: server-measured time when reply   departs *)
+} [@@big_endian]]
+
+
+type pkt = {
+    leap            : leap_flavor;
+    version         : version;
+    mode            : mode;
+    stratum         : stratum;
+    poll            : int;
+    precision       : int;
+    root_delay      : short_ts;
+    root_dispersion : short_ts;
+    refid           : int32;
+    reference_ts    : ts;
+    origin_ts       : ts;
+    recv_ts         : ts;
+    trans_ts        : ts;
+}
+
+let buf_of_pkt p =
+    let buf = Cstruct.create sizeof_ntp in
+    set_ntp_flags           buf  (lvm_to_int p.leap p.version p.mode);
+    set_ntp_stratum         buf     (stratum_to_int p.stratum);
+    set_ntp_poll            buf                     p.poll;
+    set_ntp_precision       buf                     p.precision;
+    set_ntp_root_delay      buf (short_ts_to_int32  p.root_delay);
+    set_ntp_root_dispersion buf (short_ts_to_int32  p.root_dispersion);
+    set_ntp_refid           buf                     p.refid;
+    set_ntp_reference_ts    buf (ts_to_int64        p.reference_ts);
+    set_ntp_origin_ts       buf (ts_to_int64        p.origin_ts);
+    set_ntp_recv_ts         buf (ts_to_int64        p.recv_ts);
+    set_ntp_trans_ts        buf (ts_to_int64        p.trans_ts);
+
+    buf
+
+
+
+
+let pkt_of_buf b =
+    if Cstruct.len b <> sizeof_ntp then
+        None
+    else
+        let leap            = get_ntp_flags             b |> flags_to_leap      in
+        let version         = get_ntp_flags             b |> flags_to_version   in
+        let mode            = get_ntp_flags             b |> flags_to_mode      in
+        let stratum         = get_ntp_stratum           b |> int_to_stratum     in
+        let poll            = get_ntp_poll              b                       in
+        let precision       = get_ntp_precision         b                       in
+        let root_delay      = get_ntp_root_delay        b |> int32_to_short_ts  in
+        let root_dispersion = get_ntp_root_dispersion   b |> int32_to_short_ts  in
+        let refid           = get_ntp_refid             b                       in
+        let reference_ts    = get_ntp_reference_ts      b |> int64_to_ts        in
+        let origin_ts       = get_ntp_origin_ts         b |> int64_to_ts        in
+        let recv_ts         = get_ntp_recv_ts           b |> int64_to_ts        in
+        let trans_ts        = get_ntp_trans_ts          b |> int64_to_ts        in
+        Some {leap;version;mode; stratum; poll; precision; root_delay; root_dispersion; refid; reference_ts; origin_ts; recv_ts; trans_ts}

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -58,6 +58,7 @@ module Make
        include Mirage_clock_lwt.MCLOCK
        val connect: unit -> t Lwt.t
      end)
+    (PClock: Mirage_clock_lwt.PCLOCK)
     (Random: Mirage_random.C)
     (Vnet : Vnetif.BACKEND with type macaddr = Macaddr.t) =
 struct
@@ -69,6 +70,7 @@ struct
     client_uuids: uuid_table;
     vnet_switch: Vnet.t;
     clock: Clock.t;
+    pclock: PClock.t;
   }
 
   module Filteredif = Filter.Make(Vmnet)
@@ -106,7 +108,7 @@ struct
   module Http_forwarder =
     Hostnet_http.Make(Stack_ipv4)(Stack_udp)(Stack_tcp)(Host.Sockets)(Host.Dns)
   module Ntp_server =
-    Ntp_server.Make(Stack_ipv4)(Stack_udp)(Clock)
+    Ntp_server.Make(Stack_ipv4)(Stack_udp)(PClock)
 
   module Udp_nat = Hostnet_udp.Make(Host.Sockets)(Clock)(Host.Time)
   module Icmp_nat = Hostnet_icmp.Make(Host.Sockets)(Clock)(Host.Time)
@@ -545,6 +547,7 @@ struct
   module Gateway = struct
     type t = {
       clock: Clock.t;
+      pclock: PClock.t;
       endpoint: Endpoint.t;
       udp_nat: Udp_nat.t;
       dns_ips: Ipaddr.V4.t list;
@@ -593,7 +596,7 @@ struct
              payload = Udp { src = src_port; dst = 123;
                              payload = Payload payload; _ }; _ } ->
       let udp = t.endpoint.Endpoint.udp4 in
-      Ntp_server.handle_udp ~udp ~src ~dst ~src_port payload
+      Ntp_server.handle_udp ~clock:t.pclock ~udp ~src ~dst ~src_port payload
       >|= lift_udp_error
 
     (* HTTP proxy *)
@@ -616,8 +619,8 @@ struct
     | _ ->
       Lwt.return (Ok ())
 
-    let create clock endpoint udp_nat dns_ips localhost_names localhost_ips =
-      let tcp_stack = { clock; endpoint; udp_nat; dns_ips; localhost_names; localhost_ips } in
+    let create clock pclock endpoint udp_nat dns_ips localhost_names localhost_ips =
+      let tcp_stack = { clock; pclock; endpoint; udp_nat; dns_ips; localhost_names; localhost_ips } in
       let open Lwt.Infix in
       (* Wire up the listeners to receive future packets: *)
       Switch.Port.listen endpoint.Endpoint.netif
@@ -898,7 +901,7 @@ struct
     end
 
   let connect x vnet_switch vnet_client_id client_macaddr
-      c (global_arp_table:arp_table) clock
+      c (global_arp_table:arp_table) clock pclock
     =
 
     let valid_subnets = [ Ipaddr.V4.Prefix.global ] in
@@ -1098,7 +1101,7 @@ struct
               find_endpoint dst >>= fun endpoint ->
               Log.debug (fun f ->
                   f "creating gateway TCP/IP proxy for %a" Ipaddr.V4.pp_hum dst);
-              Gateway.create clock endpoint udp_nat [ c.Configuration.gateway_ip ]
+              Gateway.create clock pclock endpoint udp_nat [ c.Configuration.gateway_ip ]
                 c.Configuration.host_names [ Ipaddr.V4 c.Configuration.host_ip ]
             end >>= function
             | Error e ->
@@ -1226,7 +1229,7 @@ struct
         );
         Lwt.return_unit
 
-  let create_common clock vnet_switch c =
+  let create_common clock pclock vnet_switch c =
     (* If a `dns_path` is provided then watch it for updates *)
     let read_dns_file path =
       Log.info (fun f -> f "Reading DNS configuration from %s" path);
@@ -1352,17 +1355,18 @@ struct
       client_uuids;
       vnet_switch;
       clock;
+      pclock;
     } in
     Lwt.return t
 
-  let create_static clock vnet_switch c =
+  let create_static clock pclock vnet_switch c =
     update_http c
     >>= fun () ->
     update_dns c clock
     >>= fun () ->
-    create_common clock vnet_switch c
+    create_common clock pclock vnet_switch c
 
-  let create_from_active_config clock vnet_switch static_configuration config =
+  let create_from_active_config clock pclock vnet_switch static_configuration config =
     let c = ref static_configuration in
     let update f =
       let c' = f (!c) in
@@ -1451,7 +1455,7 @@ struct
     >>= fun port_max_idle_times ->
     on_change port_max_idle_times (fun port_max_idle_time -> update (fun c -> { c with port_max_idle_time }));
 
-    create_common clock vnet_switch (!c)
+    create_common clock pclock vnet_switch (!c)
 
   let connect_client_by_uuid_ip t (uuid:Uuidm.t) (preferred_ip:Ipaddr.V4.t option) =
     Lwt_mutex.with_lock t.client_uuids.mutex (fun () ->
@@ -1551,22 +1555,22 @@ struct
         Lwt.return (Hashtbl.find t.client_uuids.table uuid)
       )
 
-  let connect t client =
+  let connect stack client =
     Log.debug (fun f -> f "accepted vmnet connection");
     begin
       or_failwith "vmnet" @@
       Vmnet.of_fd
-        ~connect_client_fn:(connect_client_by_uuid_ip t)
-        ~server_macaddr:t.configuration.Configuration.server_macaddr
-        ~mtu:t.configuration.Configuration.mtu client
+        ~connect_client_fn:(connect_client_by_uuid_ip stack)
+        ~server_macaddr:stack.configuration.Configuration.server_macaddr
+        ~mtu:stack.configuration.Configuration.mtu client
       >>= fun x ->
       let client_macaddr = Vmnet.get_client_macaddr x in
       let client_uuid = Vmnet.get_client_uuid x in
-      get_client_ip_id t client_uuid
+      get_client_ip_id stack client_uuid
       >>= fun (client_ip, vnet_client_id) ->
-      connect x t.vnet_switch vnet_client_id
-        client_macaddr { t.configuration with lowest_ip = client_ip }
-        t.global_arp_table t.clock
+      connect x stack.vnet_switch vnet_client_id
+        client_macaddr { stack.configuration with lowest_ip = client_ip }
+        stack.global_arp_table stack.clock stack.pclock
     end
 
 end

--- a/src/hostnet/slirp.mli
+++ b/src/hostnet/slirp.mli
@@ -12,6 +12,7 @@ module Make
        include Mirage_clock_lwt.MCLOCK
        val connect: unit -> t Lwt.t
      end)
+    (PClock: Mirage_clock_lwt.PCLOCK)
     (Random: Mirage_random.C)
     (Vnet : Vnetif.BACKEND with type macaddr = Macaddr.t) :
 sig
@@ -19,10 +20,10 @@ sig
   type stack
   (** A TCP/IP stack which may talk to multiple ethernet clients *)
 
-  val create_static: Clock.t -> Vnet.t -> Configuration.t -> stack Lwt.t
+  val create_static: Clock.t -> PClock.t -> Vnet.t -> Configuration.t -> stack Lwt.t
   (** Initialise a TCP/IP stack, with a static configuration *)
 
-  val create_from_active_config: Clock.t -> Vnet.t -> Configuration.t -> Config.t -> stack Lwt.t
+  val create_from_active_config: Clock.t -> PClock.t -> Vnet.t -> Configuration.t -> Config.t -> stack Lwt.t
   (** Initialise a TCP/IP stack, allowing the dynamic Config.t to override
       the static Configuration.t *)
 

--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -66,7 +66,7 @@ module VMNET = Vmnet.Make(Host.Sockets.Stream.Tcp)
 module Config = Active_config.Make(Host.Time)(Host.Sockets.Stream.Unix)
 module Vnet = Basic_backend.Make
 module Slirp_stack =
-  Slirp.Make(Config)(VMNET)(Dns_policy)(Mclock)(Stdlibrandom)(Vnet)
+  Slirp.Make(Config)(VMNET)(Dns_policy)(Mclock)(Pclock)(Stdlibrandom)(Vnet)
 
 module Client = struct
   module Netif = VMNET
@@ -147,8 +147,9 @@ let config =
     host_names = names_for_localhost;
   } in
   Mclock.connect () >>= fun clock ->
+  Pclock.connect () >>= fun pclock ->
   let vnet = Vnet.create () in
-  Slirp_stack.create_static clock vnet configuration
+  Slirp_stack.create_static clock pclock vnet configuration
 
 (* This is a hacky way to get a hancle to the server side of the stack. *)
 let slirp_stack = ref None

--- a/src/hostnet_test/suite.ml
+++ b/src/hostnet_test/suite.ml
@@ -386,7 +386,7 @@ let tests =
   @ (test_dns true) @ (test_dns false)
   @ test_tcp @ Test_nat.tests @ Test_http.tests @ Test_http.Exclude.tests
   @ Test_half_close.tests @ Test_ping.tests
-  @ Test_bridge.tests
+  @ Test_bridge.tests @ Test_ntp.tests
 
 let scalability = [
   "1026conns",

--- a/src/hostnet_test/test_ntp.ml
+++ b/src/hostnet_test/test_ntp.ml
@@ -1,0 +1,94 @@
+open Lwt.Infix
+open Slirp_stack
+
+let src =
+  let src = Logs.Src.create "test" ~doc:"Test NTP" in
+  Logs.Src.set_level src (Some Logs.Debug);
+  src
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+let run ?(timeout=Duration.of_sec 60) t =
+  let timeout =
+    Host.Time.sleep_ns timeout >>= fun () ->
+    Lwt.fail_with "timeout"
+  in
+  Host.Main.run @@ Lwt.pick [ timeout; t ]
+
+let err_udp e = Fmt.kstrf failwith "%a" Client.UDPV4.pp_error e
+
+(* Send an NTP request *)
+let test_ntp() =
+  let t =
+    with_stack ~pcap:"test_ntp.pcap"  (fun _ stack ->
+      let virtual_port = 1024 in
+
+      let packet_t, packet_u = Lwt.task () in
+
+      Client.listen_udpv4 stack.t ~port:virtual_port (fun ~src:_ ~dst:_ ~src_port:_ buffer ->
+        match Ntp_wire.pkt_of_buf buffer with
+        | None ->
+          Log.err (fun f -> f "failed to parse NTP response: %a" Cstruct.hexdump_pp buffer);
+          Lwt.return_unit
+        | Some pkt ->
+          Lwt.wakeup_later packet_u pkt;
+        Lwt.return_unit
+      );
+
+      let request =
+        let open Ntp_wire in {
+          leap = NoWarning;
+          version = 4;
+          mode = Client;
+          stratum = Secondary 1;
+          poll = 0;
+          precision = 0;
+          root_delay = { seconds = 0; fraction = 0 };
+          root_dispersion = { seconds = 0; fraction = 0 };
+          refid = 0l;
+          reference_ts = { timestamp = 1L };
+          origin_ts = { timestamp = 2L };
+          recv_ts = { timestamp = 3L };
+          trans_ts = { timestamp = 4L };
+        } in
+        let buffer = Ntp_wire.buf_of_pkt request in
+        let udpv4 = Client.udpv4 stack.t in
+        let rec loop remaining =
+          if remaining = 0 then
+            failwith "Timed-out before UDP response arrived";
+          Log.debug (fun f -> f "Sending %d -> 123" virtual_port);
+          Client.UDPV4.write
+            ~src_port:virtual_port
+            ~dst:primary_dns_ip
+            ~dst_port:123 udpv4 buffer
+          >>= function
+          | Error e -> err_udp e
+          | Ok ()   ->
+            Lwt.pick [
+              (Host.Time.sleep_ns (Duration.of_sec 1) >|= fun () -> `Timeout);
+              (packet_t >|= fun p -> `Ok p)
+            ]
+            >>= function
+            | `Timeout ->
+              loop (remaining - 1)
+            | `Ok reply ->
+              let open Ntp_wire in
+              assert (reply.leap = NoWarning);
+              assert (reply.version = 4);
+              assert (reply.mode = Server);
+              assert (reply.stratum = Primary);
+              assert (reply.refid > 0l);
+              assert (reply.reference_ts.timestamp <> 1L);
+              assert (reply.origin_ts.timestamp = 4L); (* original trans_ts *)
+              assert (reply.recv_ts.timestamp <> 3L);
+              assert (reply.trans_ts.timestamp <> 4L);
+              Lwt.return_unit
+          in
+          loop 5
+        )
+  in
+  run t
+
+let tests = [
+  "NTP: got reply", [ "", `Quick, test_ntp ];
+]


### PR DESCRIPTION
This replaces the UDP forwarder on the gateway address port 123 with a Simple NTP server which uses the host's wall-clock as a time source. This allows the VMs to synchronise with the host, even when the host itself is not synchronised anywhere sensible.

Related to [docker/for-mac#2076]