### PR TITLE
Add a notion of forwarded UDP services

### DIFF
--- a/src/hostnet/configuration.ml
+++ b/src/hostnet/configuration.ml
@@ -54,10 +54,11 @@ type t = {
   host_names: Dns.Name.t list;
   gateway_names: Dns.Name.t list;
   vm_names: Dns.Name.t list;
+  udpv4_forwards: (int * (Ipaddr.V4.t * int)) list;
 }
 
 let to_string t =
-  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns_path = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; gateway_ip = %s; host_ip = %s; lowest_ip = %s; highest_ip = %s; dhcp_json_path = %s; dhcp_configuration = %s; mtu = %d; http_intercept = %s; http_intercept_path = %s; port_max_idle_time = %s; host_names = %s; gateway_names = %s; vm_names = %s"
+  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns_path = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; gateway_ip = %s; host_ip = %s; lowest_ip = %s; highest_ip = %s; dhcp_json_path = %s; dhcp_configuration = %s; mtu = %d; http_intercept = %s; http_intercept_path = %s; port_max_idle_time = %s; host_names = %s; gateway_names = %s; vm_names = %s; udpv4_forwards = %s"
     (Macaddr.to_string t.server_macaddr)
     (match t.max_connections with None -> "None" | Some x -> string_of_int x)
     (match t.dns_path with None -> "None" | Some x -> x)
@@ -78,6 +79,7 @@ let to_string t =
     (String.concat ", " (List.map Dns.Name.to_string t.host_names))
     (String.concat ", " (List.map Dns.Name.to_string t.gateway_names))
     (String.concat ", " (List.map Dns.Name.to_string t.vm_names))
+    (String.concat ", " (List.map (fun (src_port, (dst_ipv4, dst_port)) -> Printf.sprintf "%d -> %s:%d" src_port (Ipaddr.V4.to_string dst_ipv4) dst_port) t.udpv4_forwards))
 
 let no_dns_servers =
   Dns_forward.Config.({ servers = Server.Set.empty; search = []; assume_offline_after_drops = None })
@@ -120,6 +122,7 @@ let default = {
   host_names = default_host_names;
   gateway_names = default_gateway_names;
   vm_names = default_gateway_names;
+  udpv4_forwards = [];
 }
 
 module Parse = struct

--- a/src/hostnet/hostnet_udp.mli
+++ b/src/hostnet/hostnet_udp.mli
@@ -6,8 +6,9 @@
 type address = Ipaddr.t * int
 
 type datagram = {
-  src: address;
-  dst: address;
+  src: address; (** origin of the packet from the guest *)
+  dst: address; (** expected destination of the packet from the guest *)
+  intercept: address; (** address we will really send the packet to, pretending to be `dst` *)
   payload: Cstruct.t;
 }
 (** A UDP datagram *)
@@ -23,9 +24,11 @@ sig
   type t
   (** A UDP NAT implementation *)
 
-  val create: ?max_idle_time:int64 -> Clock.t -> t
+  val create: ?max_idle_time:int64 -> ?preserve_remote_port:bool -> Clock.t -> t
   (** Create a UDP NAT implementation which will keep "NAT rules" alive until
-      they become idle for the given [?max_idle_time] *)
+      they become idle for the given [?max_idle_time].
+      If [~preserve_remote_port] is set then reply traffic will come from the
+      remote source port, otherwise it will come from the NAT port. *)
 
   val set_send_reply: t:t -> send_reply:(datagram -> unit Lwt.t) -> unit
   (** Register a reply callback which will be used to send datagrams to the

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -603,21 +603,6 @@ struct
         ) raw
       >|= ok
 
-    (* UDP to port 123: localhost NTP *)
-    | Ipv4 { src; ttl;
-             payload = Udp { src = src_port; dst = 123;
-                             payload = Payload payload; _ }; _ } ->
-      let localhost = Ipaddr.V4.localhost in
-      Log.debug (fun f ->
-          f "UDP/123 request from port %d -- sending it to %a:%d" src_port
-            Ipaddr.V4.pp_hum localhost 123);
-      let datagram =
-        { Hostnet_udp.src = Ipaddr.V4 src, src_port;
-          dst = Ipaddr.V4 localhost, 123; payload }
-      in
-      Udp_nat.input ~t:t.udp_nat ~datagram ~ttl ()
-      >|= ok
-
     (* HTTP proxy *)
     | Ipv4 { src; dst;
              payload = Tcp { src = src_port; dst = dst_port; syn; raw;


### PR DESCRIPTION
Clients can connect to services on the host as well as virtual services running on the "gateway" address. This PR allows extra virtual UDP services on the gateway to be configured which are automatically proxied to somewhere else. This is convenient if we can't use `localhost` because the ports are privileged and we can't easily bind there (for example NTP on port `123`).

For example the argument `--udpv4-forwards 123:8.8.8.8:123` sets up a virtual listener on `docker.for.mac.gateway.internal:123` and proxies all traffic to `8.8.8.8:123`.

This PR also removes the default forwarding of NTP to `localhost` since this can now be accomplished with the command-line `--udpv4-forwards 123:127.0.0.1:123`