### PR TITLE
Avoid leaking fd on ethernet socket close

### DIFF
--- a/src/hostnet/vmnet.ml
+++ b/src/hostnet/vmnet.ml
@@ -519,6 +519,7 @@ module Make(C: Sig.CONN) = struct
 
   let err_eof t =
     Log.err (fun f -> f "%s.listen: read EOF so closing connection" t.log_prefix);
+    disconnect t >>= fun () ->
     Lwt.return false
 
   let err_unexpected t pp e =


### PR DESCRIPTION
Previously if the peer closes the ethernet socket (e.g. a hyperkit process
shuts down) then there would be a read error on the socket and we would log

> read EOF so closing connection

but we wouldn't close the connection (unlike in the "unexpected" error case).
This patch calls the idempotent function `disconnect` which wakes up callers
blocked in `after_disconnect` which includes the caller which will close
the underlying connection.

Signed-off-by: David Scott <dave.scott@docker.com>