### PR TITLE
ICMP: don't log an error if we can't parse an ICMP packet

### DIFF
--- a/src/hostnet/hostnet_icmp.ml
+++ b/src/hostnet/hostnet_icmp.ml
@@ -223,7 +223,7 @@ module Make
           Log.err (fun f -> f "Failed to forward unexpected ICMP datagram with type %d" ty);
           Lwt.return_true
         | Ok _ ->
-          Log.err (fun f -> f "Failed to forward unexpected IPv4 datagram");
+          Log.debug (fun f -> f "Failed to forward unexpected IPv4 datagram");
           Lwt.return_true
       ) (fun e ->
         Log.err (fun f ->


### PR DESCRIPTION
The ICMP sockets on the host are unusual in that they receive all the traffic seen by the host. For example if the user opens another terminal and runs `ping`, then `vpnkit` will see the responses too even though it didn't send the requests.

It's safe to ignore ICMP packets that we don't recognise since they weren't meant for us. This patch reduces the log level from `error` to `debug`.

Fixes #381

Signed-off-by: David Scott <dave.scott@docker.com>