### PR TITLE
Improve the HTTP error handling

### DIFF
--- a/src/hostnet/hostnet_http.ml
+++ b/src/hostnet/hostnet_http.ml
@@ -447,63 +447,69 @@ module Make
     let listeners _port =
       Log.debug (fun f -> f "HTTPS TCP handshake complete");
       let process flow =
-        Lwt.finalize
+        Lwt.catch
           (fun () ->
-            address_of_proxy ~localhost_names ~localhost_ips proxy
-            >>= function
-            | Error (`Msg m) ->
-              Log.err (fun f -> f "HTTP proxy: cannot forward to %s: %s" (Uri.to_string proxy) m);
-              Lwt.return_unit
-            | Ok ((ip, port) as address) ->
-              let host = Ipaddr.V4.to_string dst in
-              let description outgoing =
-                Fmt.strf "%s:443 %s %s:%d" host
-                  (if outgoing then "-->" else "<--") (Ipaddr.to_string ip) port
-              in
-              Log.info (fun f -> f "%s: CONNECT" (description true));
-              let connect =
-                let host = Ipaddr.V4.to_string dst in
-                let port = 443 in
-                let uri = Uri.make ~host ~port () in
-                let headers = add_proxy_authorization proxy (Cohttp.Header.init ()) in
-                let request = Cohttp.Request.make ~meth:`CONNECT ~headers uri in
-                { request with Cohttp.Request.resource = host ^ ":" ^ (string_of_int port) }
-              in
-              Socket.Stream.Tcp.connect address >>= function
-              | Error _ ->
-                Log.err (fun f ->
-                    f "Failed to connect to %s" (string_of_address address));
-                Lwt.return_unit
-              | Ok remote ->
-                let outgoing = Outgoing.C.create remote in
-                Lwt.finalize  (fun () ->
-                    Outgoing.Request.write ~flush:true (fun _ -> Lwt.return_unit)
-                      connect outgoing
-                    >>= fun () ->
-                    Outgoing.Response.read outgoing >>= function
-                    | `Eof ->
-                      Log.warn (fun f ->
-                          f "EOF from %s" (string_of_address address));
-                      Lwt.return_unit
-                    | `Invalid x ->
-                      Log.warn (fun f ->
-                          f "Failed to parse HTTP response on port %s: %s"
-                            (string_of_address address) x);
-                      Lwt.return_unit
-                    | `Ok res ->
-                      Log.info (fun f ->
-                          let open Cohttp.Response in
-                          f "%s: %s %s"
-                            (description false)
-                            (Cohttp.Code.string_of_version res.version)
-                            (Cohttp.Code.string_of_status res.status));
-                      Log.debug (fun f ->
-                          f "%s" (Sexplib.Sexp.to_string_hum
-                                    (Cohttp.Response.sexp_of_t res)));
-                      let incoming = Incoming.C.create flow in
-                      proxy_bytes ~incoming ~outgoing ~flow ~remote
-                  ) (fun () -> Socket.Stream.Tcp.close remote)
-          ) (fun () -> Tcp.close flow)
+            Lwt.finalize
+              (fun () ->
+                address_of_proxy ~localhost_names ~localhost_ips proxy
+                >>= function
+                | Error (`Msg m) ->
+                  Log.err (fun f -> f "HTTP proxy: cannot forward to %s: %s" (Uri.to_string proxy) m);
+                  Lwt.return_unit
+                | Ok ((ip, port) as address) ->
+                  let host = Ipaddr.V4.to_string dst in
+                  let description outgoing =
+                    Fmt.strf "%s:443 %s %s:%d" host
+                      (if outgoing then "-->" else "<--") (Ipaddr.to_string ip) port
+                  in
+                  Log.info (fun f -> f "%s: CONNECT" (description true));
+                  let connect =
+                    let host = Ipaddr.V4.to_string dst in
+                    let port = 443 in
+                    let uri = Uri.make ~host ~port () in
+                    let headers = add_proxy_authorization proxy (Cohttp.Header.init ()) in
+                    let request = Cohttp.Request.make ~meth:`CONNECT ~headers uri in
+                    { request with Cohttp.Request.resource = host ^ ":" ^ (string_of_int port) }
+                  in
+                  Socket.Stream.Tcp.connect address >>= function
+                  | Error _ ->
+                    Log.err (fun f ->
+                        f "Failed to connect to %s" (string_of_address address));
+                    Lwt.return_unit
+                  | Ok remote ->
+                    let outgoing = Outgoing.C.create remote in
+                    Lwt.finalize  (fun () ->
+                        Outgoing.Request.write ~flush:true (fun _ -> Lwt.return_unit)
+                          connect outgoing
+                        >>= fun () ->
+                        Outgoing.Response.read outgoing >>= function
+                        | `Eof ->
+                          Log.warn (fun f ->
+                              f "EOF from %s" (string_of_address address));
+                          Lwt.return_unit
+                        | `Invalid x ->
+                          Log.warn (fun f ->
+                              f "Failed to parse HTTP response on port %s: %s"
+                                (string_of_address address) x);
+                          Lwt.return_unit
+                        | `Ok res ->
+                          Log.info (fun f ->
+                              let open Cohttp.Response in
+                              f "%s: %s %s"
+                                (description false)
+                                (Cohttp.Code.string_of_version res.version)
+                                (Cohttp.Code.string_of_status res.status));
+                          Log.debug (fun f ->
+                              f "%s" (Sexplib.Sexp.to_string_hum
+                                        (Cohttp.Response.sexp_of_t res)));
+                          let incoming = Incoming.C.create flow in
+                          proxy_bytes ~incoming ~outgoing ~flow ~remote
+                      ) (fun () -> Socket.Stream.Tcp.close remote)
+              ) (fun () -> Tcp.close flow)
+          ) (fun e ->
+            Log.warn (fun f -> f "tunnel_https_over_connect caught exception: %s" (Printexc.to_string e));
+            Lwt.return_unit
+          )
       in Some { Tcp.process; keepalive }
     in
     Lwt.return listeners
@@ -677,27 +683,33 @@ module Make
     let listeners _port =
       Log.debug (fun f -> f "HTTP TCP handshake complete");
       let process flow =
-        Lwt.finalize (fun () ->
-            let incoming = Incoming.C.create flow in
-            let rec loop () =
-              Incoming.Request.read incoming >>= function
-              | `Eof -> Lwt.return_unit
-              | `Invalid x ->
-                Log.warn (fun f ->
-                    f "HTTP proxy failed to parse HTTP request: %s"
-                      x);
-                Lwt.return_unit
-              | `Ok req ->
-                fetch ~localhost_names ~localhost_ips ~flow proxy exclude incoming req
-                >>= function
-                | true ->
-                  (* keep the connection open, read more requests *)
+        Lwt.catch
+          (fun () ->
+            Lwt.finalize (fun () ->
+                let incoming = Incoming.C.create flow in
+                let rec loop () =
+                  Incoming.Request.read incoming >>= function
+                  | `Eof -> Lwt.return_unit
+                  | `Invalid x ->
+                    Log.warn (fun f ->
+                        f "HTTP proxy failed to parse HTTP request: %s"
+                          x);
+                    Lwt.return_unit
+                  | `Ok req ->
+                    fetch ~localhost_names ~localhost_ips ~flow proxy exclude incoming req
+                    >>= function
+                    | true ->
+                      (* keep the connection open, read more requests *)
+                      loop ()
+                    | false ->
+                      Log.debug (fun f -> f "HTTP session complete, closing connection");
+                      Lwt.return_unit in
                   loop ()
-                | false ->
-                  Log.debug (fun f -> f "HTTP session complete, closing connection");
-                  Lwt.return_unit in
-              loop ()
-          ) (fun () -> Tcp.close flow)
+              ) (fun () -> Tcp.close flow)
+          ) (fun e ->
+            Log.warn (fun f -> f "explicit_proxy caught exception: %s" (Printexc.to_string e));
+            Lwt.return_unit
+          )
       in
       Some { Tcp.process; keepalive }
     in
@@ -707,36 +719,42 @@ module Make
     let listeners _port =
       Log.debug (fun f -> f "HTTP TCP handshake complete");
       let process flow =
-        Lwt.finalize (fun () ->
-          let incoming = Incoming.C.create flow in
-          let rec loop () =
-            Incoming.Request.read incoming >>= function
-            | `Eof -> Lwt.return_unit
-            | `Invalid x ->
-              Log.warn (fun f ->
-                  f "Failed to parse HTTP request on port %a:80: %s"
-                    Ipaddr.V4.pp_hum dst x);
-              Lwt.return_unit
-            | `Ok req ->
-              (* If there is no Host: header or host in the URI then add a
-                 Host: header with the destination IP address -- this is not perfect
-                 but better than nothing and the majority of people will supply a Host:
-                 header these days because otherwise virtual hosts don't work *)
-              let req =
-                match get_host req with
-                | Error `Missing_host_header ->
-                  { req with Cohttp.Request.headers = Cohttp.Header.replace req.headers "host" (Ipaddr.V4.to_string dst) }
-                | Ok _ -> req in
-              fetch ~localhost_names ~localhost_ips ~flow (Some proxy) exclude incoming req
-              >>= function
-              | true ->
-                (* keep the connection open, read more requests *)
+        Lwt.catch
+          (fun () ->
+            Lwt.finalize (fun () ->
+              let incoming = Incoming.C.create flow in
+              let rec loop () =
+                Incoming.Request.read incoming >>= function
+                | `Eof -> Lwt.return_unit
+                | `Invalid x ->
+                  Log.warn (fun f ->
+                      f "Failed to parse HTTP request on port %a:80: %s"
+                        Ipaddr.V4.pp_hum dst x);
+                  Lwt.return_unit
+                | `Ok req ->
+                  (* If there is no Host: header or host in the URI then add a
+                    Host: header with the destination IP address -- this is not perfect
+                    but better than nothing and the majority of people will supply a Host:
+                    header these days because otherwise virtual hosts don't work *)
+                  let req =
+                    match get_host req with
+                    | Error `Missing_host_header ->
+                      { req with Cohttp.Request.headers = Cohttp.Header.replace req.headers "host" (Ipaddr.V4.to_string dst) }
+                    | Ok _ -> req in
+                  fetch ~localhost_names ~localhost_ips ~flow (Some proxy) exclude incoming req
+                  >>= function
+                  | true ->
+                    (* keep the connection open, read more requests *)
+                    loop ()
+                  | false ->
+                    Log.debug (fun f -> f "HTTP session complete, closing connection");
+                    Lwt.return_unit in
                 loop ()
-              | false ->
-                Log.debug (fun f -> f "HTTP session complete, closing connection");
-                Lwt.return_unit in
-            loop ()
-          ) (fun () -> Tcp.close flow)
+              ) (fun () -> Tcp.close flow)
+          ) (fun e ->
+            Log.warn (fun f -> f "transparent_http caught exception: %s" (Printexc.to_string e));
+            Lwt.return_unit
+          )
       in Some { Tcp.process; keepalive }
     in
     Lwt.return listeners


### PR DESCRIPTION
- catch stray exceptions in the byte proxy and treat as EOF
- log any stray exceptions that hit the top-level handlers