### PR TITLE
vpnkit-tap-vsockd: update logging, add a post-up script

### DIFF
--- a/c/vpnkit-tap-vsockd/Dockerfile
+++ b/c/vpnkit-tap-vsockd/Dockerfile
@@ -4,6 +4,8 @@ RUN apk add --no-cache go musl-dev build-base linux-headers
 COPY . /build
 RUN make -C /build sbin/vpnkit-tap-vsockd
 
-FROM scratch
+# Using alpine rather than scratch allows us to support post-up scripts
+FROM alpine:3.6
+
 COPY --from=build /build/sbin/vpnkit-tap-vsockd /sbin/vpnkit-tap-vsockd
 CMD [ "/sbin/vpnkit-tap-vsockd", "--tap", "eth0", "--message-size", "8192", "--buffer-size", "262144", "--listen" ]

--- a/c/vpnkit-tap-vsockd/log.c
+++ b/c/vpnkit-tap-vsockd/log.c
@@ -1,0 +1,13 @@
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "log.h"
+
+int verbose = 0;
+
+void fatal(const char *msg)
+{
+	ERROR("%s Error: %d. %s", msg, errno, strerror(errno));
+	exit(1);
+}

--- a/c/vpnkit-tap-vsockd/log.h
+++ b/c/vpnkit-tap-vsockd/log.h
@@ -1,0 +1,32 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+extern int verbose;
+#define ERROR(...)                                                      \
+    do {                                                                \
+		printf(__VA_ARGS__);                                            \
+		fflush(stdout);                                                 \
+    } while (0)
+#define INFO(...)                                                       \
+    do {                                                                \
+        if (verbose) {                                                  \
+            printf(__VA_ARGS__);                                        \
+            fflush(stdout);                                             \
+        }                                                               \
+    } while (0)
+#define DBG(...)                                                        \
+    do {                                                                \
+        if (verbose > 1) {                                              \
+            printf(__VA_ARGS__);                                        \
+            fflush(stdout);                                             \
+        }                                                               \
+    } while (0)
+#define TRC(...)                                                        \
+    do {                                                                \
+        if (verbose > 2) {                                              \
+            printf(__VA_ARGS__);                                        \
+            fflush(stdout);                                             \
+        }                                                               \
+    } while (0)
+
+extern void fatal(const char *msg);

--- a/c/vpnkit-tap-vsockd/tap-vsockd.c
+++ b/c/vpnkit-tap-vsockd/tap-vsockd.c
@@ -545,6 +545,7 @@ int main(int argc, char **argv)
 	struct connection connection;
 	char *tap = "eth1";
 	char *pidfile = NULL;
+	char *post_up_script = NULL;
 	int lsocket = -1;
 	int sock = -1;
 	int res = 0;
@@ -564,6 +565,7 @@ int main(int argc, char **argv)
 		{"serviceid", required_argument, NULL, 's'},
 		{"tap", required_argument, NULL, 't'},
 		{"pidfile", required_argument, NULL, 'p'},
+		{"post-up-script", required_argument, NULL, 'x'},
 		{"listen", no_argument, &listen_flag, 1},
 		{"connect", no_argument, &connect_flag, 1},
 		{"buffer-size", required_argument, NULL, 'b'},
@@ -596,6 +598,9 @@ int main(int argc, char **argv)
 			break;
 		case 'p':
 			pidfile = optarg;
+			break;
+		case 'x':
+			post_up_script = optarg;
 			break;
 		case 'b':
 			ring_size = atoi(optarg);
@@ -666,6 +671,12 @@ int main(int argc, char **argv)
 			);
 		set_macaddr(tap, &connection.vif.mac[0]);
 		set_mtu(tap, connection.vif.mtu);
+
+		if (post_up_script) {
+			INFO("Executing post-up-script %s", post_up_script);
+			int result = system(post_up_script);
+			INFO("Result of post-up-script = %d", result);
+		}
 
 		/* Daemonize after we've made our first reliable connection */
 		if (daemon_flag) {

--- a/c/vpnkit-tap-vsockd/tap-vsockd.c
+++ b/c/vpnkit-tap-vsockd/tap-vsockd.c
@@ -598,6 +598,7 @@ int main(int argc, char **argv)
 		{"connect", no_argument, &connect_flag, 1},
 		{"buffer-size", required_argument, NULL, 'b'},
 		{"message-size", required_argument, NULL, 'm'},
+		{"verbose", no_argument, NULL, 'v'},
 		{0, 0, 0, 0}
 	};
 


### PR DESCRIPTION
Previously we used a mixture of `DEBUG` `INFO` macros and calls to `syslog`. We had a `verbose` flag in the code but this wasn't hooked up to the command-line. This PR makes the code use logging macros everywhere and hooks up the `verbose` flag, removing `syslog` because there is no `syslog` in LinuxKit VMs.

Since a user of this will want to configure the interface once it has been brought up, this PR also adds a command-line `--post-up-script` which will be called as soon as the interface is created. The script can be used to run DHCP or otherwise configure the IP address of the interface. To make use of this easier, the final image has been upgraded to an `alpine` with the usual scripting tools.