### PR TITLE
vpnkit-tap-vsockd, vpnkit-9pmount-vsock: try AF_VSOCK first, fall back to AF_HVSOCK

### DIFF
--- a/c/vpnkit-9pmount-vsock/9pmount-vsock.c
+++ b/c/vpnkit-9pmount-vsock/9pmount-vsock.c
@@ -11,6 +11,8 @@
 #include <fcntl.h>
 #include <err.h>
 #include <sys/wait.h>
+#include <sys/socket.h>
+#include <linux/vm_sockets.h>
 
 #include "hvsock.h"
 
@@ -20,7 +22,6 @@
 
 int mode = NONE;
 
-char *default_sid = "C378280D-DA14-42C8-A24E-0DE92A1028E2";
 char *mount = "/bin/mount";
 
 void fatal(const char *msg)
@@ -64,7 +65,7 @@ static int handle(int fd, char *tag, char *path)
 	return WEXITSTATUS(status);
 }
 
-static int create_listening_socket(GUID serviceid)
+static int create_listening_hvsocket(GUID serviceid)
 {
 	SOCKADDR_HV sa;
 	int lsock;
@@ -72,7 +73,7 @@ static int create_listening_socket(GUID serviceid)
 
 	lsock = socket(AF_HYPERV, SOCK_STREAM, HV_PROTOCOL_RAW);
 	if (lsock == -1)
-		fatal("socket()");
+		return -1;
 
 	sa.Family = AF_HYPERV;
 	sa.Reserved = 0;
@@ -81,16 +82,43 @@ static int create_listening_socket(GUID serviceid)
 
 	res = bind(lsock, (const struct sockaddr *)&sa, sizeof(sa));
 	if (res == -1)
-		fatal("bind()");
+		return -1; /* ignore the fd leak */
 
 	res = listen(lsock, 1);
 	if (res == -1)
-		fatal("listen()");
+		return -1; /* ignore the fd leak */
 
 	return lsock;
 }
 
-static int connect_socket(GUID serviceid)
+static int create_listening_vsocket(long port)
+{
+	struct sockaddr_vm sa;
+	int lsock;
+	int res;
+
+	lsock = socket(AF_VSOCK, SOCK_STREAM, 0);
+	if (lsock == -1)
+		return -1;
+
+	sa.svm_family = AF_VSOCK;
+	sa.svm_reserved1 = 0;
+	sa.svm_port = port;
+	sa.svm_cid = VMADDR_CID_ANY;
+
+	res = bind(lsock, (const struct sockaddr *)&sa, sizeof(sa));
+	if (res == -1)
+		return -1; /* ignore the fd leak */
+
+	res = listen(lsock, 1);
+	if (res == -1)
+		return -1; /* ignore the fd leak */
+
+	return lsock;
+}
+
+
+static int connect_hvsocket(GUID serviceid)
 {
 	SOCKADDR_HV sa;
 	int sock;
@@ -98,7 +126,7 @@ static int connect_socket(GUID serviceid)
 
 	sock = socket(AF_HYPERV, SOCK_STREAM, HV_PROTOCOL_RAW);
 	if (sock == -1)
-		fatal("socket()");
+		return -1;
 
 	sa.Family = AF_HYPERV;
 	sa.Reserved = 0;
@@ -107,12 +135,34 @@ static int connect_socket(GUID serviceid)
 
 	res = connect(sock, (const struct sockaddr *)&sa, sizeof(sa));
 	if (res == -1)
-		fatal("connect()");
+		return -1; /* ignore the fd leak */
 
 	return sock;
 }
 
-static int accept_socket(int lsock)
+static int connect_vsocket(long port)
+{
+	struct sockaddr_vm sa;
+	int sock;
+	int res;
+
+	sock = socket(AF_VSOCK, SOCK_STREAM, 0);
+	if (sock == -1)
+		return -1;
+
+	sa.svm_family = AF_VSOCK;
+	sa.svm_reserved1 = 0;
+	sa.svm_port = port;
+	sa.svm_cid = VMADDR_CID_HOST;
+
+	res = connect(sock, (const struct sockaddr *)&sa, sizeof(sa));
+	if (res == -1)
+		return -1; /* ignore the fd leak */
+
+	return sock;
+}
+
+static int accept_hvsocket(int lsock)
 {
 	SOCKADDR_HV sac;
 	socklen_t socklen = sizeof(sac);
@@ -128,15 +178,29 @@ static int accept_socket(int lsock)
 	return csock;
 }
 
+static int accept_vsocket(int lsock)
+{
+	struct sockaddr_vm sac;
+	socklen_t socklen = sizeof(sac);
+	int csock;
+
+	csock = accept(lsock, (struct sockaddr *)&sac, &socklen);
+	if (csock == -1)
+		fatal("accept()");
+
+	syslog(LOG_INFO, "Connect from: port=%x cid=%d", sac.svm_port, sac.svm_cid);
+
+	return csock;
+}
+
 void usage(char *name)
 {
 	printf("%s: mount a 9P filesystem from an hvsock connection\n", name);
 	printf("usage:\n");
-	printf("\t[--serviceid <guid>] <listen | connect> <tag> <path>\n");
+	printf("\t[--vsock port] <listen | connect> <tag> <path>\n");
 	printf("where\n");
-	printf("\t--serviceid <guid>: use <guid> as the well-known service GUID\n");
-	printf("\t  (defaults to %s)\n", default_sid);
-	printf("\t--listen: listen forever for incoming AF_HVSOCK connections\n");
+	printf("\t--vsock <port>: use the AF_VSOCK <port>\n");
+	printf("\t--listen: listen forever for incoming AF_VSOCK connections\n");
 	printf("\t--connect: connect to the parent partition\n");
 }
 
@@ -145,8 +209,8 @@ int main(int argc, char **argv)
 	int res = 0;
 	GUID sid;
 	int c;
-	/* Defaults to a testing GUID */
-	char *serviceid = default_sid;
+	unsigned int port = 0;
+	char serviceid[36];
 	char *tag = NULL;
 	char *path = NULL;
 
@@ -154,18 +218,18 @@ int main(int argc, char **argv)
 	while (1) {
 		static struct option long_options[] = {
 			/* These options set a flag. */
-			{"serviceid", required_argument, NULL, 's'},
+			{"vsock", required_argument, NULL, 'v'},
 			{0, 0, 0, 0}
 		};
 		int option_index = 0;
 
-		c = getopt_long(argc, argv, "s:", long_options, &option_index);
+		c = getopt_long(argc, argv, "v:", long_options, &option_index);
 		if (c == -1)
 			break;
 
 		switch (c) {
-		case 's':
-			serviceid = optarg;
+		case 'v':
+			port = (unsigned int) strtol(optarg, NULL, 0);
 			break;
 		case 0:
 			break;
@@ -206,6 +270,7 @@ int main(int argc, char **argv)
 		exit(1);
 	}
 
+	snprintf(serviceid, sizeof(serviceid), "%08x-FACB-11E6-BD58-64006A7986D3", port);
 	res = parseguid(serviceid, &sid);
 	if (res) {
 		fprintf(stderr,
@@ -221,20 +286,33 @@ int main(int argc, char **argv)
 		int r;
 
 		if (mode == LISTEN) {
-			syslog(LOG_INFO, "starting in listening mode with serviceid=%s, tag=%s, path=%s", serviceid, tag, path);
-			lsocket = create_listening_socket(sid);
-			sock = accept_socket(lsocket);
-			close(lsocket);
+			syslog(LOG_INFO, "starting in listening mode with port=%x, tag=%s, path=%s", port, tag, path);
+			lsocket = create_listening_vsocket(port);
+			if (lsocket != -1) {
+				sock = accept_vsocket(lsocket);
+				close(lsocket);
+			} else {
+				syslog(LOG_INFO, "failed to create AF_VSOCK, trying with AF_HVSOCK serviceid=%s", serviceid);
+				lsocket = create_listening_hvsocket(sid);
+				if (lsocket == -1)
+					fatal("create_listening_vsocket");
+				sock = accept_hvsocket(lsocket);
+				close(lsocket);
+			}
 		} else {
-			syslog(LOG_INFO, "starting in connect mode with serviceid=%s, tag=%s, path=%s", serviceid, tag, path);
-			sock = connect_socket(sid);
+			syslog(LOG_INFO, "starting in connect mode with port=%x, tag=%s, path=%s", port, tag, path);
+			sock = connect_vsocket(port);
+			if (sock == -1) {
+				syslog(LOG_INFO, "failed to connect AF_VSOCK, trying with AF_HVSOCK serviceid=%s", sid);
+				sock = connect_hvsocket(sid);
+			}
 		}
 
 		r = handle(sock, tag, path);
 		close(sock);
 
 		if (r == 0) {
-			syslog(LOG_INFO, "mount successful for serviceid=%s tag=%s path=%s", serviceid, tag, path);
+			syslog(LOG_INFO, "mount successful for (serviceid=%s) port=%x tag=%s path=%s", serviceid, port, tag, path);
 			exit(0);
 		}
 
@@ -242,7 +320,7 @@ int main(int argc, char **argv)
 		 * This can happen if the client times out the connection
 		 * after we accept it
 		 */
-		syslog(LOG_CRIT, "mount failed with %d for serviceid=%s tag=%s path=%s", r, serviceid, tag, path);
+		syslog(LOG_CRIT, "mount failed with %d for (serviceid=%s) port=%x tag=%s path=%s", r, serviceid, port, tag, path);
 		sleep(1); /* retry */
 	}
 }

--- a/c/vpnkit-9pmount-vsock/Dockerfile
+++ b/c/vpnkit-9pmount-vsock/Dockerfile
@@ -1,11 +1,11 @@
-FROM alpine:3.6 as build
-RUN apk add --no-cache go musl-dev build-base linux-headers
+FROM alpine:3.8 as build
+RUN apk add --no-cache musl-dev build-base linux-headers
 
 COPY . /build
 RUN make -C /build sbin/vpnkit-9pmount-vsock
 
 # Can't use scratch as we need /bin/mount
-FROM alpine:3.6
+FROM alpine:3.8
 ENTRYPOINT []
 CMD []
 WORKDIR /

--- a/c/vpnkit-9pmount-vsock/log.c
+++ b/c/vpnkit-9pmount-vsock/log.c
@@ -1,0 +1,13 @@
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "log.h"
+
+int verbose = 0;
+
+void fatal(const char *msg)
+{
+	ERROR("%s Error: %d. %s", msg, errno, strerror(errno));
+	exit(1);
+}

--- a/c/vpnkit-9pmount-vsock/log.h
+++ b/c/vpnkit-9pmount-vsock/log.h
@@ -1,0 +1,34 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+extern int verbose;
+#define ERROR(...)                                                      \
+    do {                                                                \
+		printf(__VA_ARGS__);                                            \
+        printf("\n");                                                   \
+		fflush(stdout);                                                 \
+    } while (0)
+#define INFO(...)                                                       \
+    do {                                                                \
+        printf(__VA_ARGS__);                                            \
+        printf("\n");                                                   \
+        fflush(stdout);                                                 \
+    } while (0)
+#define DBG(...)                                                        \
+    do {                                                                \
+        if (verbose > 1) {                                              \
+            printf(__VA_ARGS__);                                        \
+            printf("\n");                                               \
+            fflush(stdout);                                             \
+        }                                                               \
+    } while (0)
+#define TRC(...)                                                        \
+    do {                                                                \
+        if (verbose > 2) {                                              \
+            printf(__VA_ARGS__);                                        \
+            printf("\n");                                               \
+            fflush(stdout);                                             \
+        }                                                               \
+    } while (0)
+
+extern void fatal(const char *msg);

--- a/c/vpnkit-tap-vsockd/Dockerfile
+++ b/c/vpnkit-tap-vsockd/Dockerfile
@@ -1,11 +1,11 @@
-FROM alpine:3.6 as build
-RUN apk add --no-cache go musl-dev build-base linux-headers
+FROM alpine:3.8 as build
+RUN apk add --no-cache musl-dev build-base linux-headers
 
 COPY . /build
 RUN make -C /build sbin/vpnkit-tap-vsockd
 
 # Using alpine rather than scratch allows us to support post-up scripts
-FROM alpine:3.6
+FROM alpine:3.8
 
 COPY --from=build /build/sbin/vpnkit-tap-vsockd /sbin/vpnkit-tap-vsockd
 CMD [ "/sbin/vpnkit-tap-vsockd", "--tap", "eth0", "--message-size", "8192", "--buffer-size", "262144", "--listen" ]

--- a/c/vpnkit-tap-vsockd/Makefile
+++ b/c/vpnkit-tap-vsockd/Makefile
@@ -6,7 +6,7 @@ HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
 all: sbin/vpnkit-tap-vsockd
 
 build-in-container:
-	docker build --network none -t vpnkit-tap-vsockd:$(HASH) -f Dockerfile .
+	docker build -t vpnkit-tap-vsockd:$(HASH) -f Dockerfile .
 
 sbin/vpnkit-tap-vsockd: $(SRC)
 	mkdir -p sbin

--- a/c/vpnkit-tap-vsockd/log.h
+++ b/c/vpnkit-tap-vsockd/log.h
@@ -5,17 +5,20 @@ extern int verbose;
 #define ERROR(...)                                                      \
     do {                                                                \
 		printf(__VA_ARGS__);                                            \
+        printf("\n");                                                   \
 		fflush(stdout);                                                 \
     } while (0)
 #define INFO(...)                                                       \
     do {                                                                \
         printf(__VA_ARGS__);                                            \
+        printf("\n");                                                   \
         fflush(stdout);                                                 \
     } while (0)
 #define DBG(...)                                                        \
     do {                                                                \
         if (verbose > 1) {                                              \
             printf(__VA_ARGS__);                                        \
+            printf("\n");                                               \
             fflush(stdout);                                             \
         }                                                               \
     } while (0)
@@ -23,6 +26,7 @@ extern int verbose;
     do {                                                                \
         if (verbose > 2) {                                              \
             printf(__VA_ARGS__);                                        \
+            printf("\n");                                               \
             fflush(stdout);                                             \
         }                                                               \
     } while (0)

--- a/c/vpnkit-tap-vsockd/log.h
+++ b/c/vpnkit-tap-vsockd/log.h
@@ -9,10 +9,8 @@ extern int verbose;
     } while (0)
 #define INFO(...)                                                       \
     do {                                                                \
-        if (verbose) {                                                  \
-            printf(__VA_ARGS__);                                        \
-            fflush(stdout);                                             \
-        }                                                               \
+        printf(__VA_ARGS__);                                            \
+        fflush(stdout);                                                 \
     } while (0)
 #define DBG(...)                                                        \
     do {                                                                \


### PR DESCRIPTION
The `AF_HVSOCK` patches were never merged in upstream Linux, instead Hyper-V support was added to `AF_VSOCK` instead. One consequence is the `AF_VSOCK` "port" is mapped into a special space of Hyper-V service GUIDs. This patch modifies `vpnkit-tap-vsockd` and `vpnkit-9pmount-vsock` to first try `AF_VSOCK` and then fall back to `AF_HVSOCK`.

This patch changes the command-lines from
```
      --serviceid <guid>
```
 to
```
      --vsock <port>
```