### PR TITLE
hvsock: call `bind` before `listen`

### DIFF
--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -123,6 +123,8 @@ let hvsock_addr_of_uri ~default_serviceid uri =
             (Hvsock.string_of_vmid sockaddr.Hvsock.vmid)
             sockaddr.Hvsock.serviceid);
           log_exception_continue "HV.Hvsock.close" (fun () -> HV.Hvsock.close socket)
+          >>= fun () ->
+          Host.Time.sleep_ns (Duration.of_sec 1)
       )
       >>= fun () ->
       aux () in

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -107,6 +107,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       hvsock_create ()
       >>= fun socket ->
       Lwt.catch (fun () ->
+        HV.Hvsock.bind socket sockaddr;
         HV.Hvsock.listen socket 5;
         let rec accept_forever () =
           HV.Hvsock.accept socket


### PR DESCRIPTION
In the `hvsock-listen://` codepath, we forgot to call `bind` which would cause the `listen` to return with `EINVAL` (reasonably) and then `vpnkit` to spin hard (unreasonably). So

- call `bind` before `listen`
- on error, wait 1s rather than spin hard