### PR TITLE
vpnkit-{9pmount,tap}-vsock: bzero struct sockaddr

### DIFF
--- a/c/vpnkit-9pmount-vsock/9pmount-vsock.c
+++ b/c/vpnkit-9pmount-vsock/9pmount-vsock.c
@@ -68,6 +68,7 @@ static int create_listening_hvsocket(GUID serviceid)
 	if (lsock == -1)
 		return -1;
 
+	bzero(&sa, sizeof(sa));
 	sa.Family = AF_HYPERV;
 	sa.Reserved = 0;
 	sa.VmId = HV_GUID_WILDCARD;
@@ -94,6 +95,7 @@ static int create_listening_vsocket(long port)
 	if (lsock == -1)
 		return -1;
 
+	bzero(&sa, sizeof(sa));
 	sa.svm_family = AF_VSOCK;
 	sa.svm_reserved1 = 0;
 	sa.svm_port = port;
@@ -121,6 +123,7 @@ static int connect_hvsocket(GUID serviceid)
 	if (sock == -1)
 		return -1;
 
+	bzero(&sa, sizeof(sa));
 	sa.Family = AF_HYPERV;
 	sa.Reserved = 0;
 	sa.VmId = HV_GUID_PARENT;
@@ -143,6 +146,7 @@ static int connect_vsocket(long port)
 	if (sock == -1)
 		return -1;
 
+	bzero(&sa, sizeof(sa));
 	sa.svm_family = AF_VSOCK;
 	sa.svm_reserved1 = 0;
 	sa.svm_port = port;

--- a/c/vpnkit-tap-vsockd/tap-vsockd.c
+++ b/c/vpnkit-tap-vsockd/tap-vsockd.c
@@ -411,6 +411,7 @@ static int create_listening_hvsocket(GUID serviceid)
 	if (lsock == -1)
 		return -1;
 
+	bzero(&sa, sizeof(sa));
 	sa.Family = AF_HYPERV;
 	sa.Reserved = 0;
 	sa.VmId = HV_GUID_WILDCARD;
@@ -437,6 +438,7 @@ static int create_listening_vsocket(long port)
 	if (lsock == -1)
 		return -1;
 
+	bzero(&sa, sizeof(sa));
 	sa.svm_family = AF_VSOCK;
 	sa.svm_reserved1 = 0;
 	sa.svm_port = port;
@@ -464,6 +466,7 @@ static int connect_hvsocket(GUID serviceid)
 	if (sock == -1)
 		return -1;
 
+	bzero(&sa, sizeof(sa));
 	sa.Family = AF_HYPERV;
 	sa.Reserved = 0;
 	sa.VmId = HV_GUID_PARENT;
@@ -486,6 +489,7 @@ static int connect_vsocket(long port)
 	if (sock == -1)
 		return -1;
 
+	bzero(&sa, sizeof(sa));
 	sa.svm_family = AF_VSOCK;
 	sa.svm_reserved1 = 0;
 	sa.svm_port = port;


### PR DESCRIPTION
These `struct sockaddr` values are on the stack and are therefore not pre-zeroed. Some of the Linux syscalls check for zeros (in particular `connect`) and will reject the calls with EINVAL if non-zero data is present.

Signed-off-by: David Scott <dave.scott@docker.com>