### PR TITLE
Add an "nmap" test case

### DIFF
--- a/src/hostnet/capture.ml
+++ b/src/hostnet/capture.ml
@@ -264,6 +264,12 @@ module Make(Input: Sig.VMNET) = struct
   let of_fd ~connect_client_fn:_ ~server_macaddr:_ ~mtu:_ =
     failwith "Capture.of_fd unimplemented"
 
+  let start_capture _ ?size_limit:_ _ =
+    failwith "Capture.start_capture unimplemented"
+
+  let stop_capture _ =
+    failwith "Capture.stop_capture unimplemented"
+
   let get_client_uuid _ =
     failwith "Capture.get_client_uuid unimplemented"
 

--- a/src/hostnet/filter.ml
+++ b/src/hostnet/filter.ml
@@ -129,4 +129,9 @@ module Make(Input: Sig.VMNET) = struct
   let get_client_macaddr _ =
     failwith "Filter.get_client_macaddr unimplemented"
 
+  let start_capture _ ?size_limit:_ _ =
+    failwith "Filter.start_capture unimplemented"
+
+  let stop_capture _ =
+    failwith "Filter.stop_capture unimplemented"
 end

--- a/src/hostnet/sig.ml
+++ b/src/hostnet/sig.ml
@@ -214,6 +214,10 @@ module type VMNET = sig
     mtu:int ->
     fd -> (t, [`Msg of string]) result Lwt.t
 
+  val start_capture: t -> ?size_limit:int64 -> string -> unit Lwt.t
+
+  val stop_capture: t -> unit Lwt.t
+
   val get_client_uuid: t -> Uuidm.t
 
   val get_client_macaddr: t -> Macaddr.t

--- a/src/hostnet/vmnet.ml
+++ b/src/hostnet/vmnet.ml
@@ -358,6 +358,54 @@ module Make(C: Sig.CONN) = struct
         Log.err (fun f -> f "%s: Server requires protocol version %s, we have %s" client_log_prefix (Int32.to_string x) (Int32.to_string Init.default.version));
         Lwt_result.fail (`Msg "Server does not support our version of the protocol")
 
+  (* Use blocking I/O here so we can avoid Using Lwt_unix or Uwt. Ideally we
+     would use a FLOW handle referencing a file/stream. *)
+  let really_write fd str =
+    let rec loop ofs =
+      if ofs = (Bytes.length str)
+      then ()
+      else
+        let n = Unix.write fd str ofs (Bytes.length str - ofs) in
+        loop (ofs + n)
+    in
+    loop 0
+
+  let start_capture t ?size_limit filename =
+    Lwt_mutex.with_lock t.pcap_m (fun () ->
+        (match t.pcap with Some fd -> Unix.close fd | None -> ());
+        let fd =
+          Unix.openfile filename [ Unix.O_WRONLY; Unix.O_TRUNC; Unix.O_CREAT ]
+            0o0644
+        in
+        let buf = Cstruct.create Pcap.LE.sizeof_pcap_header in
+        let open Pcap.LE in
+        set_pcap_header_magic_number buf Pcap.magic_number;
+        set_pcap_header_version_major buf Pcap.major_version;
+        set_pcap_header_version_minor buf Pcap.minor_version;
+        set_pcap_header_thiszone buf 0l;
+        set_pcap_header_sigfigs buf 4l;
+        set_pcap_header_snaplen buf 1500l;
+        set_pcap_header_network buf
+          (Pcap.Network.to_int32 Pcap.Network.Ethernet);
+        really_write fd (Cstruct.to_string buf |> Bytes.of_string);
+        t.pcap <- Some fd;
+        t.pcap_size_limit <- size_limit;
+        Lwt.return ()
+      )
+
+  let stop_capture_already_locked t = match t.pcap with
+  | None    -> ()
+  | Some fd ->
+    Unix.close fd;
+    t.pcap <- None;
+    t.pcap_size_limit <- None
+
+  let stop_capture t =
+    Lwt_mutex.with_lock t.pcap_m  (fun () ->
+        stop_capture_already_locked t;
+        Lwt.return_unit
+      )
+
   let make ~client_macaddr ~server_macaddr ~mtu ~client_uuid ~log_prefix fd =
     let fd = Some fd in
     let stats = Mirage_net.Stats.create () in
@@ -414,8 +462,35 @@ module Make(C: Sig.CONN) = struct
 
   let after_disconnect t = t.after_disconnect
 
+  let capture t bufs =
+    match t.pcap with
+    | None -> Lwt.return ()
+    | Some pcap ->
+      Lwt_mutex.with_lock t.pcap_m (fun () ->
+          let len = List.(fold_left (+) 0 (map Cstruct.len bufs)) in
+          let time = Unix.gettimeofday () in
+          let secs = Int32.of_float time in
+          let usecs = Int32.of_float (1e6 *. (time -. (floor time))) in
+          let buf = Cstruct.create Pcap.sizeof_pcap_packet in
+          let open Pcap.LE in
+          set_pcap_packet_ts_sec buf secs;
+          set_pcap_packet_ts_usec buf usecs;
+          set_pcap_packet_incl_len buf @@ Int32.of_int len;
+          set_pcap_packet_orig_len buf @@ Int32.of_int len;
+          really_write pcap (Cstruct.to_string buf |> Bytes.of_string);
+          List.iter (fun buf -> really_write pcap (Cstruct.to_string buf |> Bytes.of_string)) bufs;
+          match t.pcap_size_limit with
+          | None -> Lwt.return () (* no limit *)
+          | Some limit ->
+            let limit = Int64.(sub limit (of_int len)) in
+            t.pcap_size_limit <- Some limit;
+            if limit < 0L then stop_capture_already_locked t;
+            Lwt.return_unit
+        )
+
   let writev t bufs =
     Lwt_mutex.with_lock t.write_m (fun () ->
+        capture t bufs >>= fun () ->
         let len = List.(fold_left (+) 0 (map Cstruct.len bufs)) in
         if len > (t.mtu + ethernet_header_length) then begin
           Log.err (fun f ->
@@ -479,6 +554,7 @@ module Make(C: Sig.CONN) = struct
        let read_header = Cstruct.concat bufs in
        with_msg t (Packet.unmarshal read_header) @@ fun (len, _) ->
        with_read t (Channel.read_exactly ~len fd) @@ fun bufs ->
+       capture t bufs >>= fun () ->
        Log.debug (fun f ->
            let b = Buffer.create 128 in
            List.iter (Cstruct.hexdump_to_buffer b) bufs;
@@ -549,6 +625,7 @@ module Make(C: Sig.CONN) = struct
 
   let write t buf =
     Lwt_mutex.with_lock t.write_m (fun () ->
+        capture t [ buf ] >>= fun () ->
         let len = Cstruct.len buf in
         if len > (t.mtu + ethernet_header_length) then begin
           Log.err (fun f ->

--- a/src/hostnet/vmnet.ml
+++ b/src/hostnet/vmnet.ml
@@ -482,7 +482,7 @@ module Make(C: Sig.CONN) = struct
        Log.debug (fun f ->
            let b = Buffer.create 128 in
            List.iter (Cstruct.hexdump_to_buffer b) bufs;
-           f "received\n%s" (Buffer.contents b)
+           f "received%s" (Buffer.contents b)
          );
        let buf = Cstruct.concat bufs in
        let callback buf =
@@ -551,7 +551,7 @@ module Make(C: Sig.CONN) = struct
             Log.debug (fun f ->
                 let b = Buffer.create 128 in
                 Cstruct.hexdump_to_buffer b buf;
-                f "sending\n%s" (Buffer.contents b)
+                f "sending%s" (Buffer.contents b)
               );
             Channel.write_buffer fd buf;
             Channel.flush fd >|= function

--- a/src/hostnet/vmnet.mli
+++ b/src/hostnet/vmnet.mli
@@ -27,6 +27,17 @@ module Make(C: Sig.CONN): sig
   val client_of_fd: uuid:Uuidm.t -> ?preferred_ip:Ipaddr.V4.t ->
       server_macaddr:Macaddr.t -> C.flow -> (t, [`Msg of string]) result Lwt.t
 
+  val start_capture: t -> ?size_limit:int64 -> string -> unit Lwt.t
+  (** [start_capture t ?size_limit filename] closes any existing pcap
+      capture file and starts capturing to [filename]. If
+      [?size_limit] is provided then the file will be automatically
+      closed after the given number of bytes are written -- this is to
+      avoid forgetting to close the file and filling up your storage
+      with capture data. *)
+
+  val stop_capture: t -> unit Lwt.t
+  (** [stop_capture t] stops any in-progress capture and closes the file. *)
+
   val get_client_uuid: t -> Uuidm.t
 
   val get_client_macaddr: t -> Macaddr.t

--- a/src/hostnet_test/packets.ml
+++ b/src/hostnet_test/packets.ml
@@ -1,0 +1,12 @@
+
+
+let icmp_echo_request ~id ~seq ~len =
+  let payload = Cstruct.create len in
+  let pattern = "plz reply i'm so lonely" in
+  for i = 0 to Cstruct.len payload - 1 do
+    Cstruct.set_char payload i pattern.[i mod (String.length pattern)]
+  done;
+  let req = Icmpv4_packet.({code = 0x00; ty = Icmpv4_wire.Echo_request;
+                            subheader = Id_and_seq (id, seq)}) in
+  let header = Icmpv4_packet.Marshal.make_cstruct req ~payload in
+  Cstruct.concat [ header; payload ]

--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -127,6 +127,7 @@ module Client = struct
     } in
     connect cfg ethif arp ipv4 icmpv4 udp4 tcp4
     >>= fun t ->
+    Log.info (fun f -> f "Client has connected");
     Lwt.return { t; icmpv4 ; netif=interface }
 end
 
@@ -167,16 +168,20 @@ let start_stack config () =
   Host.Sockets.Stream.Tcp.bind (Ipaddr.V4 Ipaddr.V4.localhost, 0)
   >|= fun server ->
   let _, port = Host.Sockets.Stream.Tcp.getsockname server in
+  Log.info (fun f -> f "Bound vpnkit server to localhost:%d" port);
   Host.Sockets.Stream.Tcp.listen server (fun flow ->
+      Log.info (fun f -> f "Server connecting   TCP/IP stack");
       Slirp_stack.connect config flow  >>= fun stack ->
+      Log.info (fun f -> f "Server connected    TCP/IP stack");
       set_slirp_stack stack;
-      Log.info (fun f -> f "stack connected");
       Slirp_stack.after_disconnect stack >|= fun () ->
-      Log.info (fun f -> f "stack disconnected")
+      Log.info (fun f -> f "Server disconnected TCP/IP stack")
     );
   server, port
 
-let stop_stack server = Host.Sockets.Stream.Tcp.shutdown server
+let stop_stack server =
+  Log.info (fun f -> f "Shutting down slirp stack");
+  Host.Sockets.Stream.Tcp.shutdown server
 
 let pcap_dir = "./_pcap/"
 
@@ -184,11 +189,12 @@ let with_stack ?uuid ?preferred_ip ~pcap:_ f =
   config >>= fun config ->
   start_stack config ()
   >>= fun (server, port) ->
+  Log.info (fun f -> f "Connecting to vpnkit server on localhost:%d" port);
   Host.Sockets.Stream.Tcp.connect (Ipaddr.V4 Ipaddr.V4.localhost, port)
   >>= function
   | Error (`Msg x) -> failwith x
   | Ok flow ->
-    Log.info (fun f -> f "Made a loopback connection");
+    Log.info (fun f -> f "Connected  to vpnkit server on localhost:%d" port);
     let server_macaddr = Configuration.default_server_macaddr in
     let uuid =
       match uuid, Uuidm.of_string "d1d9cd61-d0dc-4715-9bb3-4c11da7ad7a5" with
@@ -203,11 +209,14 @@ let with_stack ?uuid ?preferred_ip ~pcap:_ f =
       Host.Sockets.Stream.Tcp.close flow >>= fun () ->
       failwith x
     | Ok client' ->
+      Log.info (fun f -> f "Client has established an ethernet link with the vpnkit server");
       (try Unix.mkdir pcap_dir 0o0755 with Unix.Unix_error(Unix.EEXIST, _, _) -> ());
       Lwt.finalize (fun () ->
-          Log.info (fun f -> f "Initialising client TCP/IP stack");
+          Log.info (fun f -> f "Client connecting TCP/IP stack");
           Client.connect client' >>= fun client ->
+          Log.info (fun f -> f "Client connected  TCP/IP stack");
           get_slirp_stack () >>= fun slirp_stack ->
+          Log.info (fun f -> f "Calling test case with client and server stack handles");
           f slirp_stack client
         ) (fun () ->
           (* Server will close when it gets EOF *)

--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -185,7 +185,7 @@ let stop_stack server =
 
 let pcap_dir = "./_pcap/"
 
-let with_stack ?uuid ?preferred_ip ~pcap:_ f =
+let with_stack ?uuid ?preferred_ip ~pcap f =
   config >>= fun config ->
   start_stack config ()
   >>= fun (server, port) ->
@@ -211,6 +211,8 @@ let with_stack ?uuid ?preferred_ip ~pcap:_ f =
     | Ok client' ->
       Log.info (fun f -> f "Client has established an ethernet link with the vpnkit server");
       (try Unix.mkdir pcap_dir 0o0755 with Unix.Unix_error(Unix.EEXIST, _, _) -> ());
+      VMNET.start_capture client' (pcap_dir ^ pcap)
+      >>= fun () ->
       Lwt.finalize (fun () ->
           Log.info (fun f -> f "Client connecting TCP/IP stack");
           Client.connect client' >>= fun client ->

--- a/src/hostnet_test/suite.ml
+++ b/src/hostnet_test/suite.ml
@@ -420,4 +420,6 @@ let tests =
 let scalability = [
   "1026conns",
   [ "Test many connections", `Quick, test_many_connections (1024 + 2) ];
+  "nmap the host",
+  [ "check that we can survive an agressive port scan", `Quick, Test_nmap.test_nmap ];
 ]

--- a/src/hostnet_test/test_nmap.ml
+++ b/src/hostnet_test/test_nmap.ml
@@ -1,0 +1,107 @@
+open Lwt.Infix
+open Slirp_stack
+
+let src =
+  let src = Logs.Src.create "test" ~doc:"Test the slirp stack" in
+  Logs.Src.set_level src (Some Logs.Debug);
+  src
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+let failf fmt = Fmt.kstrf failwith fmt
+
+let run_test ?(timeout=Duration.of_sec 60) t =
+  let timeout =
+    Host.Time.sleep_ns timeout >>= fun () ->
+    Lwt.fail_with "timeout"
+  in
+  Host.Main.run @@ Lwt.pick [ timeout; t ]
+
+let run ?timeout ~pcap t = run_test ?timeout (with_stack ~pcap t)
+
+let test_nmap () =
+  (* Attempt to connect to all ports on the host IP, then see if the host
+     is still pingable afterwards. This checks for connection leaks / exchaustion. *)
+
+  let t _ stack =
+    let start = Unix.gettimeofday () in
+    let open_ports = ref [] in
+    let connect_disconnect ip port =
+      Client.TCPV4.create_connection (Client.tcpv4 stack.Client.t) (ip, port)
+      >>= function
+      | Error _ ->
+        Lwt.return_unit
+      | Ok flow ->
+        open_ports := port :: !open_ports;
+        Client.TCPV4.close flow
+        >>= fun () ->
+        Lwt.return_unit in
+    (* Limit the number of concurrent connection requests *)
+    let max_concurrent = 10000 in
+    let cur_concurrent = ref 0 in
+    let completed = ref 0 in
+    let cur_concurrent_c = Lwt_condition.create () in
+    let rec scan_all_ports ip first last =
+      if first > last
+      then Lwt.return_unit
+      else begin
+        let rec wait () =
+          if !cur_concurrent < max_concurrent then begin
+            incr cur_concurrent;
+            Lwt.return_unit
+          end else begin
+            Lwt_condition.wait cur_concurrent_c
+            >>= fun () ->
+            wait ()
+          end in
+        wait ()
+        >>= fun () ->
+        Lwt.async (fun () ->
+          connect_disconnect ip first
+          >>= fun () ->
+          decr cur_concurrent;
+          incr completed;
+          Lwt_condition.broadcast cur_concurrent_c ();
+          Lwt.return_unit
+        );
+        scan_all_ports ip (first + 1) last
+      end in
+    let rec show_status () =
+      Host.Time.sleep_ns (Duration.of_sec 5)
+      >>= fun () ->
+      Log.info (fun f -> f "Connections completed: %d; connections in progress: %d" !completed !cur_concurrent);
+      show_status () in
+    Lwt.pick [
+      scan_all_ports localhost_ip 1 65535;
+      show_status ()
+    ] >>= fun () ->
+    let rec wait () =
+      if !cur_concurrent > 0 then begin
+        Lwt_condition.wait cur_concurrent_c
+        >>= fun () ->
+        wait ()
+      end else Lwt.return_unit in
+    wait ()
+    >>= fun () ->
+    Log.info (fun f -> f "Total time taken to scan localhost: %.1f seconds" (Unix.gettimeofday () -. start));
+    Log.info (fun f -> f "The following ports are open:");
+    List.iter (fun port -> Log.info (fun f -> f "  %d" port)) !open_ports;
+    (* Ping the host to check it's still working *)
+    let rec loop seq =
+      if Queue.length Client.Icmpv41.packets > 0
+      then Lwt.return_unit
+      else begin
+        let ping = Packets.icmp_echo_request ~id:0x1234 ~seq ~len:0 in
+        Log.info (fun f -> f "sending ping to verify the stack is still working");
+        Client.Icmpv41.write stack.Client.icmpv4 ~dst:localhost_ip ping
+        >>= function
+        | Error e -> failf "Icmpv41.write failed: %a" Client.Icmpv41.pp_error e
+        | Ok () ->
+          Host.Time.sleep_ns (Duration.of_sec 1)
+          >>= fun () ->
+          loop (seq + 1)
+      end in
+    Queue.clear Client.Icmpv41.packets;
+    loop 0
+  in
+  run ~timeout:(Duration.of_sec 900) ~pcap:"nmap.pcap" t


### PR DESCRIPTION
This new test case tries to connect to every port on the Host's localhost very quickly. Before we switched to `libuv` via `uwt` this kind of traffic could cause the process to exit.

This PR also fixes a long-standing bug in the harness which would cause the main ethernet listener thread to be cancelled after 4s, due to a timeout in the DHCP client.