### PR TITLE
Add support for more hypervisor socket URIs

### DIFF
--- a/repo/darwin/packages/dev/hvsock.2.0.0/url
+++ b/repo/darwin/packages/dev/hvsock.2.0.0/url
@@ -1,1 +1,1 @@
-git: "git://github.com/djs55/ocaml-hvsock.git#vsock"
+git: "git://github.com/djs55/ocaml-hvsock.git#relative-paths"


### PR DESCRIPTION
In the future we will probably only support the URIs supported natively by the `hvsock` library, but in the meantime this PR adds support for `hvsock` URIs while keeping the existing `hvsock-listen` `hvsock-connect` and `fd:` URIs for backwards-compatibility.