### PR TITLE
vmnet: move vmnet to its own package

### DIFF
--- a/go/pkg/vmnet/vmnet.go
+++ b/go/pkg/vmnet/vmnet.go
@@ -1,4 +1,4 @@
-package vpnkit
+package vmnet
 
 import (
 	"bytes"
@@ -21,8 +21,8 @@ type Vmnet struct {
 	remoteVersion *InitMessage
 }
 
-// NewVmnet constructs an instance of Vmnet.
-func NewVmnet(ctx context.Context, path string) (*Vmnet, error) {
+// New constructs an instance of Vmnet.
+func New(ctx context.Context, path string) (*Vmnet, error) {
 	d := &net.Dialer{}
 	conn, err := d.DialContext(ctx, "unix", path)
 	if err != nil {


### PR DESCRIPTION
This allows library users to import vmnet without datakit.

Signed-off-by: Tibor Vass <tibor@docker.com>