### PR TITLE
go: multiplexer: support net.Conn

### DIFF
--- a/go/cmd/dial-example/.gitignore
+++ b/go/cmd/dial-example/.gitignore
@@ -1,0 +1,1 @@
+dial-example

--- a/go/cmd/dial-example/main.go
+++ b/go/cmd/dial-example/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"flag"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"runtime"
+
+	"github.com/moby/vpnkit/go/pkg/vpnkit"
+)
+
+func main() {
+	dialer := &vpnkit.Dialer{}
+
+	switch runtime.GOOS {
+	case "darwin":
+		flag.StringVar(&dialer.HyperkitConnectPath, "hyperkit-connect", "", "path to hyperkit connect socket")
+	case "windows":
+		flag.StringVar(&dialer.HyperVVMID, "vm-guid", "", "Hyper-V VM GUID")
+	}
+	flag.IntVar(&dialer.Port, "port", 0, "AF_VSOCK port of vpnkit-forwarder")
+	flag.Parse()
+
+	transport := &http.Transport{
+		Dial: dialer.Dial,
+	}
+	client := &http.Client{Transport: transport}
+	url := "https://www.docker.com"
+	resp, err := client.Get(url)
+	if err != nil {
+		log.Fatalf("Failed to HTTP GET %s: %v", url, err)
+	}
+	if _, err := io.Copy(os.Stdout, resp.Body); err != nil {
+		log.Fatalf("Failed to read the body: %v", err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		log.Fatalf("Failed to close the body: %v", err)
+	}
+}

--- a/go/pkg/libproxy/loopbackconn.go
+++ b/go/pkg/libproxy/loopbackconn.go
@@ -2,7 +2,9 @@ package libproxy
 
 import (
 	"io"
+	"net"
 	"sync"
+	"time"
 )
 
 // io.Pipe is synchronous but we need to decouple the Read and Write calls
@@ -15,10 +17,11 @@ import (
 //   and reads return EOF after the buffer is exhausted
 
 type bufferedPipe struct {
-	bufs [][]byte
-	eof  bool
-	m    *sync.Mutex
-	c    *sync.Cond
+	bufs         [][]byte
+	eof          bool
+	m            *sync.Mutex
+	c            *sync.Cond
+	readDeadline time.Time
 }
 
 func newBufferedPipe() *bufferedPipe {
@@ -51,6 +54,33 @@ func (pipe *bufferedPipe) TryReadLocked(p []byte) (n int, err error) {
 	return 0, nil
 }
 
+func (pipe *bufferedPipe) SetReadDeadline(deadline time.Time) error {
+	pipe.m.Lock()
+	defer pipe.m.Unlock()
+	pipe.readDeadline = deadline
+	pipe.c.Broadcast()
+	return nil
+}
+
+type errTimeout struct {
+}
+
+func (e *errTimeout) String() string {
+	return "i/o timeout"
+}
+
+func (e *errTimeout) Error() string {
+	return e.String()
+}
+
+func (e *errTimeout) Timeout() bool {
+	return true
+}
+
+func (e *errTimeout) Temporary() bool {
+	return true
+}
+
 func (pipe *bufferedPipe) Read(p []byte) (n int, err error) {
 	pipe.m.Lock()
 	defer pipe.m.Unlock()
@@ -59,7 +89,28 @@ func (pipe *bufferedPipe) Read(p []byte) (n int, err error) {
 		if n > 0 || err != nil {
 			return n, err
 		}
-		pipe.c.Wait()
+		done := make(chan struct{})
+		timeout := make(chan time.Time)
+		if !pipe.readDeadline.IsZero() {
+			go func() {
+				time.Sleep(time.Until(pipe.readDeadline))
+				close(timeout)
+			}()
+		}
+		go func() {
+			pipe.c.Wait()
+			close(done)
+		}()
+		select {
+		case <-timeout:
+			// Clean up the goroutine
+			pipe.c.Broadcast()
+			<-done
+			return n, &errTimeout{}
+		case <-done:
+			// The timeout will still fire in the background
+			continue
+		}
 	}
 }
 
@@ -102,6 +153,40 @@ func newLoopback() *loopback {
 	}
 }
 
+func (l *loopback) LocalAddr() net.Addr {
+	return &addrLoopback{}
+}
+
+func (l *loopback) RemoteAddr() net.Addr {
+	return &addrLoopback{}
+}
+
+type addrLoopback struct {
+}
+
+func (a *addrLoopback) Network() string {
+	return "loopback"
+}
+func (a *addrLoopback) String() string {
+	return ""
+}
+
+func (l *loopback) SetReadDeadline(timeout time.Time) error {
+	return l.read.SetReadDeadline(timeout)
+}
+
+func (l *loopback) SetWriteDeadline(_ time.Time) error {
+	// Writes never block
+	return nil
+}
+
+func (l *loopback) SetDeadline(timeout time.Time) error {
+	if err := l.SetReadDeadline(timeout); err != nil {
+		return err
+	}
+	return l.SetWriteDeadline(timeout)
+}
+
 func (l *loopback) OtherEnd() *loopback {
 	return &loopback{
 		write: l.read,
@@ -110,15 +195,7 @@ func (l *loopback) OtherEnd() *loopback {
 }
 
 func (l *loopback) Read(p []byte) (n int, err error) {
-	l.read.m.Lock()
-	defer l.read.m.Unlock()
-	for {
-		n, err := l.read.TryReadLocked(p)
-		if n > 0 || err != nil {
-			return n, err
-		}
-		l.read.c.Wait()
-	}
+	return l.read.Read(p)
 }
 
 func (l *loopback) Write(p []byte) (n int, err error) {

--- a/go/pkg/libproxy/stream_proxy.go
+++ b/go/pkg/libproxy/stream_proxy.go
@@ -3,13 +3,12 @@ package libproxy
 import (
 	"io"
 	"log"
+	"net"
 )
 
 // Conn defines a network connection
 type Conn interface {
-	io.Reader
-	io.Writer
-	io.Closer
+	net.Conn
 	CloseRead() error
 	CloseWrite() error
 }

--- a/go/pkg/vpnkit/dialer.go
+++ b/go/pkg/vpnkit/dialer.go
@@ -1,0 +1,90 @@
+package vpnkit
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strconv"
+	"sync"
+
+	"github.com/moby/vpnkit/go/pkg/libproxy"
+)
+
+// DefaultVsockPort is the default AF_VSOCK port where vpnkit-forwarder listens.
+const DefaultVsockPort = 62373
+
+// Dialer connects to remote addresses via the vpnkit-forwarder.
+type Dialer struct {
+	HyperkitConnectPath string // HyperkitConnectPath is the path of the `connect` Unix domain socket
+	HyperVVMID          string // HyperkitVMVMID is the GUID of the VM running vpnkit-forwarder
+	Port                int    // Port is the AF_VSOCK port where vpnkit-forwarder is listening
+	m                   sync.Mutex
+	mux                 *libproxy.Multiplexer
+}
+
+func (d *Dialer) setupMultiplexer() error {
+	d.m.Lock()
+	defer d.m.Unlock()
+	if d.mux == nil {
+		conn, err := d.connectTransport()
+		if err != nil {
+			return err
+		}
+		d.mux = libproxy.NewMultiplexer("host", conn)
+		d.mux.Run()
+	}
+	return nil
+}
+
+// Dial connects to the address on the named network.
+func (d *Dialer) Dial(network, address string) (net.Conn, error) {
+	if err := d.setupMultiplexer(); err != nil {
+		return nil, err
+	}
+	switch network {
+	case "unix":
+		return d.mux.Dial(libproxy.Destination{
+			Proto: libproxy.Unix,
+			Path:  address,
+		})
+	case "udp", "tcp":
+		host, portS, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, err
+		}
+		port, err := strconv.Atoi(portS)
+		if err != nil {
+			return nil, err
+		}
+		resolver := &net.Resolver{}
+		addrs, err := resolver.LookupIPAddr(context.Background(), host)
+		if err != nil {
+			return nil, err
+		}
+		if len(addrs) == 0 {
+			return nil, errors.New("Failed to resolve IP of " + host)
+		}
+		var ip net.IP
+		// we only support IPv4 for now, so pick the first
+		for _, addr := range addrs {
+			if ipv4 := addr.IP.To4(); ipv4 != nil && ip == nil {
+				ip = addr.IP
+				break
+			}
+		}
+		if ip == nil {
+			return nil, errors.New("Failed to resolve an IPv4 of " + host)
+		}
+		proto := libproxy.UDP
+		if network == "tcp" {
+			proto = libproxy.TCP
+		}
+		return d.mux.Dial(libproxy.Destination{
+			Proto: proto,
+			IP:    ip,
+			Port:  uint16(port),
+		})
+	default:
+		return nil, errors.New("unknown network: " + network)
+	}
+}

--- a/go/pkg/vpnkit/dialer_darwin.go
+++ b/go/pkg/vpnkit/dialer_darwin.go
@@ -1,0 +1,29 @@
+package vpnkit
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+)
+
+func (d *Dialer) connectTransport() (io.ReadWriteCloser, error) {
+	path := d.HyperkitConnectPath
+	if path == "" {
+		// On Mac assume Docker Desktop
+		path = filepath.Join(os.Getenv("HOME"), "Library", "Containers", "com.docker.docker", "Data", "vms", "0", "connect")
+	}
+	port := d.Port
+	if port == 0 {
+		port = DefaultVsockPort
+	}
+	conn, err := net.Dial("unix", path)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := io.WriteString(conn, fmt.Sprintf("00000003.%08x\n", port)); err != nil {
+		return nil, err
+	}
+	return conn, nil
+}

--- a/go/pkg/vpnkit/dialer_linux.go
+++ b/go/pkg/vpnkit/dialer_linux.go
@@ -1,0 +1,16 @@
+package vpnkit
+
+import (
+	"io"
+
+	"github.com/linuxkit/virtsock/pkg/vsock"
+)
+
+func (d *Dialer) connectTransport() (io.ReadWriteCloser, error) {
+	port := d.Port
+	if port == 0 {
+		port = DefaultVsockPort
+	}
+	// 3 is the first VM
+	return vsock.Dial(3, port)
+}

--- a/go/pkg/vpnkit/dialer_windows.go
+++ b/go/pkg/vpnkit/dialer_windows.go
@@ -1,0 +1,29 @@
+package vpnkit
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/linuxkit/virtsock/pkg/hvsock"
+)
+
+func (d *Dialer) connectTransport() (io.ReadWriteCloser, error) {
+	if d.HyperVVMID == "" {
+		return nil, errors.New("Hyper-V VMID must be provided")
+	}
+	port := d.Port
+	if port == 0 {
+		port = DefaultVsockPort
+	}
+	guid := fmt.Sprintf("%08x-FACB-11E6-BD58-64006A7986D3", port)
+	svc, err := hvsock.GUIDFromString(guid)
+	if err != nil {
+		return nil, err
+	}
+	addr := hvsock.Addr{
+		VMID:      d.HyperVVMID,
+		ServiceID: svc,
+	}
+	return hvsock.Dial(addr)
+}


### PR DESCRIPTION
Previously we supported `io.Reader`, `io.Writer`, `io.Closer`, `ReadClose()` and `WriteClose()`. However it's useful to conform to the whole `net.Conn` interface since some libraries require it, notably the http client, the docker client and `net.Dialer`.

This bulk of this patch adds read and write deadlines. The local and remote address functionality is stubbed as it's not particularly meaningful.

Signed-off-by: David Scott <dave.scott@docker.com>