### PR TITLE
vpnkit-forwarder: autodetect AF_VSOCK versus AF_HVSOCK

### DIFF
--- a/go/cmd/vpnkit-forwarder/hvsock.go
+++ b/go/cmd/vpnkit-forwarder/hvsock.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"log"
+	"syscall"
+)
+
+// HvsockSupported returns true if the kernel has been patched to use AF_HVSOCK.
+func HvsockSupported() bool {
+	// Try opening  a hvsockAF socket. If it works we are on older, i.e. 4.9.x kernels.
+	// 4.11 defines AF_SMC as 43 but it doesn't support protocol 1 so the
+	// socket() call should fail.
+	fd, err := syscall.Socket(43, syscall.SOCK_STREAM, 1)
+	if err != nil {
+		return false
+	}
+	if err := syscall.Close(fd); err != nil {
+		log.Printf("cannot close AF_HVSOCK socket: %v", err)
+	}
+	return true
+}

--- a/go/cmd/vpnkit-forwarder/main.go
+++ b/go/cmd/vpnkit-forwarder/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"io"
 	"log"
 	"net"
@@ -11,49 +12,50 @@ import (
 	"github.com/moby/vpnkit/go/pkg/libproxy"
 )
 
-// Listen on virtio-vsock and AF_HYPERV for multiplexed connections
+// Listen on either AF_VSOCK or AF_HVSOCK (depending on the kernel) for multiplexed connections
 func main() {
 	var (
-		vsockPort = flag.Int("vsockPort", 0, "virtio-vsock port")
-		hvGUID    = flag.String("hvGuid", "", "Hyper-V service GUID")
-		listener  net.Listener
+		port     int
+		listener net.Listener
 	)
+	flag.IntVar(&port, "port", 0, "AF_VSOCK port")
 	flag.Parse()
 
 	quit := make(chan struct{})
 	defer close(quit)
 
-	if *vsockPort != 0 {
-		vsock, err := vsock.Listen(vsock.CIDAny, uint32(*vsockPort))
-		if err != nil {
-			log.Fatalf("Failed to bind to vsock port %d: %v", vsockPort, err)
-		}
-		log.Printf("Bound to AF_VSOCK port %d", *vsockPort)
-		listener = vsock
-	}
-
-	if *hvGUID != "" {
-		svcid, _ := hvsock.GUIDFromString(*hvGUID)
-		hvsock, err := hvsock.Listen(hvsock.HypervAddr{VMID: hvsock.GUIDWildcard, ServiceID: svcid})
-		if err != nil {
-			log.Fatalf("Failed to bind hvsock guid: %s: %v", *hvGUID, err)
-		}
-		log.Printf("Bound to AF_HYPERV GUID %s", *hvGUID)
-		listener = hvsock
-	}
-
-	if listener == nil {
-		log.Fatal("Failed to bind vsock or hvsock")
+	if HvsockSupported() {
+		listener = hyperVListener(port)
+	} else {
+		listener = vsockListener(port)
 	}
 
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
-			log.Printf("Error accepting connection: %#v", err)
+			log.Printf("Error accepting connection: %v", err)
 			return // no more listening
 		}
 		go handleConn(conn, quit)
 	}
+}
+
+func hyperVListener(port int) net.Listener {
+	serviceID := fmt.Sprintf("%08x-FACB-11E6-BD58-64006A7986D3", port)
+	svcid, _ := hvsock.GUIDFromString(serviceID)
+	l, err := hvsock.Listen(hvsock.HypervAddr{VMID: hvsock.GUIDWildcard, ServiceID: svcid})
+	if err != nil {
+		log.Fatalf("Failed to bind AF_HVSOCK guid: %s: %v", serviceID, err)
+	}
+	return l
+}
+
+func vsockListener(port int) net.Listener {
+	l, err := vsock.Listen(vsock.CIDAny, uint32(port))
+	if err != nil {
+		log.Fatalf("Failed to bind to AF_VSOCK port %d: %v", port, err)
+	}
+	return l
 }
 
 // handle every AF_VSOCK connection to the multiplexer


### PR DESCRIPTION
Since AF_HVSOCK only exists in patched kernels, this changes the command-line to only require an AF_VSOCK port number. At runtime we detect whether the kernel is patched and use the correct
interface.

Signed-off-by: David Scott <dave.scott@docker.com>