### PR TITLE
Prevent UDP NAT overload from exhausting all available connections

### DIFF
--- a/src/hostnet/hostnet_udp.ml
+++ b/src/hostnet/hostnet_udp.ml
@@ -63,7 +63,24 @@ struct
 
   let set_send_reply ~t ~send_reply = t.send_reply <- Some send_reply
 
-  let get_nat_table_size t = Hashtbl.length t.table
+  module Debug = struct
+    type address = Ipaddr.t * int
+
+    type flow = {
+      inside: address;
+      outside: address;
+      last_use_time_ns: int64;
+    }
+
+    let get_table t =
+      Hashtbl.fold (fun _ flow acc ->
+        {
+          inside = flow.src;
+          outside = flow.external_address;
+          last_use_time_ns = flow.last_use;
+        } :: acc
+      ) t.table []
+  end
 
   let expire table by_last_use flow =
     Lwt.catch (fun () ->

--- a/src/hostnet/hostnet_udp.ml
+++ b/src/hostnet/hostnet_udp.ml
@@ -80,6 +80,8 @@ struct
           last_use_time_ns = flow.last_use;
         } :: acc
       ) t.table []
+
+    let get_max_active_flows t = t.max_active_flows
   end
 
   let expire table by_last_use flow =

--- a/src/hostnet/hostnet_udp.mli
+++ b/src/hostnet/hostnet_udp.mli
@@ -50,6 +50,8 @@ sig
 
     val get_table: t -> flow list
     (** Return an instantaneous snapshot of the NAT table *)
+
+    val get_max_active_flows: t -> int
   end
 end
 

--- a/src/hostnet/hostnet_udp.mli
+++ b/src/hostnet/hostnet_udp.mli
@@ -24,9 +24,10 @@ sig
   type t
   (** A UDP NAT implementation *)
 
-  val create: ?max_idle_time:int64 -> ?preserve_remote_port:bool -> Clock.t -> t
+  val create: ?max_idle_time:int64 -> ?preserve_remote_port:bool -> ?max_active_flows:int -> Clock.t -> t
   (** Create a UDP NAT implementation which will keep "NAT rules" alive until
-      they become idle for the given [?max_idle_time].
+      they become idle for the given [?max_idle_time] or until the number of
+      flows hits [?max_active_flows] at which point the oldest will be expired.
       If [~preserve_remote_port] is set then reply traffic will come from the
       remote source port, otherwise it will come from the NAT port. *)
 

--- a/src/hostnet/hostnet_udp.mli
+++ b/src/hostnet/hostnet_udp.mli
@@ -39,8 +39,18 @@ sig
   (** Process an incoming datagram, forwarding it over the Sockets implementation
       and set up a listening rule to catch replies. *)
 
-  val get_nat_table_size: t -> int
-  (** Return the current number of allocated NAT table entries *)
+  module Debug : sig
+    type address = Ipaddr.t * int
+
+    type flow = {
+        inside: address;
+        outside: address;
+        last_use_time_ns: int64;
+    }
+
+    val get_table: t -> flow list
+    (** Return an instantaneous snapshot of the NAT table *)
+  end
 end
 
 val external_to_internal: (int, address) Hashtbl.t

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -894,6 +894,7 @@ struct
     module Nat = struct
       include Udp_nat.Debug
       let get_table t = get_table t.udp_nat
+      let get_max_active_flows t = get_max_active_flows t.udp_nat
     end
     let update_dns
         ?(local_ip = Ipaddr.V4 Ipaddr.V4.localhost) ?(builtin_names = []) clock

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -891,8 +891,10 @@ struct
           l "error while flushing the diagnostic: %a" C.pp_write_error e)
 
   module Debug = struct
-    let get_nat_table_size t = Udp_nat.get_nat_table_size t.udp_nat
-
+    module Nat = struct
+      include Udp_nat.Debug
+      let get_table t = get_table t.udp_nat
+    end
     let update_dns
         ?(local_ip = Ipaddr.V4 Ipaddr.V4.localhost) ?(builtin_names = []) clock
       =

--- a/src/hostnet/slirp.mli
+++ b/src/hostnet/slirp.mli
@@ -57,6 +57,8 @@ sig
 
       val get_table: connection -> flow list
       (** Return an instantaneous snapshot of the NAT table *)
+
+      val get_max_active_flows: connection -> int
     end
 
     val update_dns: ?local_ip:Ipaddr.t -> ?builtin_names:(Dns.Name.t * Ipaddr.t) list ->

--- a/src/hostnet/slirp.mli
+++ b/src/hostnet/slirp.mli
@@ -46,8 +46,18 @@ sig
   (** Output all traffic in pcap format over a local Unix socket or named pipe *)
 
   module Debug: sig
-    val get_nat_table_size: connection -> int
-    (** Return the number of active NAT table entries *)
+    module Nat : sig
+      type address = Ipaddr.t * int
+
+      type flow = {
+        inside: address;
+        outside: address;
+        last_use_time_ns: int64;
+      }
+
+      val get_table: connection -> flow list
+      (** Return an instantaneous snapshot of the NAT table *)
+    end
 
     val update_dns: ?local_ip:Ipaddr.t -> ?builtin_names:(Dns.Name.t * Ipaddr.t) list ->
       Clock.t -> unit

--- a/src/hostnet_test/test_nat.ml
+++ b/src/hostnet_test/test_nat.ml
@@ -273,7 +273,7 @@ let test_shared_nat_rule () =
           let virtual_port = 1024 in
           let server = UdpServer.make stack.t virtual_port in
           let init_table_size =
-            Slirp_stack.Debug.get_nat_table_size slirp_server
+            List.length @@ Slirp_stack.Debug.Nat.get_table slirp_server
           in
 
           let rec loop remaining =
@@ -295,7 +295,7 @@ let test_shared_nat_rule () =
           in
           loop 5 >>= fun () ->
           Alcotest.(check int) "One NAT rule" 1
-            (Slirp_stack.Debug.get_nat_table_size slirp_server
+            ((List.length @@ Slirp_stack.Debug.Nat.get_table slirp_server)
              - init_table_size);
           (* Send '2' *)
           Cstruct.set_uint8 buffer 0 2;
@@ -320,7 +320,7 @@ let test_shared_nat_rule () =
               in
               loop 5 >|= fun () ->
               Alcotest.(check int) "Still one NAT rule" 1
-                (Slirp_stack.Debug.get_nat_table_size slirp_server
+                ((List.length @@ Slirp_stack.Debug.Nat.get_table slirp_server)
                  - init_table_size)
             )))
   in


### PR DESCRIPTION
There is a configurable global connection limit which is useful on platforms (such as macOS) which have abnormally low maximum file descriptor limits.

The UDP NAT binds a socket per internal source address, and expires it after it has been idle for 60s.

Unfortunately a UDP protocol which sends UDP from random source ports and which doesn't expect replies (such as that in `envoy`, as used by `kubeflow`) can quickly exhaust the global limit which then breaks other things, such as port forwards.

This PR adds a new limit on the total number of active UDP NAT table entries and sockets, and expires the oldest when the new limit is hit. This should keep the network usable even when using one of these chatty UDP protocols.