### PR TITLE
pkg/libproxy: fix write-after-close race in the multiplexer

### DIFF
--- a/go/pkg/libproxy/loopbackconn.go
+++ b/go/pkg/libproxy/loopbackconn.go
@@ -139,9 +139,10 @@ func (pipe *bufferedPipe) CloseWrite() error {
 }
 
 type loopback struct {
-	write  *bufferedPipe
-	read   *bufferedPipe
-	closed bool
+	write           *bufferedPipe
+	read            *bufferedPipe
+	closed          bool
+	simulateLatency time.Duration
 }
 
 func newLoopback() *loopback {
@@ -199,7 +200,9 @@ func (l *loopback) Read(p []byte) (n int, err error) {
 }
 
 func (l *loopback) Write(p []byte) (n int, err error) {
-	return l.write.Write(p)
+	n, err = l.write.Write(p)
+	time.Sleep(l.simulateLatency)
+	return
 }
 
 func (l *loopback) CloseRead() error {


### PR DESCRIPTION
Previously it was possible for a concurrent `Write` and `Close` (or `CloseWrite`) to permute, triggering a fatal error in the remote's state machine.

This PR fixes the race condition by setting the local state before sending the `Close` or `CloseWrite` messages, which `Write` already checks for. This will prevent any further payloads being sent.

The test case tests this condition reliably by simulating a high-latency link, so it is easy to call `Write` while a `Close` is still being transmitted.