### PR TITLE
pkg/libproxy: fix double Close, Shutdown

### DIFF
--- a/go/pkg/libproxy/multiplexed.go
+++ b/go/pkg/libproxy/multiplexed.go
@@ -191,7 +191,7 @@ func (c *channel) CloseWrite() error {
 	// Avoid a Write() racing with us and sending after we Close()
 	// Avoid sending Shutdown twice
 	c.m.Lock()
-	alreadyShutdown := c.shutdownSent
+	alreadyShutdown := c.shutdownSent || c.closeSent
 	c.shutdownSent = true
 	c.m.Unlock()
 

--- a/go/pkg/libproxy/multiplexed_test.go
+++ b/go/pkg/libproxy/multiplexed_test.go
@@ -69,6 +69,78 @@ func TestClose(t *testing.T) {
 	}
 }
 
+func TestCloseClose(t *testing.T) {
+	loopback := newLoopback()
+	local := NewMultiplexer("local", loopback)
+	local.Run()
+	remote := NewMultiplexer("remote", loopback.OtherEnd())
+	remote.Run()
+	// There was a bug where the second iteration failed because the main loop had deadlocked
+	// when it received a Close message.
+	for i := 0; i < 2; i++ {
+		client, err := local.Dial(Destination{
+			Proto: TCP,
+			IP:    net.ParseIP("127.0.0.1"),
+			Port:  8080,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		server, _, err := remote.Accept()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := client.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := client.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := server.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if !remote.IsRunning() {
+			t.Fatal("remote multiplexer has failed")
+		}
+	}
+}
+
+func TestCloseWriteCloseWrite(t *testing.T) {
+	loopback := newLoopback()
+	local := NewMultiplexer("local", loopback)
+	local.Run()
+	remote := NewMultiplexer("remote", loopback.OtherEnd())
+	remote.Run()
+	// There was a bug where the second iteration failed because the main loop had deadlocked
+	// when it received a Close message.
+	for i := 0; i < 2; i++ {
+		client, err := local.Dial(Destination{
+			Proto: TCP,
+			IP:    net.ParseIP("127.0.0.1"),
+			Port:  8080,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		server, _, err := remote.Accept()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := client.CloseWrite(); err != nil {
+			t.Fatal(err)
+		}
+		if err := client.CloseWrite(); err != nil {
+			t.Fatal(err)
+		}
+		if err := server.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if !remote.IsRunning() {
+			t.Fatal("remote multiplexer has failed")
+		}
+	}
+}
+
 func TestCloseThenWrite(t *testing.T) {
 	loopback := newLoopback()
 	local := NewMultiplexer("local", loopback)

--- a/go/pkg/libproxy/multiplexed_test.go
+++ b/go/pkg/libproxy/multiplexed_test.go
@@ -141,6 +141,42 @@ func TestCloseWriteCloseWrite(t *testing.T) {
 	}
 }
 
+func TestCloseCloseWrite(t *testing.T) {
+	loopback := newLoopback()
+	local := NewMultiplexer("local", loopback)
+	local.Run()
+	remote := NewMultiplexer("remote", loopback.OtherEnd())
+	remote.Run()
+	// There was a bug where the second iteration failed because the main loop had deadlocked
+	// when it received a Close message.
+	for i := 0; i < 2; i++ {
+		client, err := local.Dial(Destination{
+			Proto: TCP,
+			IP:    net.ParseIP("127.0.0.1"),
+			Port:  8080,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		server, _, err := remote.Accept()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := client.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := client.CloseWrite(); err != nil {
+			t.Fatal(err)
+		}
+		if err := server.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if !remote.IsRunning() {
+			t.Fatal("remote multiplexer has failed")
+		}
+	}
+}
+
 func TestCloseThenWrite(t *testing.T) {
 	loopback := newLoopback()
 	local := NewMultiplexer("local", loopback)


### PR DESCRIPTION
Previously it was possible for the client to confuse the server by sending
- `Close` then `Close`
- `Shutdown` then `Shutdown`
- `Close` then `Shutdown`

This PR suppresses these duplicate messages on the client-side. If the application calls `Close` then the second is a no-op.