### PR TITLE
Go: pkg/vpnkit: simplify the port interface

### DIFF
--- a/go/cmd/vpnkit-expose-port/main.go
+++ b/go/cmd/vpnkit-expose-port/main.go
@@ -30,21 +30,25 @@ func main() {
 	}
 	switch *proto {
 	case "ucp", "udp":
-		outIP := net.ParseIP(*hostIP)
-		outPort := uint16(*hostPort)
-		inIP := net.ParseIP(*containerIP)
-		inPort := uint16(*containerPort)
-		p := vpnkit.NewPort(c, *proto, outIP, outPort, inIP, inPort)
-		if err = p.Expose(context.Background()); err != nil {
+		p := &vpnkit.Port{
+			OutIP:   net.ParseIP(*hostIP),
+			OutPort: uint16(*hostPort),
+			InIP:    net.ParseIP(*containerIP),
+			InPort:  uint16(*containerPort),
+		}
+		if err = c.Expose(context.Background(), p); err != nil {
 			log.Fatal(err)
 		}
-		defer p.Unexpose(context.Background())
+		defer c.Unexpose(context.Background(), p)
 	case "unix":
-		p := vpnkit.NewPath(c, *hostPath, *containerPath)
-		if err = p.Expose(context.Background()); err != nil {
+		p := &vpnkit.Port{
+			OutPath: *hostPath,
+			InPath:  *containerPath,
+		}
+		if err = c.Expose(context.Background(), p); err != nil {
 			log.Fatal(err)
 		}
-		defer p.Unexpose(context.Background())
+		defer c.Unexpose(context.Background(), p)
 	default:
 		log.Fatalf("Unknown protocol %s. Use tcp, udp or unix", *proto)
 	}

--- a/go/cmd/vpnkit-list-ports/main.go
+++ b/go/cmd/vpnkit-list-ports/main.go
@@ -19,7 +19,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	ports, err := vpnkit.ListExposed(c)
+	ports, err := c.ListExposed(context.Background())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go/pkg/vpnkit/connection.go
+++ b/go/pkg/vpnkit/connection.go
@@ -1,0 +1,12 @@
+package vpnkit
+
+import (
+	"context"
+)
+
+// Client exposes and unexposes ports on vpnkit.
+type Client interface {
+	Expose(context.Context, *Port) error
+	Unexpose(context.Context, *Port) error
+	ListExposed(context.Context) ([]Port, error)
+}

--- a/go/pkg/vpnkit/connection_unix.go
+++ b/go/pkg/vpnkit/connection_unix.go
@@ -50,3 +50,5 @@ func NewConnection(ctx context.Context, path string) (*Connection, error) {
 func NewConnectionForClient(client *datakit.Client) *Connection {
 	return &Connection{client}
 }
+
+var _ = Client(&Connection{})


### PR DESCRIPTION
We now have a `vpnkit.Client`:

```
// Client exposes and unexposes ports on vpnkit.
type Client interface {
	Expose(context.Context, *Port) error
	Unexpose(context.Context, *Port) error
	ListExposed(context.Context) ([]*Port, error)
}
```

which we can use instead of the ad-hoc functions spread over both
the package (`vpnkit.ListExposed`) and Ports (`port.Expose`)

This should make this library easier to Mock for testing.

Signed-off-by: David Scott <dave.scott@docker.com>