### PR TITLE
Add a notion of forwarded TCP services

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       TERM: vt100
     steps:
       - checkout
-      - run: brew unlink python # remove files in /usr/local/bin
+      - run: brew uninstall python # remove files in /usr/local/bin
       - run: brew install wget pkg-config dylibbundler
       - run: brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/72ce8812eaa33abe23533dfa021b51351a6b9c3e/Formula/opam.rb
       - run: make

--- a/src/hostnet/configuration.ml
+++ b/src/hostnet/configuration.ml
@@ -55,11 +55,12 @@ type t = {
   gateway_names: Dns.Name.t list;
   vm_names: Dns.Name.t list;
   udpv4_forwards: (int * (Ipaddr.V4.t * int)) list;
+  tcpv4_forwards: (int * (Ipaddr.V4.t * int)) list;
   pcap_snaplen: int;
 }
 
 let to_string t =
-  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns_path = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; gateway_ip = %s; host_ip = %s; lowest_ip = %s; highest_ip = %s; dhcp_json_path = %s; dhcp_configuration = %s; mtu = %d; http_intercept = %s; http_intercept_path = %s; port_max_idle_time = %s; host_names = %s; gateway_names = %s; vm_names = %s; udpv4_forwards = %s; pcap_snaplen = %d"
+  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns_path = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; gateway_ip = %s; host_ip = %s; lowest_ip = %s; highest_ip = %s; dhcp_json_path = %s; dhcp_configuration = %s; mtu = %d; http_intercept = %s; http_intercept_path = %s; port_max_idle_time = %s; host_names = %s; gateway_names = %s; vm_names = %s; udpv4_forwards = %s; tcpv4_forwards = %s; pcap_snaplen = %d"
     (Macaddr.to_string t.server_macaddr)
     (match t.max_connections with None -> "None" | Some x -> string_of_int x)
     (match t.dns_path with None -> "None" | Some x -> x)
@@ -81,6 +82,7 @@ let to_string t =
     (String.concat ", " (List.map Dns.Name.to_string t.gateway_names))
     (String.concat ", " (List.map Dns.Name.to_string t.vm_names))
     (String.concat ", " (List.map (fun (src_port, (dst_ipv4, dst_port)) -> Printf.sprintf "%d -> %s:%d" src_port (Ipaddr.V4.to_string dst_ipv4) dst_port) t.udpv4_forwards))
+    (String.concat ", " (List.map (fun (src_port, (dst_ipv4, dst_port)) -> Printf.sprintf "%d -> %s:%d" src_port (Ipaddr.V4.to_string dst_ipv4) dst_port) t.tcpv4_forwards))
     t.pcap_snaplen
 
 let no_dns_servers =
@@ -126,6 +128,7 @@ let default = {
   gateway_names = default_gateway_names;
   vm_names = default_gateway_names;
   udpv4_forwards = [];
+  tcpv4_forwards = [];
   pcap_snaplen = default_pcap_snaplen;
 }
 

--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -141,11 +141,14 @@ let preferred_ip1 = Ipaddr.V4.of_string_exn "192.168.65.250"
 
 let names_for_localhost = List.map Dns.Name.of_string [ "name1.for.localhost"; "name2.for.localhost" ]
 
+let local_tcpv4_forwarded_port = 8888
+
 let config =
   let configuration = {
     Configuration.default with
     domain = Some "local";
     host_names = names_for_localhost;
+    tcpv4_forwards = [ local_tcpv4_forwarded_port, (Ipaddr.V4.localhost, local_tcpv4_forwarded_port)];
   } in
   Mclock.connect () >>= fun clock ->
   let vnet = Vnet.create () in


### PR DESCRIPTION
Clients can connect to services on the host as well as virtual services running on the "gateway" address. This PR allows extra virtual TCP services on the gateway to be configured which are automatically proxied to somewhere else. This is convenient if we can't use localhost because the ports are privileged and we can't easily bind there (for example DNS on port 53).

For example the argument `--tcpv4-forwards 53:8.8.8.8:53` sets up a virtual listener on `docker.for.mac.gateway.internal:53` and proxies all traffic to `8.8.8.8:53`.
