### PR TITLE
Make UDP/TCP port forwards from the gateway dynamic

### DIFF
--- a/go/pkg/vpnkit/config.go
+++ b/go/pkg/vpnkit/config.go
@@ -1,0 +1,60 @@
+package vpnkit
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+// DHCPConfiguration configures the built-in DHCP server.
+type DHCPConfiguration struct {
+	SearchDomains []string `json:"searchDomains"`
+	DomainName    string   `json:"domainName"`
+}
+
+func (d DHCPConfiguration) Write(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(d); err != nil {
+		return errors.Wrap(err, "while writing DHCPConfiguration")
+	}
+	return nil
+}
+
+// HTTPConfiguration configures the built-in HTTP proxy.
+type HTTPConfiguration struct {
+	HTTP                  string `json:"http,omitempty"`
+	HTTPS                 string `json:"https,omitempty"`
+	Exclude               string `json:"exclude,omitempty"`
+	TransparentHTTPPorts  []int  `json:"transparent_http_ports"`
+	TransparentHTTPSPorts []int  `json:"transparent_https_ports"`
+}
+
+func (h HTTPConfiguration) Write(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(h); err != nil {
+		return errors.Wrap(err, "while writing HTTPConfiguration")
+	}
+	return nil
+}
+
+// Forward is a single forward from the gateway IP ExternalPort to (InternalIP, InternalPort)
+type Forward struct {
+	Protocol     Protocol `json:"protocol"`
+	ExternalPort int      `json:"external_port"`
+	InternalIP   string   `json:"internal_ip"`
+	InternalPort int      `json:"internal_port"`
+}
+
+// GatewayForwards is a list of individual forwards.
+type GatewayForwards []Forward
+
+func (g GatewayForwards) Write(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	if err := enc.Encode(g); err != nil {
+		return errors.Wrap(err, "while writing GatewayForewards")
+	}
+	return nil
+}

--- a/go/pkg/vpnkit/config_test.go
+++ b/go/pkg/vpnkit/config_test.go
@@ -1,0 +1,42 @@
+package vpnkit
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestGatewayForwards(t *testing.T) {
+	forwards := GatewayForwards([]Forward{
+		Forward{
+			Protocol:     TCP,
+			ExternalPort: 53,
+			InternalIP:   "127.0.0.1",
+			InternalPort: 5353,
+		},
+		Forward{
+			Protocol:     UDP,
+			ExternalPort: 53,
+			InternalIP:   "127.0.0.1",
+			InternalPort: 5353,
+		},
+	})
+	var b bytes.Buffer
+	if err := forwards.Write(&b); err != nil {
+		t.Fatal(err)
+	}
+	expected := `[{"protocol":"tcp","external_port":53,"internal_ip":"127.0.0.1","internal_port":5353},{"protocol":"udp","external_port":53,"internal_ip":"127.0.0.1","internal_port":5353}]
+`
+
+	assertEqual(t, expected, b.String(), "gateway forwards not marshalled as expected")
+}
+
+func assertEqual(t *testing.T, a interface{}, b interface{}, message string) {
+	if a == b {
+		return
+	}
+	if len(message) == 0 {
+		message = fmt.Sprintf("%v != %v", a, b)
+	}
+	t.Fatal(message)
+}

--- a/go/vendor.conf
+++ b/go/vendor.conf
@@ -3,3 +3,4 @@ github.com/linuxkit/virtsock a381dcc5bcddf1d7f449495c373dbf70f8e501c0
 github.com/docker/go-p9p 87ae8514a3a2d9684994a6c319f96ba9e18a062e
 github.com/moby/datakit 97b3d230535397a813323902c23751e176481a86
 github.com/google/uuid 7e072fc3a7be179aee6d3359e46015aa8c995314
+github.com/pkg/errors 059132a15dd08d6704c67711dae0cf35ab991756

--- a/go/vendor/github.com/pkg/errors/LICENSE
+++ b/go/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/go/vendor/github.com/pkg/errors/README.md
+++ b/go/vendor/github.com/pkg/errors/README.md
@@ -1,0 +1,52 @@
+# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors) [![Sourcegraph](https://sourcegraph.com/github.com/pkg/errors/-/badge.svg)](https://sourcegraph.com/github.com/pkg/errors?badge)
+
+Package errors provides simple error handling primitives.
+
+`go get github.com/pkg/errors`
+
+The traditional error handling idiom in Go is roughly akin to
+```go
+if err != nil {
+        return err
+}
+```
+which applied recursively up the call stack results in error reports without context or debugging information. The errors package allows programmers to add context to the failure path in their code in a way that does not destroy the original value of the error.
+
+## Adding context to an error
+
+The errors.Wrap function returns a new error that adds context to the original error. For example
+```go
+_, err := ioutil.ReadAll(r)
+if err != nil {
+        return errors.Wrap(err, "read failed")
+}
+```
+## Retrieving the cause of an error
+
+Using `errors.Wrap` constructs a stack of errors, adding context to the preceding error. Depending on the nature of the error it may be necessary to reverse the operation of errors.Wrap to retrieve the original error for inspection. Any error value which implements this interface can be inspected by `errors.Cause`.
+```go
+type causer interface {
+        Cause() error
+}
+```
+`errors.Cause` will recursively retrieve the topmost error which does not implement `causer`, which is assumed to be the original cause. For example:
+```go
+switch err := errors.Cause(err).(type) {
+case *MyError:
+        // handle specifically
+default:
+        // unknown error
+}
+```
+
+[Read the package documentation for more information](https://godoc.org/github.com/pkg/errors).
+
+## Contributing
+
+We welcome pull requests, bug fixes and issue reports. With that said, the bar for adding new symbols to this package is intentionally set high.
+
+Before proposing a change, please discuss your change by raising an issue.
+
+## License
+
+BSD-2-Clause

--- a/go/vendor/github.com/pkg/errors/errors.go
+++ b/go/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,282 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which when applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error by recording a stack trace at the point Wrap is called,
+// together with the supplied message. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// If additional control is required, the errors.WithStack and
+// errors.WithMessage functions destructure errors.Wrap into its component
+// operations: annotating an error with a stack trace and with a message,
+// respectively.
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error that does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// Although the causer interface is not exported by this package, it is
+// considered a part of its stable public interface.
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported:
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively.
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface:
+//
+//     type stackTracer interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// The returned errors.StackTrace type is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stack trace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stack trace of this error. For example:
+//
+//     if err, ok := err.(stackTracer); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d", f)
+//             }
+//     }
+//
+// Although the stackTracer interface is not exported by this package, it is
+// considered a part of its stable public interface.
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+// New returns an error with the supplied message.
+// New also records the stack trace at the point it was called.
+func New(message string) error {
+	return &fundamental{
+		msg:   message,
+		stack: callers(),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+// Errorf also records the stack trace at the point it was called.
+func Errorf(format string, args ...interface{}) error {
+	return &fundamental{
+		msg:   fmt.Sprintf(format, args...),
+		stack: callers(),
+	}
+}
+
+// fundamental is an error that has a message and a stack, but no caller.
+type fundamental struct {
+	msg string
+	*stack
+}
+
+func (f *fundamental) Error() string { return f.msg }
+
+func (f *fundamental) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, f.msg)
+			f.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, f.msg)
+	case 'q':
+		fmt.Fprintf(s, "%q", f.msg)
+	}
+}
+
+// WithStack annotates err with a stack trace at the point WithStack was called.
+// If err is nil, WithStack returns nil.
+func WithStack(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+type withStack struct {
+	error
+	*stack
+}
+
+func (w *withStack) Cause() error { return w.error }
+
+func (w *withStack) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v", w.Cause())
+			w.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, w.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with a stack trace
+// at the point Wrap is called, and the supplied message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   message,
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with a stack trace
+// at the point Wrapf is called, and the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// WithMessage annotates err with a new message.
+// If err is nil, WithMessage returns nil.
+func WithMessage(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   message,
+	}
+}
+
+// WithMessagef annotates err with the format specifier.
+// If err is nil, WithMessagef returns nil.
+func WithMessagef(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg: fmt.Sprintf(format, args...),
+	}
+}
+
+type withMessage struct {
+	cause error
+	msg   string
+}
+
+func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
+func (w *withMessage) Cause() error  { return w.cause }
+
+func (w *withMessage) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			io.WriteString(s, w.msg)
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		io.WriteString(s, w.Error())
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}

--- a/go/vendor/github.com/pkg/errors/stack.go
+++ b/go/vendor/github.com/pkg/errors/stack.go
@@ -1,0 +1,147 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   function name and path of source file relative to the compile time
+//          GOPATH separated by \n\t (<funcname>\n\t<path>)
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			pc := f.pc()
+			fn := runtime.FuncForPC(pc)
+			if fn == nil {
+				io.WriteString(s, "unknown")
+			} else {
+				file, _ := fn.FileLine(pc)
+				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+			}
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		fmt.Fprintf(s, "%d", f.line())
+	case 'n':
+		name := runtime.FuncForPC(f.pc()).Name()
+		io.WriteString(s, funcname(name))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+// Format formats the stack of Frames according to the fmt.Formatter interface.
+//
+//    %s	lists source files for each Frame in the stack
+//    %v	lists the source file and line number for each Frame in the stack
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+v   Prints filename, function, and line number for each Frame in the stack.
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				fmt.Fprintf(s, "\n%+v", f)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			fmt.Fprintf(s, "%v", []Frame(st))
+		}
+	case 's':
+		fmt.Fprintf(s, "%s", []Frame(st))
+	}
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) Format(st fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case st.Flag('+'):
+			for _, pc := range *s {
+				f := Frame(pc)
+				fmt.Fprintf(st, "\n%+v", f)
+			}
+		}
+	}
+}
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -530,18 +530,18 @@ let hvsock_addr_of_uri ~default_serviceid uri =
     let host_ip = Ipaddr.V4.of_string_exn host_ip in
     let lowest_ip = Ipaddr.V4.of_string_exn lowest_ip in
     let highest_ip = Ipaddr.V4.of_string_exn highest_ip in
-    let parse_forwards forwards =
+    let parse_forwards protocol forwards =
       List.map (fun x -> match Stringext.split ~on:':' x with
-        | [ local_port; remote_ip; remote_port ] ->
-          let local_port = int_of_string local_port in
-          let remote_ip = Ipaddr.V4.of_string_exn remote_ip in
-          let remote_port = int_of_string remote_port in
-          local_port, (remote_ip, remote_port)
+        | [ external_port; internal_ip; internal_port ] ->
+          let external_port = int_of_string external_port in
+          let internal_ip = Ipaddr.V4.of_string_exn internal_ip in
+          let internal_port = int_of_string internal_port in
+          Gateway_forwards.( { protocol; external_port; internal_ip; internal_port } )
         | _ ->
           failwith "Failed to parse forwards: expected <local-port>:<remote IP>:<remote port>"
       ) (Stringext.split ~on:',' forwards) in
-    let udpv4_forwards = parse_forwards udpv4_forwards in
-    let tcpv4_forwards = parse_forwards tcpv4_forwards in
+    let udpv4_forwards = parse_forwards Gateway_forwards.Udp udpv4_forwards in
+    let tcpv4_forwards = parse_forwards Gateway_forwards.Tcp tcpv4_forwards in
     let configuration = {
       Configuration.default with
       max_connections;

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -502,7 +502,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       max_connections port_forwards db_path db_branch dns http hosts host_names gateway_names
       vm_names listen_backlog port_max_idle_time debug
       server_macaddr domain allowed_bind_addresses gateway_ip host_ip lowest_ip highest_ip
-      dhcp_json_path mtu udpv4_forwards tcpv4_forwards gc_compact log_destination
+      dhcp_json_path mtu udpv4_forwards tcpv4_forwards gateway_forwards_path gc_compact log_destination
     =
     let level =
       let env_debug =
@@ -564,6 +564,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       mtu;
       udpv4_forwards;
       tcpv4_forwards;
+      gateway_forwards_path;
       pcap_snaplen;
     } in
     match socket_url with
@@ -850,6 +851,14 @@ let tcpv4_forwards =
   in
   Arg.(value & opt string "" doc)
 
+let gateway_forwards_path =
+  let doc =
+    Arg.info ~doc:
+      "Path of gateway forwards configuration file"
+      [ "gateway-forwards" ]
+  in
+  Arg.(value & opt (some file) None doc)
+
 let gc_compact =
   let doc =
     Arg.info ~doc:
@@ -871,7 +880,7 @@ let command =
         $ host_names $ gateway_names $ vm_names $ listen_backlog $ port_max_idle_time $ debug
         $ server_macaddr $ domain $ allowed_bind_addresses $ gateway_ip $ host_ip
         $ lowest_ip $ highest_ip $ dhcp_json_path $ mtu $ udpv4_forwards $ tcpv4_forwards
-        $ gc_compact $ Logging.log_destination),
+        $ gateway_forwards_path $ gc_compact $ Logging.log_destination),
   Term.info (Filename.basename Sys.argv.(0)) ~version:Version.git ~doc ~man
 
 let () =

--- a/src/hostnet/configuration.ml
+++ b/src/hostnet/configuration.ml
@@ -54,8 +54,8 @@ type t = {
   host_names: Dns.Name.t list;
   gateway_names: Dns.Name.t list;
   vm_names: Dns.Name.t list;
-  udpv4_forwards: (int * (Ipaddr.V4.t * int)) list;
-  tcpv4_forwards: (int * (Ipaddr.V4.t * int)) list;
+  udpv4_forwards: Gateway_forwards.t;
+  tcpv4_forwards: Gateway_forwards.t;
   gateway_forwards_path: string option;
   pcap_snaplen: int;
 }
@@ -82,8 +82,8 @@ let to_string t =
     (String.concat ", " (List.map Dns.Name.to_string t.host_names))
     (String.concat ", " (List.map Dns.Name.to_string t.gateway_names))
     (String.concat ", " (List.map Dns.Name.to_string t.vm_names))
-    (String.concat ", " (List.map (fun (src_port, (dst_ipv4, dst_port)) -> Printf.sprintf "%d -> %s:%d" src_port (Ipaddr.V4.to_string dst_ipv4) dst_port) t.udpv4_forwards))
-    (String.concat ", " (List.map (fun (src_port, (dst_ipv4, dst_port)) -> Printf.sprintf "%d -> %s:%d" src_port (Ipaddr.V4.to_string dst_ipv4) dst_port) t.tcpv4_forwards))
+    (Gateway_forwards.to_string t.udpv4_forwards)
+    (Gateway_forwards.to_string t.tcpv4_forwards)
     (match t.gateway_forwards_path with None -> "None" | Some x -> x)
     t.pcap_snaplen
 

--- a/src/hostnet/configuration.ml
+++ b/src/hostnet/configuration.ml
@@ -56,11 +56,12 @@ type t = {
   vm_names: Dns.Name.t list;
   udpv4_forwards: (int * (Ipaddr.V4.t * int)) list;
   tcpv4_forwards: (int * (Ipaddr.V4.t * int)) list;
+  gateway_forwards_path: string option;
   pcap_snaplen: int;
 }
 
 let to_string t =
-  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns_path = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; gateway_ip = %s; host_ip = %s; lowest_ip = %s; highest_ip = %s; dhcp_json_path = %s; dhcp_configuration = %s; mtu = %d; http_intercept = %s; http_intercept_path = %s; port_max_idle_time = %s; host_names = %s; gateway_names = %s; vm_names = %s; udpv4_forwards = %s; tcpv4_forwards = %s; pcap_snaplen = %d"
+  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns_path = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; gateway_ip = %s; host_ip = %s; lowest_ip = %s; highest_ip = %s; dhcp_json_path = %s; dhcp_configuration = %s; mtu = %d; http_intercept = %s; http_intercept_path = %s; port_max_idle_time = %s; host_names = %s; gateway_names = %s; vm_names = %s; udpv4_forwards = %s; tcpv4_forwards = %s; gateway_forwards_path = %s; pcap_snaplen = %d"
     (Macaddr.to_string t.server_macaddr)
     (match t.max_connections with None -> "None" | Some x -> string_of_int x)
     (match t.dns_path with None -> "None" | Some x -> x)
@@ -83,6 +84,7 @@ let to_string t =
     (String.concat ", " (List.map Dns.Name.to_string t.vm_names))
     (String.concat ", " (List.map (fun (src_port, (dst_ipv4, dst_port)) -> Printf.sprintf "%d -> %s:%d" src_port (Ipaddr.V4.to_string dst_ipv4) dst_port) t.udpv4_forwards))
     (String.concat ", " (List.map (fun (src_port, (dst_ipv4, dst_port)) -> Printf.sprintf "%d -> %s:%d" src_port (Ipaddr.V4.to_string dst_ipv4) dst_port) t.tcpv4_forwards))
+    (match t.gateway_forwards_path with None -> "None" | Some x -> x)
     t.pcap_snaplen
 
 let no_dns_servers =
@@ -129,6 +131,7 @@ let default = {
   vm_names = default_gateway_names;
   udpv4_forwards = [];
   tcpv4_forwards = [];
+  gateway_forwards_path = None;
   pcap_snaplen = default_pcap_snaplen;
 }
 

--- a/src/hostnet/gateway_forwards.ml
+++ b/src/hostnet/gateway_forwards.ml
@@ -48,18 +48,28 @@ let of_string x =
 
 let dynamic = ref []
 
-let update xs = dynamic := xs
+let static = ref []
+
+let all = ref []
+
+let set_static xs =
+    static := xs;
+    all := !static @ !dynamic
+
+let update xs =
+    dynamic := xs;
+    all := !static @ !dynamic
 
 module Udp = struct
-  let mem port = List.exists (fun f -> f.protocol = Udp && f.external_port = port) !dynamic
+  let mem port = List.exists (fun f -> f.protocol = Udp && f.external_port = port) !all
   let find port =
-    let f = List.find (fun f -> f.protocol = Udp && f.external_port = port) !dynamic in
+    let f = List.find (fun f -> f.protocol = Udp && f.external_port = port) !all in
     f.internal_ip, f.internal_port
 end
 
 module Tcp = struct
-  let mem port = List.exists (fun f -> f.protocol = Udp && f.external_port = port) !dynamic
+  let mem port = List.exists (fun f -> f.protocol = Tcp && f.external_port = port) !all
   let find port =
-    let f = List.find (fun f -> f.protocol = Udp && f.external_port = port) !dynamic in
+    let f = List.find (fun f -> f.protocol = Tcp && f.external_port = port) !all in
     f.internal_ip, f.internal_port
 end

--- a/src/hostnet/gateway_forwards.ml
+++ b/src/hostnet/gateway_forwards.ml
@@ -1,0 +1,65 @@
+
+type protocol =
+  | Tcp
+  | Udp
+
+type forward = {
+    protocol: protocol;
+    external_port: int;
+    internal_ip: Ipaddr.V4.t;
+    internal_port: int;
+}
+
+let forward_to_json t =
+    let open Ezjsonm in
+    dict [
+        "protocol", string (match t.protocol with Tcp -> "tcp" | Udp -> "udp");
+        "external_port", int t.external_port;
+        "internal_ip", string (Ipaddr.V4.to_string t.internal_ip);
+        "internal_port", int t.internal_port;
+    ]
+
+let forward_of_json j =
+    let open Ezjsonm in
+    let protocol = match get_string @@ find j [ "protocol" ] with
+      | "tcp" -> Tcp
+      | "udp" -> Udp
+      | _ -> raise (Parse_error(j, "protocol should be tcp or udp")) in
+    let external_port = get_int @@ find j [ "external_port" ] in
+    let internal_port = get_int @@ find j [ "internal_port" ] in
+    let internal_ip = match Ipaddr.V4.of_string @@ get_string @@ find j [ "internal_ip" ] with
+      | Some x -> x
+      | None -> raise (Parse_error(j, "internal_ip should be an IPv4 address")) in
+    {
+        protocol; external_port; internal_ip; internal_port;
+    }
+
+type t = forward list
+
+let to_json = Ezjsonm.list forward_to_json
+let of_json = Ezjsonm.get_list forward_of_json
+
+let to_string x = Ezjsonm.to_string @@ to_json x
+let of_string x =
+    try
+        Ok (of_json @@ Ezjsonm.from_string x)
+    with Ezjsonm.Parse_error(_v, msg) ->
+        Error (`Msg msg)
+
+let dynamic = ref []
+
+let update xs = dynamic := xs
+
+module Udp = struct
+  let mem port = List.exists (fun f -> f.protocol = Udp && f.external_port = port) !dynamic
+  let find port =
+    let f = List.find (fun f -> f.protocol = Udp && f.external_port = port) !dynamic in
+    f.internal_ip, f.internal_port
+end
+
+module Tcp = struct
+  let mem port = List.exists (fun f -> f.protocol = Udp && f.external_port = port) !dynamic
+  let find port =
+    let f = List.find (fun f -> f.protocol = Udp && f.external_port = port) !dynamic in
+    f.internal_ip, f.internal_port
+end

--- a/src/hostnet/gateway_forwards.ml
+++ b/src/hostnet/gateway_forwards.ml
@@ -1,3 +1,9 @@
+let src =
+    let src = Logs.Src.create "gateway_forwards" ~doc:"Manages IP forwarding from the gateway IP" in
+    Logs.Src.set_level src (Some Logs.Info);
+    src
+
+module Log = (val Logs.src_log src : Logs.LOG)
 
 type protocol =
   | Tcp
@@ -54,11 +60,13 @@ let all = ref []
 
 let set_static xs =
     static := xs;
-    all := !static @ !dynamic
+    all := !static @ !dynamic;
+    Log.info (fun f -> f "New Gateway forward configuration: %s" (to_string !all))
 
 let update xs =
     dynamic := xs;
-    all := !static @ !dynamic
+    all := !static @ !dynamic;
+    Log.info (fun f -> f "New Gateway forward configuration: %s" (to_string !all))
 
 module Udp = struct
   let mem port = List.exists (fun f -> f.protocol = Udp && f.external_port = port) !all

--- a/src/hostnet/gateway_forwards.mli
+++ b/src/hostnet/gateway_forwards.mli
@@ -14,8 +14,11 @@ type t = forward list
 val to_string: t -> string
 val of_string: string -> (t, [`Msg of string]) result
 
+val set_static: t -> unit
+(** update the static forwarding table *)
+
 val update: t -> unit
-(** update the current forwarding table *)
+(** update the dynamic forwarding table *)
 
 module Udp: sig
   val mem: int -> bool

--- a/src/hostnet/gateway_forwards.mli
+++ b/src/hostnet/gateway_forwards.mli
@@ -1,0 +1,34 @@
+type protocol =
+  | Tcp
+  | Udp
+
+type forward = {
+    protocol: protocol;
+    external_port: int;
+    internal_ip: Ipaddr.V4.t;
+    internal_port: int;
+}
+
+type t = forward list
+
+val to_string: t -> string
+val of_string: string -> (t, [`Msg of string]) result
+
+val update: t -> unit
+(** update the current forwarding table *)
+
+module Udp: sig
+  val mem: int -> bool
+  (** [mem port] is true if there is a rule to forward UDP from external port [port] *)
+
+  val find: int -> (Ipaddr.V4.t * int)
+  (** [find port] returns the internal IP and port to forward UDP on external port [port] *)
+end
+
+module Tcp: sig
+  val mem: int -> bool
+  (** [mem port] is true if there is a rule to forward TCP from external port [port] *)
+
+  val find: int -> (Ipaddr.V4.t * int)
+  (** [find port] returns the internal IP and port to forward TCP on external port [port] *)
+end

--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -148,7 +148,12 @@ let config =
     Configuration.default with
     domain = Some "local";
     host_names = names_for_localhost;
-    tcpv4_forwards = [ local_tcpv4_forwarded_port, (Ipaddr.V4.localhost, local_tcpv4_forwarded_port)];
+    tcpv4_forwards = [ {
+      protocol = Tcp;
+      external_port = local_tcpv4_forwarded_port;
+      internal_ip = Ipaddr.V4.localhost;
+      internal_port = local_tcpv4_forwarded_port;
+    } ];
   } in
   Mclock.connect () >>= fun clock ->
   let vnet = Vnet.create () in


### PR DESCRIPTION
Previously we only supported a static set of forwards set via the command-line.

This PR adds support for a dynamic json config file, which is watched and reparsed when it changes.

Both the command-line and the dynamic json file may be used together, with the command-line rules taking precedence if there is a clash.

Signed-off-by: David Scott <dave.scott@docker.com>