### PR TITLE
Permit missing --gateway-forwards <file>

### DIFF
--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -857,7 +857,7 @@ let gateway_forwards_path =
       "Path of gateway forwards configuration file"
       [ "gateway-forwards" ]
   in
-  Arg.(value & opt (some file) None doc)
+  Arg.(value & opt (some string) None doc)
 
 let gc_compact =
   let doc =


### PR DESCRIPTION
Previously `vpnkit` would fail to start if the gateway forwards file didn't exist but the `--gateway-forwards` argument was provided. This makes it difficult to have the configuration written entirely dynamically, for example by another process starting in parallel.

With this patch `vpnkit` will log a warning but will read the file when it is created.

Signed-off-by: David Scott <dave.scott@docker.com>