### PR TITLE
Attempt to fix the main vpnkit Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM ocaml/opam:alpine
+FROM ocaml/opam2:alpine
 ADD . /home/opam/src
 # Latest packages plus some overrides are in this repo:
 RUN opam remote add vpnkit /home/opam/src/repo/darwin
 RUN opam pin add -y -n vpnkit /home/opam/src
 RUN opam depext vpnkit -y
+RUN opam pin add -y -n tcpip https://github.com/djs55/mirage-tcpip.git#vpnkit-20180607
 RUN opam install --deps-only vpnkit -y
 RUN opam pin remove vpnkit
 WORKDIR /home/opam/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocaml/opam2:alpine
+FROM ocaml/opam2:alpine as build
 ADD . /home/opam/src
 # Latest packages plus some overrides are in this repo:
 RUN opam remote add vpnkit /home/opam/src/repo/darwin
@@ -8,3 +8,7 @@ RUN opam pin add -y -n tcpip https://github.com/djs55/mirage-tcpip.git#vpnkit-20
 RUN opam install --deps-only vpnkit -y
 RUN opam pin remove vpnkit
 WORKDIR /home/opam/src
+RUN opam exec -- sudo dune build src/bin/main.exe
+
+FROM scratch
+COPY --from=build /home/opam/src/_build/default/src/bin/main.exe /vpnkit

--- a/src/bin/jbuild
+++ b/src/bin/jbuild
@@ -7,6 +7,7 @@
      datakit-server-9p win-eventlog asl fd-send-recv duration
      mirage-clock-unix mirage-random
    ))
+   (flags (:standard -ccopt -static))
    (preprocess  no_preprocessing)))
 
 (rule

--- a/vpnkit.opam
+++ b/vpnkit.opam
@@ -63,4 +63,5 @@ depends: [
   "sha"
   "stringext"
   "mirage-clock-unix"
+  "mirage-random" {= "1.1.0"}
 ]


### PR DESCRIPTION
Previously the `Dockerfile` was mainly used to produce a Linux development environment and it had bit-rotted. This PR

- makes the `Dockerfile` build again
- refreshes the tools to use the latest `opam2`
- attempts to statically link the `vpnkit` binary and put it in a `FROM scratch` image

Note this PR doesn't modify the CI to push the image somewhere useful.