### PR TITLE
Update to opam2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,7 @@ jobs:
     steps:
       - checkout
       - run: brew uninstall python # remove files in /usr/local/bin
-      - run: brew install wget pkg-config dylibbundler
-      - run: brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/72ce8812eaa33abe23533dfa021b51351a6b9c3e/Formula/opam.rb
+      - run: brew install wget pkg-config dylibbundler opam
       - run: make
       - run: make artefacts
       - run: make test

--- a/scripts/depends.sh
+++ b/scripts/depends.sh
@@ -10,12 +10,12 @@ case "$(uname -s)" in
 
     # default setttings
     SWITCH="${OPAM_COMP}"
-    OPAM_URL='https://dl.dropboxusercontent.com/s/b2q2vjau7if1c1b/opam64.tar.xz'
+    OPAM_URL='https://github.com/fdopen/opam-repository-mingw/releases/download/0.0.0.2/opam64.tar.xz'
     OPAM_ARCH=opam64
 
     if [ "$PROCESSOR_ARCHITECTURE" != "AMD64" ] && \
            [ "$PROCESSOR_ARCHITEW6432" != "AMD64" ]; then
-        OPAM_URL='https://dl.dropboxusercontent.com/s/eo4igttab8ipyle/opam32.tar.xz'
+	OPAM_URL='https://github.com/fdopen/opam-repository-mingw/releases/download/0.0.0.2/opam32.tar.xz'
         OPAM_ARCH=opam32
     fi
 


### PR DESCRIPTION
The Linux `Dockerfile` already works with `opam2`, which is a good start.

- remove the `opam` 1.2 pin from CircleCI
- update the download links for AppVeyor