### PR TITLE
Update linuxkit/virtsock package. Track 10586_fixes branch.

### DIFF
--- a/go/Gopkg.lock
+++ b/go/Gopkg.lock
@@ -214,14 +214,15 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:0e87612c84b64968bcddc3c0378f471d8a93384ed709b09501174c7e4ddcaf74"
+  branch = "10586_fixes"
+  digest = "1:afcc93a5ffcbf5a73618d5f832fbf65a7d62f63763a1b31dccddf2390a7f11e4"
   name = "github.com/linuxkit/virtsock"
   packages = [
     "pkg/hvsock",
     "pkg/vsock",
   ]
   pruneopts = "NUT"
-  revision = "a381dcc5bcddf1d7f449495c373dbf70f8e501c0"
+  revision = "76c5cbe7912fc569ca7d3c02ddf9974ce670f7dd"
 
 [[projects]]
   branch = "master"

--- a/go/Gopkg.toml
+++ b/go/Gopkg.toml
@@ -21,7 +21,7 @@
 
 [[constraint]]
   name = "github.com/linuxkit/virtsock"
-  revision = "a381dcc5bcddf1d7f449495c373dbf70f8e501c0"
+  branch = "10586_fixes"
 
 [[constraint]]
   name = "github.com/docker/go-p9p"

--- a/go/pkg/vpnkit/dialer_windows.go
+++ b/go/pkg/vpnkit/dialer_windows.go
@@ -17,12 +17,16 @@ func (d *Dialer) connectTransport() (io.ReadWriteCloser, error) {
 		port = DefaultVsockPort
 	}
 	guid := fmt.Sprintf("%08x-FACB-11E6-BD58-64006A7986D3", port)
+	vmid, err := hvsock.GUIDFromString(d.HyperVVMID)
+	if err != nil {
+		return nil, err
+	}
 	svc, err := hvsock.GUIDFromString(guid)
 	if err != nil {
 		return nil, err
 	}
-	addr := hvsock.Addr{
-		VMID:      d.HyperVVMID,
+	addr := hvsock.HypervAddr{
+		VMID:      vmid,
 		ServiceID: svc,
 	}
 	return hvsock.Dial(addr)

--- a/go/vendor/github.com/linuxkit/virtsock/AUTHORS
+++ b/go/vendor/github.com/linuxkit/virtsock/AUTHORS
@@ -1,0 +1,11 @@
+# This file lists all individuals having contributed content to the repository.
+# For how it is generated, see `scripts/generate-authors.sh`.
+
+Ben Weedon <beweedon@microsoft.com>
+Ian Campbell <ian.campbell@docker.com>
+John Starks <jostarks@microsoft.com>
+Justin Cormack <justin.cormack@docker.com>
+Magnus Skjegstad <magnus.skjegstad@docker.com>
+Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>
+Rolf Neugebauer <rolf.neugebauer@docker.com>
+Simon Ferquel <simon.ferquel@docker.com>

--- a/go/vendor/github.com/linuxkit/virtsock/LICENSE
+++ b/go/vendor/github.com/linuxkit/virtsock/LICENSE
@@ -1,4 +1,7 @@
-Copyright 2016 Rolf Neugebauer <rolf.neugebauer@gmail.com>
+Unless explicitly stated at the top of the file, this code is covered
+by the following license:
+
+Copyright 2016-2017 The authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -11,61 +14,3 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-
-Some of the code in ./go/hvsock.go, ./go/hvsock_windows.go, and
-zsyscall_windows.go is covered by the following licenses:
-==============================================================================
-
-The MIT License (MIT)
-
-Copyright (c) 2015 Microsoft
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-and
-===
-
-Copyright (c) 2012 The Go Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/go/vendor/github.com/linuxkit/virtsock/pkg/hvsock/hvsock_fallback.go
+++ b/go/vendor/github.com/linuxkit/virtsock/pkg/hvsock/hvsock_fallback.go
@@ -20,6 +20,10 @@ type hvsockListener struct {
 //
 // System call wrapper
 //
+func hvsocket(typ, proto int) (int, error) {
+	return 0, errors.New("hvsocket() not implemented")
+}
+
 func connect(s int, a *HypervAddr) (err error) {
 	return errors.New("connect() not implemented")
 }

--- a/go/vendor/github.com/linuxkit/virtsock/pkg/hvsock/zsyscall_windows.go
+++ b/go/vendor/github.com/linuxkit/virtsock/pkg/hvsock/zsyscall_windows.go
@@ -1,5 +1,32 @@
 package hvsock
 
+/*
+Most of this code was derived from: https://github.com/Microsoft/go-winio
+which has the following license:
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 import (
 	"syscall"
 	"unsafe"

--- a/go/vendor/github.com/linuxkit/virtsock/pkg/vsock/fallback.go
+++ b/go/vendor/github.com/linuxkit/virtsock/pkg/vsock/fallback.go
@@ -14,11 +14,11 @@ func SocketMode(socketMode string) {
 }
 
 // Dial is the unimplemented fallback for unsupported OSes
-func Dial(cid, port uint) (Conn, error) {
+func Dial(cid, port uint32) (Conn, error) {
 	return nil, fmt.Errorf("Unimplemented")
 }
 
 // Listen is the unimplemented fallback for unsupported OSes
-func Listen(cid, port uint) (net.Listener, error) {
+func Listen(cid, port uint32) (net.Listener, error) {
 	return nil, fmt.Errorf("Unimplemented")
 }

--- a/go/vendor/github.com/linuxkit/virtsock/pkg/vsock/hyperkit_darwin.go
+++ b/go/vendor/github.com/linuxkit/virtsock/pkg/vsock/hyperkit_darwin.go
@@ -15,6 +15,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 var (
@@ -27,27 +29,27 @@ var (
 // ("hyperkit:/path") or Docker for Mac mode ("docker"). This function
 // must be called before using the vsock bindings.
 func SocketMode(socketMode string) {
+	socketFmt = "%08x.%08x"
+
 	if strings.HasPrefix(socketMode, "hyperkit:") {
 		socketPath = socketMode[len("hyperkit:"):]
-		connectPath = filepath.Join(socketPath, "connect")
-		socketFmt = "%08x.%08x"
 	} else if socketMode == "docker" {
-		socketPath = filepath.Join(os.Getenv("HOME"), "/Library/Containers/com.docker.docker/Data")
-		connectPath = filepath.Join(socketPath, "@connect")
-		socketFmt = "*%08x.%08x"
+		socketPath = filepath.Join(os.Getenv("HOME"), "/Library/Containers/com.docker.docker/Data/vms/0")
 	} else {
 		log.Fatalln("Unknown socket mode: ", socketMode)
 	}
+
+	connectPath = filepath.Join(socketPath, "connect")
 }
 
 // Dial creates a connection to the VM with the given client ID and port
 func Dial(cid, port uint32) (Conn, error) {
 	c, err := net.DialUnix("unix", nil, &net.UnixAddr{connectPath, "unix"})
 	if err != nil {
-		return c, err
+		return c, errors.Wrapf(err, "failed to dial on %s", connectPath)
 	}
 	if _, err := fmt.Fprintf(c, "%08x.%08x\n", cid, port); err != nil {
-		return c, fmt.Errorf("Failed to write dest (%08x.%08x) to %s", cid, port, connectPath)
+		return c, errors.Wrapf(err, "Failed to write dest (%08x.%08x) to %s", cid, port, connectPath)
 	}
 	return c, nil
 }

--- a/go/vendor/github.com/linuxkit/virtsock/pkg/vsock/vsock.go
+++ b/go/vendor/github.com/linuxkit/virtsock/pkg/vsock/vsock.go
@@ -12,7 +12,9 @@
 package vsock
 
 import (
+	"fmt"
 	"net"
+	"os"
 )
 
 const (
@@ -24,9 +26,26 @@ const (
 	CIDHost = 2
 )
 
+// VsockAddr represents the address of a vsock end point.
+type VsockAddr struct {
+	CID  uint32
+	Port uint32
+}
+
+// Network returns the network type for a VsockAddr
+func (a VsockAddr) Network() string {
+	return "vsock"
+}
+
+// String returns a string representation of a VsockAddr
+func (a VsockAddr) String() string {
+	return fmt.Sprintf("%08x.%08x", a.CID, a.Port)
+}
+
 // Conn is a vsock connection which supports half-close.
 type Conn interface {
 	net.Conn
 	CloseRead() error
 	CloseWrite() error
+	File() (*os.File, error)
 }

--- a/go/vendor/github.com/linuxkit/virtsock/scripts/generate-authors.sh
+++ b/go/vendor/github.com/linuxkit/virtsock/scripts/generate-authors.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+# see also ".mailmap" for how email addresses and names are deduplicated
+
+{
+	cat <<-'EOH'
+	# This file lists all individuals having contributed content to the repository.
+	# For how it is generated, see `scripts/generate-authors.sh`.
+	EOH
+	echo
+	git log --format='%aN <%aE>' | LC_ALL=C.UTF-8 sort -uf
+} > AUTHORS


### PR DESCRIPTION
I can now compile all tests on Mac but I have one last failing unit test:

```
=== RUN   TestUDPWriteError
--- FAIL: TestUDPWriteError (0.00s)
	network_proxy_test.go:237: write udp 127.0.0.1:64614->127.0.0.1:25587: write: connection refused
```

Not sure it should pass on Mac or not.