### PR TITLE
Multiplexer: handle data after EOF

### DIFF
--- a/go/pkg/libproxy/frame_test.go
+++ b/go/pkg/libproxy/frame_test.go
@@ -42,6 +42,9 @@ func TestParseOpenDedicated(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if _, ok := f.Payload().(*OpenFrame); !ok {
+		t.Fatal("not an *OpenFrame")
+	}
 	assertEqual(t, o.Connection, Dedicated)
 	assertEqual(t, o.Destination.Proto, TCP)
 	assertEqual(t, o.Destination.IP.String(), "127.0.0.1")
@@ -65,6 +68,9 @@ func TestParseOpenMultiplexed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if _, ok := f.Payload().(*OpenFrame); !ok {
+		t.Fatal("not an *OpenFrame")
+	}
 	assertEqual(t, o.Destination.Proto, UDP)
 	assertEqual(t, o.Destination.IP.String(), "::1")
 	assertEqual(t, o.Destination.Port, uint16(8080))
@@ -87,6 +93,9 @@ func TestParseOpenMultiplexedUnix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if _, ok := f.Payload().(*OpenFrame); !ok {
+		t.Fatal("not an *OpenFrame")
+	}
 	assertEqual(t, o.Destination.Proto, Unix)
 	assertEqual(t, o.Destination.Path, "/tmp/foo")
 	ParsePrint(t, b)
@@ -104,6 +113,9 @@ func TestParseClose(t *testing.T) {
 	}
 	assertEqual(t, f.Command, Close)
 	assertEqual(t, f.ID, uint32(6))
+	if _, ok := f.Payload().(*CloseFrame); !ok {
+		t.Fatal("not an *CloseFrame")
+	}
 	ParsePrint(t, b)
 }
 
@@ -119,6 +131,9 @@ func TestParseShutdown(t *testing.T) {
 	}
 	assertEqual(t, f.Command, Shutdown)
 	assertEqual(t, f.ID, uint32(7))
+	if _, ok := f.Payload().(*ShutdownFrame); !ok {
+		t.Fatal("not an *ShutdownFrame")
+	}
 	ParsePrint(t, b)
 }
 
@@ -139,6 +154,9 @@ func TestParseData(t *testing.T) {
 		t.Fatal(err)
 	}
 	assertEqual(t, d.payloadlen, uint32(128))
+	if _, ok := f.Payload().(*DataFrame); !ok {
+		t.Fatal("not an *DataFrame")
+	}
 	ParsePrint(t, b)
 }
 
@@ -159,6 +177,9 @@ func TestParseWindow(t *testing.T) {
 		t.Fatal(err)
 	}
 	assertEqual(t, w.seq, uint64(8888888))
+	if _, ok := f.Payload().(*WindowFrame); !ok {
+		t.Fatal("not an *WindowFrame")
+	}
 	ParsePrint(t, b)
 }
 

--- a/go/pkg/libproxy/loopbackconn.go
+++ b/go/pkg/libproxy/loopbackconn.go
@@ -128,11 +128,15 @@ func (pipe *bufferedPipe) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-func (pipe *bufferedPipe) CloseWrite() error {
+func (pipe *bufferedPipe) closeWriteNoErr() {
 	pipe.m.Lock()
 	defer pipe.m.Unlock()
 	pipe.eof = true
 	pipe.c.Broadcast()
+}
+
+func (pipe *bufferedPipe) CloseWrite() error {
+	pipe.closeWriteNoErr()
 	return nil
 }
 

--- a/go/pkg/libproxy/multiplexed.go
+++ b/go/pkg/libproxy/multiplexed.go
@@ -326,6 +326,7 @@ func (m *Multiplexer) decrChannelRef(ID uint32) {
 	defer m.metadataMutex.Unlock()
 	if channel, ok := m.channels[ID]; ok {
 		if channel.refCount == 1 {
+			log.Printf("Close channel id %d to %s", ID, channel.destination.String())
 			delete(m.channels, ID)
 			return
 		}
@@ -411,6 +412,7 @@ func (m *Multiplexer) run() error {
 				m.pendingAccept = append(m.pendingAccept, channel)
 				m.acceptCond.Signal()
 				m.metadataMutex.Unlock()
+				log.Printf("Open channel id %d to %s", f.ID, o.Destination.String())
 			}
 		case *WindowFrame:
 			m.metadataMutex.Lock()

--- a/go/pkg/libproxy/multiplexed.go
+++ b/go/pkg/libproxy/multiplexed.go
@@ -417,7 +417,7 @@ func (m *Multiplexer) run() error {
 			channel, ok := m.channels[f.ID]
 			m.metadataMutex.Unlock()
 			if !ok {
-				return fmt.Errorf("Unknown channel id: %v", f.ID)
+				return fmt.Errorf("Unknown channel id %s", f.String())
 			}
 			channel.recvWindowUpdate(payload.seq)
 		case *DataFrame:
@@ -425,7 +425,7 @@ func (m *Multiplexer) run() error {
 			channel, ok := m.channels[f.ID]
 			m.metadataMutex.Unlock()
 			if !ok {
-				return fmt.Errorf("Unknown channel id: %v", f.ID)
+				return fmt.Errorf("Unknown channel id: %s", f.String())
 			}
 			// A confused client could send a DataFrame after a ShutdownFrame or CloseFrame.
 			if n, err := io.CopyN(channel.readPipe, m.connR, int64(payload.payloadlen)); err != nil {
@@ -446,7 +446,7 @@ func (m *Multiplexer) run() error {
 			channel, ok := m.channels[f.ID]
 			m.metadataMutex.Unlock()
 			if !ok {
-				return fmt.Errorf("Unknown channel id: %v", f.ID)
+				return fmt.Errorf("Unknown channel id: %s", f.String())
 			}
 			channel.readPipe.closeWriteNoErr()
 		case *CloseFrame:
@@ -454,7 +454,7 @@ func (m *Multiplexer) run() error {
 			channel, ok := m.channels[f.ID]
 			m.metadataMutex.Unlock()
 			if !ok {
-				return fmt.Errorf("Unknown channel id: %v", f.ID)
+				return fmt.Errorf("Unknown channel id: %s", f.String())
 			}
 			// this will unblock waiting Read calls
 			channel.readPipe.closeWriteNoErr()

--- a/go/pkg/libproxy/multiplexed.go
+++ b/go/pkg/libproxy/multiplexed.go
@@ -55,6 +55,22 @@ type channel struct {
 	testAllowDataAfterCloseWrite bool
 }
 
+func (c *channel) String() string {
+	closeReceived := ""
+	if c.closeReceived {
+		closeReceived = "closeReceived "
+	}
+	closeSent := ""
+	if c.closeSent {
+		closeSent = "closeSent "
+	}
+	shutdownSent := ""
+	if c.shutdownSent {
+		shutdownSent = "shutdownSent "
+	}
+	return fmt.Sprintf("ID %d -> %s %s%s%s", c.ID, c.destination.String(), closeReceived, closeSent, shutdownSent)
+}
+
 // newChannel registers a channel through the multiplexer
 func newChannel(multiplexer *Multiplexer, ID uint32, d Destination) *channel {
 	var m sync.Mutex
@@ -376,6 +392,10 @@ func (m *Multiplexer) Run() {
 	go func() {
 		if err := m.run(); err != nil {
 			log.Printf("Multiplexer main loop failed with %v", err)
+			log.Printf("Active channels:")
+			for _, c := range m.channels {
+				log.Printf("%s", c.String())
+			}
 		}
 		m.metadataMutex.Lock()
 		m.isRunning = false

--- a/go/pkg/libproxy/multiplexed_test.go
+++ b/go/pkg/libproxy/multiplexed_test.go
@@ -177,6 +177,46 @@ func TestCloseCloseWrite(t *testing.T) {
 	}
 }
 
+func TestCloseWriteWrite(t *testing.T) {
+	loopback := newLoopback()
+	local := NewMultiplexer("local", loopback)
+	local.Run()
+	remote := NewMultiplexer("remote", loopback.OtherEnd())
+	remote.Run()
+
+	client, err := local.Dial(Destination{
+		Proto: TCP,
+		IP:    net.ParseIP("127.0.0.1"),
+		Port:  8080,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, _, err := remote.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	channel, ok := client.(*channel)
+	if !ok {
+		t.Fatal("conn was not a *channel")
+	}
+	channel.setTestAllowDataAfterCloseWrite()
+	if err := client.CloseWrite(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Write([]byte{1}); err != nil {
+		t.Fatal(err)
+	}
+	// FIXME: need a way to wait for the multiplexer to have processed the message.
+	time.Sleep(time.Second)
+	if !remote.IsRunning() {
+		t.Fatal("remote multiplexer has failed")
+	}
+	if err := server.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestCloseThenWrite(t *testing.T) {
 	loopback := newLoopback()
 	local := NewMultiplexer("local", loopback)


### PR DESCRIPTION
Previously it was possible for a client to send a `Data` payload after a `Shutdown` or `Close` which would break the Go multiplexer's main loop, because it would get `EOF` from `io.CopyN`. This PR handles this error by discarding the unexpected data and processing the next message.

To make the code clearer this PR also
- removes unnecessary `error` cases from the Go code
- creates helper predicates `is_read_eof` and `is_write_eof` in the OCaml code.