### PR TITLE
Reconnect the connection multiplexer on failure

### DIFF
--- a/go/pkg/libproxy/multiplexed.go
+++ b/go/pkg/libproxy/multiplexed.go
@@ -352,6 +352,11 @@ func NewMultiplexer(label string, conn io.ReadWriteCloser) *Multiplexer {
 	}
 }
 
+// Close the underlying transport.
+func (m *Multiplexer) Close() error {
+	return m.conn.Close()
+}
+
 func (m *Multiplexer) appendEvent(e *event) {
 	m.eventsM.Lock()
 	defer m.eventsM.Unlock()

--- a/go/pkg/vpnkit/dialer.go
+++ b/go/pkg/vpnkit/dialer.go
@@ -25,6 +25,10 @@ type Dialer struct {
 func (d *Dialer) setupMultiplexer() error {
 	d.m.Lock()
 	defer d.m.Unlock()
+	if d.mux != nil && !d.mux.IsRunning() {
+		d.mux.Close()
+		d.mux = nil
+	}
 	if d.mux == nil {
 		conn, err := d.connectTransport()
 		if err != nil {

--- a/src/forwarder/multiplexer.ml
+++ b/src/forwarder/multiplexer.ml
@@ -384,4 +384,6 @@ module Make (Flow : Mirage_flow_lwt.S) = struct
       | true -> dispatcher ()
     in
     Lwt.async dispatcher ; outer
+
+  let disconnect m = Flow.close m.flow
 end

--- a/src/forwarder/multiplexer.mli
+++ b/src/forwarder/multiplexer.mli
@@ -17,4 +17,7 @@ module Make (Flow : Mirage_flow_lwt.S) : sig
 
   val is_running : flow -> bool
   (** [is_running flow] is true if the dispatcher thread is still running. *)
+
+  val disconnect: flow -> unit Lwt.t
+  (** [disconnect flow] disconnects the underlying flow *)
 end


### PR DESCRIPTION
On the Mac a connection to `vpnkit-forwarder` is first accepted by `hyperkit` and forwarded. If `vpnkit-forwarder` hasn't started yet then the connection is immediately closed-- this permanently breaks the forwarding.

This PR makes the client reconnect if the multiplexer dispatcher has shutdown.
