### PR TITLE
mux: ocaml: avoid sending Shutdown after Close

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - checkout
       - run: brew uninstall python # remove files in /usr/local/bin
       - run: brew install wget pkg-config dylibbundler
-      - run: brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/72ce8812eaa33abe23533dfa021b51351a6b9c3e/Formula/opam.rb
+      - run: brew install https://gist.githubusercontent.com/djs55/7a94ee5aeb882ef5399c0485d2affdda/raw/bc04ff96e0082d7ee07642337dbb77c51b93d678/opam.rb
       - run: make
       - run: make artefacts
       - run: make test

--- a/src/hostnet_test/test_forward_protocol.ml
+++ b/src/hostnet_test/test_forward_protocol.ml
@@ -196,6 +196,34 @@ let test_close_close () =
      Lwt.return_unit
      )
 
+let test_close_shutdown () =
+  Host.Main.run
+    (let left_flow = Shared_memory.create () in
+     let right_flow = Shared_memory.otherend left_flow in
+     let left_mux =
+       Mux.connect left_flow "left" (fun _channel _destination ->
+           Lwt.fail_with "left side shouldn't get a connection" )
+     in
+     let right_mux =
+       Mux.connect right_flow "right" (fun channel destination ->
+           Log.debug (fun f ->
+               f "Got a connection to %s" (Destination.to_string destination)
+           ) ;
+           Mux.Channel.close channel )
+     in
+     Mux.Channel.connect left_mux (`Tcp (Ipaddr.V4 Ipaddr.V4.localhost, 8080))
+     >>= fun channel ->
+     Mux.Channel.close channel
+     >>= fun () ->
+     Mux.Channel.shutdown_write channel
+     >>= fun () ->
+     if not (Mux.is_running left_mux)
+     then failwith "left_mux has failed";
+     if not (Mux.is_running right_mux)
+     then failwith "right_mux has failed";
+     Lwt.return_unit
+     )
+
 let send channel n =
   let sha = Sha256.init () in
   let rec loop n =
@@ -370,6 +398,9 @@ let mux_suite =
       ; ( "check that double-close doesn't break the connection"
         , `Quick
         , test_close_close )
+      ; ( "check that shutdown after close doesn't break the connection"
+        , `Quick
+        , test_close_shutdown )
       ; ( "check that the multiplexer can handle concurrent connections"
         , `Quick
         , stress_multiplexer ) ] ) ]


### PR DESCRIPTION
A badly-behaved client could send Shutdown after Close, for example if the Proxy.proxy function in `vpnkit` throws an exception for one of the directions, the function will return and the `Lwt.finalize` will call `close`. Some time later the other copy will finish and call `close_write` which will send a Shutdown message.

This PR avoids sending Shutdown messages after Close. We already covered the case of sending Data or Close messages after Close.