### PR TITLE
Fixes for Unix domain socket forwarding

### DIFF
--- a/go/pkg/vpnkit/port.go
+++ b/go/pkg/vpnkit/port.go
@@ -165,7 +165,7 @@ func (c *Connection) Expose(ctx context.Context, p *Port) error {
 	// shutdown the forward.
 
 	// Read any error from a previous session
-	bytes := make([]byte, 100)
+	bytes := make([]byte, 4096)
 	n, err := ctl.Read(ctx, bytes, 0)
 	if err != nil {
 		log.Printf("Expose %s: failed to read response from ctl: %#v\n", spec, err)

--- a/go/pkg/vpnkit/port.go
+++ b/go/pkg/vpnkit/port.go
@@ -77,6 +77,9 @@ func (c *Connection) ListExposed(ctx context.Context) ([]Port, error) {
 
 // String returns a human-readable string
 func (p *Port) String() string {
+	if p.Proto == Unix {
+		return fmt.Sprintf("%s forward from %s to %s", p.Proto, p.OutPath, p.InPath)
+	}
 	return fmt.Sprintf("%s forward from %s:%d to %s:%d", p.Proto, p.OutIP.String(), p.OutPort, p.InIP.String(), p.InPort)
 }
 


### PR DESCRIPTION
- pretty-print Unix forwards correctly
- allow longer paths (previously we had a limit of 100 bytes - some overhead due to base64 encoding)