### PR TITLE
Remove `make test` from `vpnkit-userland-proxy`

### DIFF
--- a/go/Dockerfile.userland-proxy
+++ b/go/Dockerfile.userland-proxy
@@ -5,7 +5,6 @@ RUN apk add --no-cache go musl-dev build-base
 ADD . /go/src/github.com/moby/vpnkit/go
 WORKDIR /go/src/github.com/moby/vpnkit/go
 
-RUN GOPATH=/go make test
 RUN GOPATH=/go make build/vpnkit-userland-proxy.linux
 
 FROM scratch


### PR DESCRIPTION
The `vpnkit-userland-proxy` doesn't use any of the common libraries.

This speeds up the build.

Signed-off-by: David Scott <dave.scott@docker.com>