### PR TITLE
go: improve build of vpnkit-userspace-proxy

### DIFF
--- a/go/.dockerignore
+++ b/go/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile*

--- a/go/Dockerfile.userland-proxy
+++ b/go/Dockerfile.userland-proxy
@@ -1,11 +1,14 @@
-FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
+FROM linuxkit/alpine:3683c9a66cd4da40bd7d6c7da599b2dcd738b559 AS mirror
 
-RUN apk add --no-cache go musl-dev build-base
+RUN apk add --no-cache go musl-dev
+
+ENV GOPATH=/go PATH=$PATH:/go/bin
 
 ADD . /go/src/github.com/moby/vpnkit/go
-WORKDIR /go/src/github.com/moby/vpnkit/go
-
-RUN GOPATH=/go make build/vpnkit-userland-proxy.linux
+RUN go-compile.sh /go/src/github.com/moby/vpnkit/go/cmd/vpnkit-userland-proxy
 
 FROM scratch
-COPY --from=mirror /go/src/github.com/moby/vpnkit/go/build/vpnkit-userland-proxy.linux /usr/bin/vpnkit-userland-proxy
+ENTRYPOINT []
+CMD []
+WORKDIR /
+COPY --from=mirror /go/bin/vpnkit-userland-proxy /usr/bin/vpnkit-userland-proxy


### PR DESCRIPTION
- simplify the `Dockerfile` by removing `make` and following the LinuxKit standard
- excluding the Dockerfiles from the build context to avoid unnecessary rebuilds
