### PR TITLE
vpnkit-userland-proxy: include the vpnkit-iptables-wrapper

### DIFF
--- a/go/Dockerfile.userland-proxy
+++ b/go/Dockerfile.userland-proxy
@@ -6,9 +6,11 @@ ENV GOPATH=/go PATH=$PATH:/go/bin
 
 COPY . /go/src/github.com/moby/vpnkit/go
 RUN go-compile.sh /go/src/github.com/moby/vpnkit/go/cmd/vpnkit-userland-proxy
+RUN go-compile.sh /go/src/github.com/moby/vpnkit/go/cmd/vpnkit-iptables-wrapper
 
 FROM scratch
 ENTRYPOINT []
 CMD []
 WORKDIR /
 COPY --from=mirror /go/bin/vpnkit-userland-proxy /usr/bin/vpnkit-userland-proxy
+COPY --from=mirror /go/bin/vpnkit-iptables-wrapper /usr/bin/vpnkit-iptables-wrapper

--- a/go/cmd/vpnkit-iptables-wrapper/README.md
+++ b/go/cmd/vpnkit-iptables-wrapper/README.md
@@ -1,6 +1,6 @@
 #### VPNKit iptables wrapper for dockerd
 
-This is an iptables wrapper that will call `vpnkit-expose-port` when a swarm port is published by `dockerd` inside the guest VM. The wrapper has to be installed as `iptables` in $PATH in a location that comes before the regular iptables. It expects regular iptables to exist in `/sbin/iptables`.
+This is an iptables wrapper that will call `vpnkit-userland-proxy` when a swarm port is published by `dockerd` inside the guest VM. The wrapper has to be installed as `iptables` in $PATH in a location that comes before the regular iptables. It expects regular iptables to exist in `/sbin/iptables`.
 
 If the file `/var/config/vpnkit/native-port-forwarding` exists and contains a `0` all requests will be passed directly to `/sbin/iptables`, disabling the wrapper.
 

--- a/go/cmd/vpnkit-iptables-wrapper/main.go
+++ b/go/cmd/vpnkit-iptables-wrapper/main.go
@@ -1,7 +1,7 @@
 package main
 
 /*
-Spawns vpnkit-expose-port instances for swarm ports by wrapping calls to iptables in the format:
+Spawns vpnkit-userland-proxy instances for swarm ports by wrapping calls to iptables in the format:
 
 --wait -t nat -I DOCKER-INGRESS -p tcp --dport 80 -j DNAT --to-destination 172.18.0.2:80
 --wait -t nat -D DOCKER-INGRESS -p tcp --dport 80 -j DNAT --to-destination 172.18.0.2:80
@@ -22,7 +22,7 @@ import (
 
 const iptablesPath = "/sbin/iptables"
 const configKey = "/var/config/vpnkit/native-port-forwarding"
-const vpnKitExposePort = "vpnkit-expose-port" // must be in PATH
+const vpnKitUserlandProxy = "vpnkit-userland-proxy" // must be in PATH
 const pidDir = "/var/run/service-port-opener"
 
 type exposedPort struct {
@@ -46,9 +46,9 @@ func pidFileName(port exposedPort) string {
 	return fmt.Sprintf("%s/%s.%s.%s.%s.pid", pidDir, port.proto, port.dport, port.ip, port.port)
 }
 
-// insert starts a vpnKitExposePort process and writes the pid to a file in pidDir
-func insert(vpnKitExposePort string, port exposedPort) error {
-	cmd := exec.Command(vpnKitExposePort, "-proto", port.proto, "-container-ip", port.ip, "-container-port", port.port, "-host-ip", "0.0.0.0", "-host-port", port.dport, "-i", "-no-local-ip")
+// insert starts a vpnKitUserlandProxy process and writes the pid to a file in pidDir
+func insert(vpnKitUserlandProxy string, port exposedPort) error {
+	cmd := exec.Command(vpnKitUserlandProxy, "-proto", port.proto, "-container-ip", port.ip, "-container-port", port.port, "-host-ip", "0.0.0.0", "-host-port", port.dport, "-i", "-no-local-ip")
 
 	if err := cmd.Start(); err != nil {
 		return err
@@ -63,7 +63,7 @@ func insert(vpnKitExposePort string, port exposedPort) error {
 	return nil
 }
 
-// remove finds the corresponding pid file in pidDir and kills the vpnKitExposePort process
+// remove finds the corresponding pid file in pidDir and kills the vpnKitUserlandProxy process
 func remove(port exposedPort) error {
 	pidFile := pidFileName(port)
 
@@ -150,7 +150,7 @@ func matchStringArray(input []string, pattern []interface{}) error {
 
 func main() {
 	var err error
-	var vpnKitExposePortPath string
+	var vpnKitUserlandProxyPath string
 	var iptables string
 
 	if iptables, err = exec.LookPath(iptablesPath); err != nil {
@@ -158,7 +158,7 @@ func main() {
 	}
 
 	if !useNativePortForwarding() {
-		if vpnKitExposePortPath, err = exec.LookPath(vpnKitExposePort); err != nil {
+		if vpnKitUserlandProxyPath, err = exec.LookPath(vpnKitUserlandProxy); err != nil {
 			log.Fatalln(err)
 		}
 
@@ -188,7 +188,7 @@ func main() {
 			case "-D":
 				remove(port)
 			case "-I":
-				insert(vpnKitExposePortPath, port)
+				insert(vpnKitUserlandProxyPath, port)
 			}
 		} else {
 			// ignore errors here, just pass to iptables


### PR DESCRIPTION
The old package used to contain both binaries and vpnkit-iptables-wrapper expects to be able to call vpnkit-userland-proxy.

Signed-off-by: David Scott <dave.scott@docker.com>