### PR TITLE
Update to new virtsock API

### DIFF
--- a/go/Gopkg.lock
+++ b/go/Gopkg.lock
@@ -214,15 +214,15 @@
   version = "v1.0.1"
 
 [[projects]]
-  branch = "10586_fixes"
-  digest = "1:afcc93a5ffcbf5a73618d5f832fbf65a7d62f63763a1b31dccddf2390a7f11e4"
+  digest = "1:baa349928d0d929a9f007afee2b1f52fdaeb0b5798864d89168ea077e26fb314"
   name = "github.com/linuxkit/virtsock"
   packages = [
     "pkg/hvsock",
     "pkg/vsock",
   ]
   pruneopts = "NUT"
-  revision = "76c5cbe7912fc569ca7d3c02ddf9974ce670f7dd"
+  revision = "4813e31717edd6d27179715ce5c919091f349892"
+  source = "github.com/djs55/virtsock"
 
 [[projects]]
   branch = "master"

--- a/go/Gopkg.toml
+++ b/go/Gopkg.toml
@@ -21,7 +21,8 @@
 
 [[constraint]]
   name = "github.com/linuxkit/virtsock"
-  branch = "10586_fixes"
+  source = "github.com/djs55/virtsock"
+  revision = "4813e31717edd6d27179715ce5c919091f349892"
 
 [[constraint]]
   name = "github.com/docker/go-p9p"

--- a/go/cmd/vpnkit-forwarder/main.go
+++ b/go/cmd/vpnkit-forwarder/main.go
@@ -43,7 +43,7 @@ func main() {
 func hyperVListener(port int) net.Listener {
 	serviceID := fmt.Sprintf("%08x-FACB-11E6-BD58-64006A7986D3", port)
 	svcid, _ := hvsock.GUIDFromString(serviceID)
-	l, err := hvsock.Listen(hvsock.HypervAddr{VMID: hvsock.GUIDWildcard, ServiceID: svcid})
+	l, err := hvsock.Listen(hvsock.Addr{VMID: hvsock.GUIDWildcard, ServiceID: svcid})
 	if err != nil {
 		log.Fatalf("Failed to bind AF_HVSOCK guid: %s: %v", serviceID, err)
 	}

--- a/go/pkg/vpnkit/dialer_windows.go
+++ b/go/pkg/vpnkit/dialer_windows.go
@@ -25,7 +25,7 @@ func (d *Dialer) connectTransport() (io.ReadWriteCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	addr := hvsock.HypervAddr{
+	addr := hvsock.Addr{
 		VMID:      vmid,
 		ServiceID: svc,
 	}

--- a/go/vendor/github.com/linuxkit/virtsock/pkg/hvsock/hvsock.go
+++ b/go/vendor/github.com/linuxkit/virtsock/pkg/hvsock/hvsock.go
@@ -67,16 +67,16 @@ func GUIDFromString(s string) (GUID, error) {
 	return g, err
 }
 
-// HypervAddr combined "address" and "port" structure
-type HypervAddr struct {
+// Addr combined "address" and "port" structure
+type Addr struct {
 	VMID      GUID
 	ServiceID GUID
 }
 
 // Network returns the type of network for Hyper-V sockets
-func (a HypervAddr) Network() string { return "hvsock" }
+func (a Addr) Network() string { return "hvsock" }
 
-func (a HypervAddr) String() string {
+func (a Addr) String() string {
 	vmid := a.VMID.String()
 	svc := a.ServiceID.String()
 
@@ -102,7 +102,7 @@ var (
 )
 
 // Dial a Hyper-V socket address
-func Dial(raddr HypervAddr) (Conn, error) {
+func Dial(raddr Addr) (Conn, error) {
 	fd, err := hvsocket(syscall.SOCK_STREAM, sysSHV_PROTO_RAW)
 	if err != nil {
 		return nil, err
@@ -113,7 +113,7 @@ func Dial(raddr HypervAddr) (Conn, error) {
 		return nil, err
 	}
 
-	v, err := newHVsockConn(fd, HypervAddr{VMID: GUIDZero, ServiceID: GUIDZero}, raddr)
+	v, err := newHVsockConn(fd, Addr{VMID: GUIDZero, ServiceID: GUIDZero}, raddr)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func Dial(raddr HypervAddr) (Conn, error) {
 }
 
 // Listen on a Hyper-V socket address
-func Listen(addr HypervAddr) (net.Listener, error) {
+func Listen(addr Addr) (net.Listener, error) {
 
 	acceptFD, err := hvsocket(syscall.SOCK_STREAM, sysSHV_PROTO_RAW)
 	if err != nil {
@@ -156,7 +156,7 @@ type Conn interface {
 }
 
 func (v *hvsockListener) Accept() (net.Conn, error) {
-	var raddr HypervAddr
+	var raddr Addr
 	fd, err := accept(v.acceptFD, &raddr)
 	if err != nil {
 		return nil, err
@@ -176,7 +176,7 @@ func (v *hvsockListener) Close() error {
 }
 
 func (v *hvsockListener) Addr() net.Addr {
-	return HypervAddr{VMID: v.laddr.VMID, ServiceID: v.laddr.ServiceID}
+	return Addr{VMID: v.laddr.VMID, ServiceID: v.laddr.ServiceID}
 }
 
 /*

--- a/go/vendor/github.com/linuxkit/virtsock/pkg/hvsock/hvsock_fallback.go
+++ b/go/vendor/github.com/linuxkit/virtsock/pkg/hvsock/hvsock_fallback.go
@@ -14,7 +14,7 @@ const (
 
 type hvsockListener struct {
 	acceptFD int
-	laddr    HypervAddr
+	laddr    Addr
 }
 
 //
@@ -24,25 +24,25 @@ func hvsocket(typ, proto int) (int, error) {
 	return 0, errors.New("hvsocket() not implemented")
 }
 
-func connect(s int, a *HypervAddr) (err error) {
+func connect(s int, a *Addr) (err error) {
 	return errors.New("connect() not implemented")
 }
 
-func bind(s int, a HypervAddr) error {
+func bind(s int, a Addr) error {
 	return errors.New("bind() not implemented")
 }
 
-func accept(s int, a *HypervAddr) (int, error) {
+func accept(s int, a *Addr) (int, error) {
 	return 0, errors.New("accept() not implemented")
 }
 
 type hvsockConn struct {
 	fd     int
-	local  HypervAddr
-	remote HypervAddr
+	local  Addr
+	remote Addr
 }
 
-func newHVsockConn(fd int, local HypervAddr, remote HypervAddr) (*HVsockConn, error) {
+func newHVsockConn(fd int, local Addr, remote Addr) (*HVsockConn, error) {
 	v := &hvsockConn{local: local, remote: remote}
 	return &HVsockConn{hvsockConn: *v}, errors.New("newHVsockConn() not implemented")
 }

--- a/go/vendor/github.com/linuxkit/virtsock/pkg/hvsock/hvsock_linux.go
+++ b/go/vendor/github.com/linuxkit/virtsock/pkg/hvsock/hvsock_linux.go
@@ -79,7 +79,7 @@ const (
 
 type hvsockListener struct {
 	acceptFD int
-	laddr    HypervAddr
+	laddr    Addr
 }
 
 // Try to determine if we need to run in legacy mode.
@@ -105,7 +105,7 @@ func hvsocket(typ, proto int) (int, error) {
 	return syscall.Socket(sysAF_VSOCK, typ, 0)
 }
 
-func connect(s int, a *HypervAddr) (err error) {
+func connect(s int, a *Addr) (err error) {
 	if legacyMode {
 		sa := C.struct_sockaddr_hv{}
 		sa.shv_family = sysAF_HYPERV
@@ -140,7 +140,7 @@ func connect(s int, a *HypervAddr) (err error) {
 	return nil
 }
 
-func bind(s int, a HypervAddr) error {
+func bind(s int, a Addr) error {
 	if legacyMode {
 		sa := C.struct_sockaddr_hv{}
 		sa.shv_family = sysAF_HYPERV
@@ -175,7 +175,7 @@ func bind(s int, a HypervAddr) error {
 	return nil
 }
 
-func accept(s int, a *HypervAddr) (int, error) {
+func accept(s int, a *Addr) (int, error) {
 	if legacyMode {
 		var acceptSA C.struct_sockaddr_hv
 		var acceptSALen C.socklen_t
@@ -216,12 +216,12 @@ func accept(s int, a *HypervAddr) (int, error) {
 type hvsockConn struct {
 	fd     int
 	hvsock *os.File
-	local  HypervAddr
-	remote HypervAddr
+	local  Addr
+	remote Addr
 }
 
 // Main constructor
-func newHVsockConn(fd int, local HypervAddr, remote HypervAddr) (*HVsockConn, error) {
+func newHVsockConn(fd int, local Addr, remote Addr) (*HVsockConn, error) {
 	hvsock := os.NewFile(uintptr(fd), fmt.Sprintf("hvsock:%d", fd))
 	v := &hvsockConn{fd: fd, hvsock: hvsock, local: local, remote: remote}
 

--- a/go/vendor/github.com/linuxkit/virtsock/pkg/hvsock/hvsock_windows.go
+++ b/go/vendor/github.com/linuxkit/virtsock/pkg/hvsock/hvsock_windows.go
@@ -1,7 +1,6 @@
 package hvsock
 
 import (
-	"errors"
 	"io"
 	"log"
 	"runtime"
@@ -43,14 +42,14 @@ type rawSockaddrHyperv struct {
 
 type hvsockListener struct {
 	acceptFD syscall.Handle
-	laddr    HypervAddr
+	laddr    Addr
 }
 
 // Internal representation. Complex mostly due to asynch send()/recv() syscalls.
 type hvsockConn struct {
 	fd     syscall.Handle
-	local  HypervAddr
-	remote HypervAddr
+	local  Addr
+	remote Addr
 
 	wg            sync.WaitGroup
 	closing       bool
@@ -67,7 +66,7 @@ type deadlineHandler struct {
 }
 
 // Main constructor
-func newHVsockConn(h syscall.Handle, local HypervAddr, remote HypervAddr) (*HVsockConn, error) {
+func newHVsockConn(h syscall.Handle, local Addr, remote Addr) (*HVsockConn, error) {
 	ioInitOnce.Do(initIo)
 	v := &hvsockConn{fd: h, local: local, remote: remote}
 
@@ -87,7 +86,7 @@ func newHVsockConn(h syscall.Handle, local HypervAddr, remote HypervAddr) (*HVso
 }
 
 // Utility function to build a struct sockaddr for syscalls.
-func (a HypervAddr) sockaddr(sa *rawSockaddrHyperv) (unsafe.Pointer, int32, error) {
+func (a Addr) sockaddr(sa *rawSockaddrHyperv) (unsafe.Pointer, int32, error) {
 	sa.Family = sysAF_HYPERV
 	sa.Reserved = 0
 	for i := 0; i < len(sa.VMID); i++ {
@@ -104,7 +103,7 @@ func hvsocket(typ, proto int) (syscall.Handle, error) {
 	return syscall.Socket(sysAF_HYPERV, typ, proto)
 }
 
-func connect(s syscall.Handle, a *HypervAddr) (err error) {
+func connect(s syscall.Handle, a *Addr) (err error) {
 	var sa rawSockaddrHyperv
 	ptr, n, err := a.sockaddr(&sa)
 	if err != nil {
@@ -114,7 +113,7 @@ func connect(s syscall.Handle, a *HypervAddr) (err error) {
 	return sys_connect(s, ptr, n)
 }
 
-func bind(s syscall.Handle, a HypervAddr) error {
+func bind(s syscall.Handle, a Addr) error {
 	var sa rawSockaddrHyperv
 	ptr, n, err := a.sockaddr(&sa)
 	if err != nil {
@@ -124,8 +123,23 @@ func bind(s syscall.Handle, a HypervAddr) error {
 	return sys_bind(s, ptr, n)
 }
 
-func accept(s syscall.Handle, a *HypervAddr) (syscall.Handle, error) {
-	return 0, errors.New("accept(): Unimplemented")
+func accept(s syscall.Handle, a *Addr) (syscall.Handle, error) {
+	var sa rawSockaddrHyperv
+	var n = int32(unsafe.Sizeof(sa))
+	fd, err := sys_accept(s, &sa, &n)
+	if err != nil {
+		return fd, err
+	}
+
+	// Extract a Addr from sa
+	raddr := Addr{}
+	for i := 0; i < len(raddr.VMID); i++ {
+		a.VMID[i] = sa.VMID[i]
+	}
+	for i := 0; i < len(raddr.ServiceID); i++ {
+		a.ServiceID[i] = sa.ServiceID[i]
+	}
+	return fd, err
 }
 
 //

--- a/go/vendor/github.com/linuxkit/virtsock/pkg/hvsock/zsyscall_windows.go
+++ b/go/vendor/github.com/linuxkit/virtsock/pkg/hvsock/zsyscall_windows.go
@@ -37,8 +37,10 @@ var (
 	modwinmm    = syscall.NewLazyDLL("winmm.dll")
 	modkernel32 = syscall.NewLazyDLL("kernel32.dll")
 
-	procConnect                            = modws2_32.NewProc("connect")
-	procbind                               = modws2_32.NewProc("bind")
+	procConnect = modws2_32.NewProc("connect")
+	procbind    = modws2_32.NewProc("bind")
+	procAccept  = modws2_32.NewProc("accept")
+
 	procCancelIoEx                         = modkernel32.NewProc("CancelIoEx")
 	procCreateIoCompletionPort             = modkernel32.NewProc("CreateIoCompletionPort")
 	procGetQueuedCompletionStatus          = modkernel32.NewProc("GetQueuedCompletionStatus")
@@ -50,6 +52,7 @@ var (
 // Errno values.
 const (
 	errnoERROR_IO_PENDING = 997
+	socketError           = uintptr(^uint32(0))
 )
 
 var (
@@ -87,6 +90,19 @@ func sys_connect(s syscall.Handle, name unsafe.Pointer, namelen int32) (err erro
 func sys_bind(s syscall.Handle, name unsafe.Pointer, namelen int32) (err error) {
 	r1, _, e1 := syscall.Syscall(procbind.Addr(), 3, uintptr(s), uintptr(name), uintptr(namelen))
 	if r1 == socket_error {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func sys_accept(s syscall.Handle, rsa *rawSockaddrHyperv, addrlen *int32) (handle syscall.Handle, err error) {
+	r1, _, e1 := syscall.Syscall(procAccept.Addr(), 3, uintptr(s), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)))
+	handle = syscall.Handle(r1)
+	if r1 == socketError {
 		if e1 != 0 {
 			err = errnoErr(e1)
 		} else {


### PR DESCRIPTION
The upstream linuxkit/virtsock API is different from that in the `10586_fixes` branch that we're using.

This PR uses a backport of the new API onto the old branch. This is useful since we're still using the old kernel in Desktop.