### PR TITLE
go: allow the Security Descriptors of forwarded Windows named pipes to be set

### DIFF
--- a/go/pkg/vpnkit/control/control.go
+++ b/go/pkg/vpnkit/control/control.go
@@ -15,6 +15,7 @@ import (
 )
 
 type Control struct {
+	Forwarder forward.Maker // Forwarder makes local port forwards
 	mux       libproxy.Multiplexer
 	muxM      *sync.Mutex
 	muxC      *sync.Cond
@@ -68,7 +69,7 @@ func (c *Control) Expose(_ context.Context, port *vpnkit.Port) error {
 	if _, ok := c.forwards[key]; ok {
 		return errors.New("port already exposed: " + port.String())
 	}
-	forward, err := forward.Make(c, *port)
+	forward, err := c.Forwarder.Make(c, *port)
 	if err != nil {
 		// This error (e.g. EADDRINUSE) is special and we want to show it to the user
 		return &vpnkit.ExposeError{

--- a/go/pkg/vpnkit/forward/forward_test.go
+++ b/go/pkg/vpnkit/forward/forward_test.go
@@ -42,7 +42,8 @@ func (m *mockMux) DumpState(_ io.Writer) {
 }
 
 type mockControl struct {
-	mux libproxy.Multiplexer
+	mux       libproxy.Multiplexer
+	Forwarder Maker
 }
 
 func (m *mockControl) Mux() libproxy.Multiplexer {
@@ -99,7 +100,7 @@ func TestTCP(t *testing.T) {
 		InPort:  inPort,
 		Proto:   vpnkit.TCP,
 	}
-	f, err := Make(ctrl, port)
+	f, err := ctrl.Forwarder.Make(ctrl, port)
 	assert.Nil(t, err)
 	f.Stop()
 }
@@ -122,7 +123,7 @@ func TestUDP(t *testing.T) {
 		InPort:  inPort,
 		Proto:   vpnkit.UDP,
 	}
-	f, err := Make(ctrl, port)
+	f, err := ctrl.Forwarder.Make(ctrl, port)
 	assert.Nil(t, err)
 	go f.Run()
 	f.Stop()
@@ -148,7 +149,7 @@ func TestUnixForward(t *testing.T) {
 		InPath:  inPath,
 		Proto:   vpnkit.Unix,
 	}
-	f, err := Make(ctrl, port)
+	f, err := ctrl.Forwarder.Make(ctrl, port)
 	assert.Nil(t, err)
 	a, err := net.Dial("unix", outPath)
 	assert.Nil(t, err)
@@ -178,7 +179,7 @@ func TestUnixForwardAlreadyExists(t *testing.T) {
 		InPath:  inPath,
 		Proto:   vpnkit.Unix,
 	}
-	_, err = Make(ctrl, port)
+	_, err = ctrl.Forwarder.Make(ctrl, port)
 	assert.NotNil(t, err)
 }
 
@@ -200,7 +201,7 @@ func TestUnixForwardAlreadyExists2(t *testing.T) {
 		InPath:  inPath,
 		Proto:   vpnkit.Unix,
 	}
-	f, err := Make(ctrl, port)
+	f, err := ctrl.Forwarder.Make(ctrl, port)
 	assert.Nil(t, err)
 	a, err := net.Dial("unix", outPath)
 	assert.Nil(t, err)
@@ -228,7 +229,7 @@ func TestUnixForwardDirNotExist(t *testing.T) {
 		InPath:  inPath,
 		Proto:   vpnkit.Unix,
 	}
-	f, err := Make(ctrl, port)
+	f, err := ctrl.Forwarder.Make(ctrl, port)
 	assert.Nil(t, err)
 	a, err := net.Dial("unix", outPath)
 	assert.Nil(t, err)
@@ -253,9 +254,9 @@ func TestAddressInUse(t *testing.T) {
 		InPort:  inPort,
 		Proto:   vpnkit.TCP,
 	}
-	f1, err := Make(ctrl, port)
+	f1, err := ctrl.Forwarder.Make(ctrl, port)
 	assert.Nil(t, err)
-	f2, err := Make(ctrl, port)
+	f2, err := ctrl.Forwarder.Make(ctrl, port)
 	if !strings.HasSuffix(err.Error(), "bind: address already in use") {
 		t.Errorf("expected an address-already-in-use type of error: %v", err)
 	}
@@ -273,7 +274,7 @@ func TestInterfaceDoesNotExist(t *testing.T) {
 		InPort:  inPort,
 		Proto:   vpnkit.TCP,
 	}
-	f, err := Make(ctrl, port)
+	f, err := ctrl.Forwarder.Make(ctrl, port)
 	if !strings.HasSuffix(err.Error(), "assign requested address") {
 		t.Errorf("expected an no-such-address type of error: %v", err)
 	}

--- a/go/pkg/vpnkit/forward/tcp.go
+++ b/go/pkg/vpnkit/forward/tcp.go
@@ -9,22 +9,23 @@ import (
 
 // Listen on TCP sockets and forward to a remote multiplexer.
 
-type tcpNetwork struct{}
+// TCPNetwork specifies common parameters for TCP-based port forwards.
+type TCPNetwork struct{}
 
-func (t *tcpNetwork) listen(port vpnkit.Port) (listener, error) {
+func (t TCPNetwork) listen(port vpnkit.Port) (listener, error) {
 	l, err := listenTCP(port)
 	if err != nil {
 		return nil, err
 	}
 	wrapped := &tcpListener{
-		l : l,
+		l:    l,
 		port: port,
 	}
 	return wrapped, nil
 }
 
 type tcpListener struct {
-	l *net.TCPListener
+	l    *net.TCPListener
 	port vpnkit.Port
 }
 
@@ -36,6 +37,6 @@ func (l *tcpListener) close() error {
 	return closeTCP(l.port, l.l)
 }
 
-func makeTCP(c common) (Forward, error) {
-	return makeStream(c, &tcpNetwork{})
+func makeTCP(c common, n TCPNetwork) (Forward, error) {
+	return makeStream(c, n)
 }

--- a/go/pkg/vpnkit/forward/unix_unix.go
+++ b/go/pkg/vpnkit/forward/unix_unix.go
@@ -3,18 +3,20 @@
 package forward
 
 import (
-	"github.com/moby/vpnkit/go/pkg/libproxy"
-	"github.com/moby/vpnkit/go/pkg/vpnkit"
-	"github.com/pkg/errors"
 	"net"
 	"os"
 	"path/filepath"
 	"syscall"
+
+	"github.com/moby/vpnkit/go/pkg/libproxy"
+	"github.com/moby/vpnkit/go/pkg/vpnkit"
+	"github.com/pkg/errors"
 )
 
-type unixNetwork struct{}
+// UnixNetwork specifies common parameters for Unix domain socket forwards.
+type UnixNetwork struct{}
 
-func (t *unixNetwork) listen(port vpnkit.Port) (listener, error) {
+func (t UnixNetwork) listen(port vpnkit.Port) (listener, error) {
 	if err := removeExistingSocket(port.OutPath); err != nil {
 		return nil, err
 	}
@@ -44,8 +46,8 @@ func (l unixListener) close() error {
 	return l.l.Close()
 }
 
-func makeUnix(c common) (Forward, error) {
-	return makeStream(c, &unixNetwork{})
+func makeUnix(c common, n UnixNetwork) (Forward, error) {
+	return makeStream(c, n)
 }
 
 func removeExistingSocket(path string) error {

--- a/go/pkg/vpnkit/forward/unix_windows.go
+++ b/go/pkg/vpnkit/forward/unix_windows.go
@@ -10,13 +10,16 @@ import (
 )
 
 // UnixNetwork specifies common parameters for Windows named pipe forwards.
-type UnixNetwork struct{}
+type UnixNetwork struct {
+	SecurityDescriptor string // SecurityDescriptor will apply to all the pipes.
+}
 
 func (t UnixNetwork) listen(port vpnkit.Port) (listener, error) {
 	l, err := winio.ListenPipe(port.OutPath, &winio.PipeConfig{
-		MessageMode:      true,  // Use message mode so that CloseWrite() is supported
-		InputBufferSize:  65536, // Use 64KB buffers to improve performance
-		OutputBufferSize: 65536,
+		SecurityDescriptor: t.SecurityDescriptor,
+		MessageMode:        true,  // Use message mode so that CloseWrite() is supported
+		InputBufferSize:    65536, // Use 64KB buffers to improve performance
+		OutputBufferSize:   65536,
 	})
 	if err != nil {
 		return nil, err

--- a/go/pkg/vpnkit/forward/unix_windows.go
+++ b/go/pkg/vpnkit/forward/unix_windows.go
@@ -9,9 +9,10 @@ import (
 	"github.com/moby/vpnkit/go/pkg/vpnkit"
 )
 
-type unixNetwork struct{}
+// UnixNetwork specifies common parameters for Windows named pipe forwards.
+type UnixNetwork struct{}
 
-func (t *unixNetwork) listen(port vpnkit.Port) (listener, error) {
+func (t UnixNetwork) listen(port vpnkit.Port) (listener, error) {
 	l, err := winio.ListenPipe(port.OutPath, &winio.PipeConfig{
 		MessageMode:      true,  // Use message mode so that CloseWrite() is supported
 		InputBufferSize:  65536, // Use 64KB buffers to improve performance
@@ -44,6 +45,6 @@ func (l unixListener) close() error {
 	return l.l.Close()
 }
 
-func makeUnix(c common) (Forward, error) {
-	return makeStream(c, &unixNetwork{})
+func makeUnix(c common, n UnixNetwork) (Forward, error) {
+	return makeStream(c, n)
 }


### PR DESCRIPTION
A caller can now set
```
controller.Forwarder.Unix.SecurityDescriptor = "<some incomprehensible SDDL string>"
```
