### PR TITLE
Go: improve the logging

### DIFF
--- a/go/pkg/libproxy/expose_port.go
+++ b/go/pkg/libproxy/expose_port.go
@@ -3,7 +3,6 @@ package libproxy
 import (
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"os"
 	"strings"

--- a/go/pkg/libproxy/forward.go
+++ b/go/pkg/libproxy/forward.go
@@ -2,7 +2,6 @@ package libproxy
 
 import (
 	"fmt"
-	"log"
 	"net"
 )
 

--- a/go/pkg/libproxy/log.go
+++ b/go/pkg/libproxy/log.go
@@ -1,0 +1,12 @@
+package libproxy
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+var log = logrus.New()
+
+// SetLogger sets a new default logger
+func SetLogger(l *logrus.Logger) {
+	log = l
+}

--- a/go/pkg/libproxy/multiplexed.go
+++ b/go/pkg/libproxy/multiplexed.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"sync"
 	"time"

--- a/go/pkg/libproxy/multiplexed_test.go
+++ b/go/pkg/libproxy/multiplexed_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha1"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"sync"
 	"testing"

--- a/go/pkg/libproxy/network_proxy_test.go
+++ b/go/pkg/libproxy/network_proxy_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"os"
 	"strings"

--- a/go/pkg/libproxy/proxy.go
+++ b/go/pkg/libproxy/proxy.go
@@ -4,7 +4,6 @@ package libproxy
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"os"
 	"syscall"

--- a/go/pkg/libproxy/stream_proxy.go
+++ b/go/pkg/libproxy/stream_proxy.go
@@ -2,7 +2,6 @@ package libproxy
 
 import (
 	"io"
-	"log"
 	"net"
 	"strings"
 )

--- a/go/pkg/libproxy/stream_proxy.go
+++ b/go/pkg/libproxy/stream_proxy.go
@@ -22,7 +22,7 @@ func ProxyStream(client, backend Conn, quit <-chan struct{}) error {
 			log.Println("error copying:", err)
 		}
 		err = to.CloseWrite()
-		if err != nil {
+		if err != nil && !errIsNotConnected(err) {
 			log.Println("error CloseWrite to:", err)
 		}
 		event <- written

--- a/go/pkg/libproxy/stream_proxy.go
+++ b/go/pkg/libproxy/stream_proxy.go
@@ -17,7 +17,7 @@ func ProxyStream(client, backend Conn, quit <-chan struct{}) error {
 	event := make(chan int64)
 	var broker = func(to, from Conn) {
 		written, err := io.Copy(to, from)
-		if err != nil {
+		if err != nil && err != io.EOF {
 			log.Println("error copying:", err)
 		}
 		err = to.CloseWrite()

--- a/go/pkg/libproxy/tcp_proxy.go
+++ b/go/pkg/libproxy/tcp_proxy.go
@@ -2,7 +2,6 @@ package libproxy
 
 import (
 	"fmt"
-	"log"
 	"net"
 )
 

--- a/go/pkg/libproxy/udp_proxy.go
+++ b/go/pkg/libproxy/udp_proxy.go
@@ -2,7 +2,6 @@ package libproxy
 
 import (
 	"encoding/binary"
-	"log"
 	"net"
 	"strings"
 	"sync"

--- a/go/pkg/libproxy/unix_proxy.go
+++ b/go/pkg/libproxy/unix_proxy.go
@@ -3,6 +3,7 @@ package libproxy
 import (
 	"fmt"
 	"net"
+	"time"
 )
 
 // UnixProxy is a proxy for Unix connections. It implements the Proxy interface to
@@ -25,14 +26,23 @@ func NewUnixProxy(listener net.Listener, backendAddr *net.UnixAddr) (*UnixProxy,
 
 // HandleUnixConnection forwards the Unix traffic to a specified backend address
 func HandleUnixConnection(client Conn, backendAddr *net.UnixAddr, quit <-chan struct{}) error {
-	backend, err := net.DialUnix("unix", nil, backendAddr)
-	if err != nil {
-		if errIsConnectionRefused(err) {
-			return err
+	start := time.Now()
+	for {
+		backend, err := net.DialUnix("unix", nil, backendAddr)
+		if err != nil {
+			if errIsConnectionRefused(err) {
+				if time.Since(start) > 120*time.Second {
+					log.Errorf("failed to connect to %s after 120s. The server appears to be down.", backendAddr.String())
+					return err
+				}
+				log.Infof("%s appears to not be started yet: will retry in 5s", backendAddr.String())
+				time.Sleep(5 * time.Second)
+				continue
+			}
+			return fmt.Errorf("can't forward traffic to backend unix/%v: %s", backendAddr, err)
 		}
-		return fmt.Errorf("can't forward traffic to backend unix/%v: %s", backendAddr, err)
+		return ProxyStream(client, backend, quit)
 	}
-	return ProxyStream(client, backend, quit)
 }
 
 // Run starts forwarding the traffic using Unix.

--- a/go/pkg/libproxy/unix_proxy.go
+++ b/go/pkg/libproxy/unix_proxy.go
@@ -2,7 +2,6 @@ package libproxy
 
 import (
 	"fmt"
-	"log"
 	"net"
 )
 

--- a/go/pkg/vpnkit/control/control.go
+++ b/go/pkg/vpnkit/control/control.go
@@ -159,6 +159,7 @@ func (c *Control) handleDataConn(rw io.ReadWriteCloser, quit <-chan struct{}) {
 	mux := libproxy.NewMultiplexer("local", rw)
 	mux.Run()
 	c.SetMux(mux)
+	defer c.SetMux(nil)
 	for {
 		conn, destination, err := mux.Accept()
 		if err != nil {

--- a/go/pkg/vpnkit/control/control.go
+++ b/go/pkg/vpnkit/control/control.go
@@ -77,7 +77,6 @@ func (c *Control) Expose(_ context.Context, port *vpnkit.Port) error {
 		}
 	}
 	c.forwards[key] = forward
-	log.Printf("adding port-forward %s\n", port.String())
 	go forward.Run()
 	return nil
 }
@@ -94,7 +93,6 @@ func (c *Control) Unexpose(_ context.Context, port *vpnkit.Port) error {
 		// make it idempotent
 		return nil
 	}
-	log.Printf("stopping port-forward %s\n", port.String())
 	forward.Stop()
 	delete(c.forwards, key)
 	return nil

--- a/go/pkg/vpnkit/control/control.go
+++ b/go/pkg/vpnkit/control/control.go
@@ -162,7 +162,7 @@ func (c *Control) handleDataConn(rw io.ReadWriteCloser, quit <-chan struct{}) {
 	for {
 		conn, destination, err := mux.Accept()
 		if err != nil {
-			log.Printf("Error accepting subconnection: %v", err)
+			log.Errorf("error accepting subconnection: %v", err)
 			return
 		}
 		go libproxy.Forward(conn, *destination, quit)

--- a/go/pkg/vpnkit/control/control.go
+++ b/go/pkg/vpnkit/control/control.go
@@ -3,13 +3,13 @@ package control
 import (
 	"context"
 	"io"
-	"log"
 	"sync"
 	"time"
 
 	"github.com/moby/vpnkit/go/pkg/libproxy"
 	"github.com/moby/vpnkit/go/pkg/vpnkit"
 	"github.com/moby/vpnkit/go/pkg/vpnkit/forward"
+	"github.com/moby/vpnkit/go/pkg/vpnkit/log"
 	"github.com/moby/vpnkit/go/pkg/vpnkit/transport"
 	"github.com/pkg/errors"
 )

--- a/go/pkg/vpnkit/control/control.go
+++ b/go/pkg/vpnkit/control/control.go
@@ -39,7 +39,7 @@ func Make() *Control {
 func (c *Control) SetMux(m libproxy.Multiplexer) {
 	c.muxM.Lock()
 	defer c.muxM.Unlock()
-	log.Println("ready to forward incoming data connections")
+	log.Println("established connection to vpnkit-forwarder")
 	c.mux = m
 	c.muxC.Broadcast()
 }

--- a/go/pkg/vpnkit/forward/forward.go
+++ b/go/pkg/vpnkit/forward/forward.go
@@ -4,10 +4,10 @@ package forward
 
 import (
 	"errors"
-	"log"
 
 	"github.com/moby/vpnkit/go/pkg/libproxy"
 	"github.com/moby/vpnkit/go/pkg/vpnkit"
+	"github.com/moby/vpnkit/go/pkg/vpnkit/log"
 )
 
 // Forward listens for incoming connections from the "outside" and forwards them to a remote.

--- a/go/pkg/vpnkit/forward/forward.go
+++ b/go/pkg/vpnkit/forward/forward.go
@@ -25,7 +25,7 @@ type Maker struct {
 
 // Make a Forward from a Port description.
 func (f Maker) Make(ctrl vpnkit.Control, port vpnkit.Port) (Forward, error) {
-	log.Printf("Adding %s", port.String())
+	log.Printf("adding %s", port.String())
 	dest := &libproxy.Destination{
 		IP:   port.InIP,
 		Port: port.InPort,

--- a/go/pkg/vpnkit/forward/stream.go
+++ b/go/pkg/vpnkit/forward/stream.go
@@ -63,7 +63,7 @@ func (s *stream) Run() {
 }
 
 func (s *stream) Stop() {
-	log.Printf("Removing %s", s.port.String())
+	log.Printf("removing %s", s.port.String())
 	s.l.close()
 	close(s.quit)
 }

--- a/go/pkg/vpnkit/forward/stream.go
+++ b/go/pkg/vpnkit/forward/stream.go
@@ -38,24 +38,24 @@ func (s *stream) Run() {
 	for {
 		src, err := s.l.accept()
 		if err != nil {
-			log.Printf("Stopping accepting connections on %s", s.port.String())
+			log.Printf("stopping accepting connections on %s", s.port.String())
 			return
 		}
 		mux := s.ctrl.Mux()
 		dest, err := mux.Dial(*s.dest)
 		if err != nil {
-			log.Printf("unable to connect on %s: %s", s.port.String(), err)
+			log.Errorf("unable to connect on %s: %s", s.port.String(), err)
 			if err := src.Close(); err != nil {
-				log.Printf("unable to Close on %s: %s", s.port.String(), err)
+				log.Errorf("unable to Close on %s: %s", s.port.String(), err)
 			}
 			continue // Multiplexer could be disconnected
 		}
 		go func() {
 			if err := libproxy.ProxyStream(src, dest, s.quit); err != nil {
-				log.Printf("unable to proxy on %s: %s", s.port.String(), err)
+				log.Errorf("unable to proxy on %s: %s", s.port.String(), err)
 			}
 			if err := src.Close(); err != nil {
-				log.Printf("unable to Close on %s: %s", s.port.String(), err)
+				log.Errorf("unable to Close on %s: %s", s.port.String(), err)
 			}
 		}()
 

--- a/go/pkg/vpnkit/forward/stream.go
+++ b/go/pkg/vpnkit/forward/stream.go
@@ -1,10 +1,9 @@
 package forward
 
 import (
-	"log"
-
 	"github.com/moby/vpnkit/go/pkg/libproxy"
 	"github.com/moby/vpnkit/go/pkg/vpnkit"
+	"github.com/moby/vpnkit/go/pkg/vpnkit/log"
 )
 
 // Listen on stream sockets and forward to a remote multiplexer.

--- a/go/pkg/vpnkit/forward/udp.go
+++ b/go/pkg/vpnkit/forward/udp.go
@@ -2,11 +2,11 @@ package forward
 
 import (
 	"fmt"
-	"log"
 	"net"
 
 	"github.com/moby/vpnkit/go/pkg/libproxy"
 	"github.com/moby/vpnkit/go/pkg/vpnkit"
+	"github.com/moby/vpnkit/go/pkg/vpnkit/log"
 	"github.com/pkg/errors"
 )
 

--- a/go/pkg/vpnkit/forward/udp.go
+++ b/go/pkg/vpnkit/forward/udp.go
@@ -72,7 +72,7 @@ func (u *udpDialer) Dial(a *net.UDPAddr) (net.Conn, error) {
 }
 
 func (u *udp) Stop() {
-	log.Printf("Removing %s", u.port.String())
+	log.Printf("removing %s", u.port.String())
 	close(u.quit)
 	if u.inside != nil {
 		// only if Run() has been called

--- a/go/pkg/vpnkit/http.go
+++ b/go/pkg/vpnkit/http.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/labstack/echo"
-	"github.com/labstack/echo/middleware"
 	"github.com/moby/vpnkit/go/pkg/vpnkit/transport"
 )
 
@@ -49,6 +48,8 @@ type Server interface {
 	UnexposePort(echo.Context) error
 	UnexposePipe(echo.Context) error
 	DumpState(echo.Context) error
+
+	Echo() *echo.Echo
 }
 
 // Implementation of the control interface.
@@ -75,7 +76,6 @@ func NewServer(path string, impl Implementation) (Server, error) {
 	e := echo.New()
 	e.HideBanner = true
 	e.Listener = l
-	e.Use(middleware.Logger())
 	h := &httpServer{
 		e,
 		impl,
@@ -106,6 +106,11 @@ func NewServer(path string, impl Implementation) (Server, error) {
 type httpServer struct {
 	e    *echo.Echo
 	impl Implementation
+}
+
+// Echo returns the server so logging can be customised.
+func (h *httpServer) Echo() *echo.Echo {
+	return h.e
 }
 
 // List ports HTTP handler

--- a/go/pkg/vpnkit/log/log.go
+++ b/go/pkg/vpnkit/log/log.go
@@ -1,0 +1,24 @@
+package log
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+var log = logrus.New()
+
+// SetLogger sets a new default logger
+func SetLogger(l *logrus.Logger) {
+	log = l
+}
+
+func Fatalf(format string, args ...interface{}) {
+	log.Fatalf(format, args...)
+}
+
+func Printf(format string, args ...interface{}) {
+	log.Printf(format, args...)
+}
+
+func Println(s string) {
+	log.Println(s)
+}

--- a/go/pkg/vpnkit/log/log.go
+++ b/go/pkg/vpnkit/log/log.go
@@ -19,6 +19,10 @@ func Printf(format string, args ...interface{}) {
 	log.Printf(format, args...)
 }
 
+func Errorf(format string, args ...interface{}) {
+	log.Errorf(format, args...)
+}
+
 func Println(s string) {
 	log.Println(s)
 }

--- a/go/pkg/vpnkit/port.go
+++ b/go/pkg/vpnkit/port.go
@@ -6,10 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"strconv"
 	"strings"
+
+	"github.com/moby/vpnkit/go/pkg/vpnkit/log"
 
 	p9p "github.com/docker/go-p9p"
 	datakit "github.com/moby/datakit/api/go-datakit"

--- a/go/pkg/vpnkit/transport/vsock.go
+++ b/go/pkg/vpnkit/transport/vsock.go
@@ -3,12 +3,13 @@ package transport
 import (
 	"context"
 	"fmt"
-	"log"
 	"net"
 	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
+
+	"github.com/moby/vpnkit/go/pkg/vpnkit/log"
 
 	"github.com/linuxkit/virtsock/pkg/hvsock"
 	"github.com/linuxkit/virtsock/pkg/vsock"


### PR DESCRIPTION
- add `logrus`
- use `Errorf` where appropriate
- don't log "expected" errors around closing
- attempt to hide transient Unix domain socket errors by retrying for up to 120s, assuming that these are forwards to internal services (Unix domain socket forwarding is not used by Docker)