### PR TITLE
go: fix binding of privileged UDP ports via vmnetd

### DIFF
--- a/go/pkg/vpnkit/forward/tcp.go
+++ b/go/pkg/vpnkit/forward/tcp.go
@@ -13,20 +13,22 @@ import (
 type TCPNetwork struct{}
 
 func (t TCPNetwork) listen(port vpnkit.Port) (listener, error) {
-	l, err := listenTCP(port)
+	l, vmnetd, err := listenTCP(port)
 	if err != nil {
 		return nil, err
 	}
 	wrapped := &tcpListener{
-		l:    l,
-		port: port,
+		l:      l,
+		vmnetd: vmnetd,
+		port:   port,
 	}
 	return wrapped, nil
 }
 
 type tcpListener struct {
-	l    *net.TCPListener
-	port vpnkit.Port
+	l      *net.TCPListener
+	vmnetd bool
+	port   vpnkit.Port
 }
 
 func (l *tcpListener) accept() (libproxy.Conn, error) {
@@ -34,7 +36,7 @@ func (l *tcpListener) accept() (libproxy.Conn, error) {
 }
 
 func (l *tcpListener) close() error {
-	return closeTCP(l.port, l.l)
+	return closeTCP(l.port, l.vmnetd, l.l)
 }
 
 func makeTCP(c common, n TCPNetwork) (Forward, error) {

--- a/go/pkg/vpnkit/forward/tcp_linux.go
+++ b/go/pkg/vpnkit/forward/tcp_linux.go
@@ -1,17 +1,19 @@
 package forward
 
 import (
-	"github.com/moby/vpnkit/go/pkg/vpnkit"
 	"net"
+
+	"github.com/moby/vpnkit/go/pkg/vpnkit"
 )
 
-func listenTCP(port vpnkit.Port) (*net.TCPListener, error) {
-	return net.ListenTCP("tcp", &net.TCPAddr{
+func listenTCP(port vpnkit.Port) (*net.TCPListener, bool, error) {
+	l, err := net.ListenTCP("tcp", &net.TCPAddr{
 		IP:   port.OutIP,
 		Port: int(port.OutPort),
 	})
+	return l, false, err
 }
 
-func closeTCP(port vpnkit.Port, l *net.TCPListener) error {
+func closeTCP(port vpnkit.Port, _ bool, l *net.TCPListener) error {
 	return l.Close()
 }

--- a/go/pkg/vpnkit/forward/tcp_windows.go
+++ b/go/pkg/vpnkit/forward/tcp_windows.go
@@ -1,17 +1,19 @@
 package forward
 
 import (
-	"github.com/moby/vpnkit/go/pkg/vpnkit"
 	"net"
+
+	"github.com/moby/vpnkit/go/pkg/vpnkit"
 )
 
-func listenTCP(port vpnkit.Port) (*net.TCPListener, error) {
-	return net.ListenTCP("tcp", &net.TCPAddr{
+func listenTCP(port vpnkit.Port) (*net.TCPListener, bool, error) {
+	l, err := net.ListenTCP("tcp", &net.TCPAddr{
 		IP:   port.OutIP,
 		Port: int(port.OutPort),
 	})
+	return l, false, err
 }
 
-func closeTCP(port vpnkit.Port, l *net.TCPListener) error {
+func closeTCP(port vpnkit.Port, _ bool, l *net.TCPListener) error {
 	return l.Close()
 }

--- a/go/pkg/vpnkit/forward/udp_darwin.go
+++ b/go/pkg/vpnkit/forward/udp_darwin.go
@@ -3,16 +3,39 @@
 package forward
 
 import (
-	"github.com/moby/vpnkit/go/pkg/vpnkit"
 	"net"
+
+	"github.com/moby/vpnkit/go/pkg/libproxy"
+	"github.com/moby/vpnkit/go/pkg/vpnkit"
 )
 
-func listenUDP(port vpnkit.Port) (*net.UDPConn, error) {
+func listenUDP(port vpnkit.Port) (libproxy.UDPListener, error) {
 	if port.OutPort > 1024 {
 		return net.ListenUDP("udp", &net.UDPAddr{
 			IP:   port.OutIP,
 			Port: int(port.OutPort),
 		})
 	}
-	return listenUDPVmnet(port.OutIP, port.OutPort)
+	l, err := listenUDPVmnet(port.OutIP, port.OutPort)
+	if err != nil {
+		return nil, err
+	}
+	return &wrappedCloser{port, l}, nil
+}
+
+type wrappedCloser struct {
+	port vpnkit.Port
+	l    *net.UDPConn
+}
+
+func (w *wrappedCloser) ReadFromUDP(b []byte) (int, *net.UDPAddr, error) {
+	return w.l.ReadFromUDP(b)
+}
+
+func (w *wrappedCloser) WriteToUDP(b []byte, addr *net.UDPAddr) (int, error) {
+	return w.l.WriteToUDP(b, addr)
+}
+
+func (w *wrappedCloser) Close() error {
+	return closeUDPVmnet(w.port.OutIP, w.port.OutPort, w.l)
 }

--- a/go/pkg/vpnkit/forward/udp_linux.go
+++ b/go/pkg/vpnkit/forward/udp_linux.go
@@ -1,8 +1,9 @@
 package forward
 
 import (
-	"github.com/moby/vpnkit/go/pkg/vpnkit"
 	"net"
+
+	"github.com/moby/vpnkit/go/pkg/vpnkit"
 )
 
 func listenUDP(port vpnkit.Port) (*net.UDPConn, error) {

--- a/go/pkg/vpnkit/forward/udp_windows.go
+++ b/go/pkg/vpnkit/forward/udp_windows.go
@@ -1,8 +1,9 @@
 package forward
 
 import (
-	"github.com/moby/vpnkit/go/pkg/vpnkit"
 	"net"
+
+	"github.com/moby/vpnkit/go/pkg/vpnkit"
 )
 
 func listenUDP(port vpnkit.Port) (*net.UDPConn, error) {

--- a/go/pkg/vpnkit/forward/vmnet_darwin.go
+++ b/go/pkg/vpnkit/forward/vmnet_darwin.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"io"
 	"net"
+	"strings"
 	"syscall"
 	"time"
 
@@ -383,4 +384,8 @@ func readBytes(conn io.Reader, length int) ([]byte, error) {
 		return nil, err
 	}
 	return b, nil
+}
+
+func isPermissionDenied(err error) bool {
+	return strings.HasSuffix(err.Error(), "permission denied")
 }

--- a/go/pkg/vpnkit/forward/vmnet_darwin.go
+++ b/go/pkg/vpnkit/forward/vmnet_darwin.go
@@ -70,6 +70,10 @@ func closeTCPVmnet(IP net.IP, Port uint16, l *net.TCPListener) error {
 }
 
 func listenUDPVmnet(IP net.IP, Port uint16) (*net.UDPConn, error) {
+	// I don't think it's possible to make a net.UDPConn from a raw file descriptor
+	// so we use a hack: we create a net.UDPConn listening on a random port and then
+	// use the `SyscallConn` low-level interface to replace the file descriptor with a
+	// clone of the one which is listening on the privileged port.
 	l, err := net.ListenUDP("udp", &net.UDPAddr{
 		IP:   IP,
 		Port: 0,
@@ -89,12 +93,9 @@ func listenUDPVmnet(IP net.IP, Port uint16) (*net.UDPConn, error) {
 		return nil, err
 	}
 
-	if err := syscall.SetNonblock(int(newFD), true); err != nil {
-		_ = l.Close()
-		_ = syscall.Close(int(newFD))
-		return nil, err
-	}
-
+	// Unfortunately setting non-blocking mode seems to break I/O in interesting ways,
+	// we we have to leave it in blocking mode. Unfortunately this makes `Close` more complicated,
+	// see below.
 	if err := switchFDs(raw, newFD); err != nil {
 		_ = l.Close()
 		_ = syscall.Close(int(newFD))
@@ -102,6 +103,30 @@ func listenUDPVmnet(IP net.IP, Port uint16) (*net.UDPConn, error) {
 	}
 	_ = syscall.Close(int(newFD))
 	return l, err
+}
+
+func closeUDPVmnet(IP net.IP, Port uint16, l *net.UDPConn) error {
+	errCh := make(chan error)
+	go func() {
+		errCh <- l.Close()
+	}()
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		conn, _ := net.DialUDP("udp", nil, &net.UDPAddr{
+			IP:   IP,
+			Port: int(Port),
+		})
+		if conn != nil {
+			conn.Write([]byte{})
+			conn.Close()
+		}
+		select {
+		case err := <-errCh:
+			return err
+		case <-ticker.C:
+		}
+	}
 }
 
 func switchFDs(raw syscall.RawConn, newFD uintptr) error {

--- a/go/pkg/vpnkit/forward/vmnet_darwin.go
+++ b/go/pkg/vpnkit/forward/vmnet_darwin.go
@@ -3,11 +3,12 @@ package forward
 import (
 	"bytes"
 	"encoding/binary"
-	"github.com/pkg/errors"
 	"io"
 	"net"
 	"syscall"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 func listenTCPVmnet(IP net.IP, Port uint16) (*net.TCPListener, error) {
@@ -45,26 +46,25 @@ func listenTCPVmnet(IP net.IP, Port uint16) (*net.TCPListener, error) {
 	return l, err
 }
 
-
 func closeTCPVmnet(IP net.IP, Port uint16, l *net.TCPListener) error {
 	errCh := make(chan error)
-	go func(){
+	go func() {
 		errCh <- l.Close()
-	} ()
+	}()
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 	for {
 		conn, _ := net.DialTCP("tcp", nil, &net.TCPAddr{
-			IP: IP,
+			IP:   IP,
 			Port: int(Port),
 		})
 		if conn != nil {
 			conn.Close()
 		}
 		select {
-		case err := <- errCh:
+		case err := <-errCh:
 			return err
-		case <- ticker.C:
+		case <-ticker.C:
 		}
 	}
 }

--- a/go/pkg/vpnkit/forward/vmnet_darwin_test.go
+++ b/go/pkg/vpnkit/forward/vmnet_darwin_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"syscall"
 
+	"github.com/moby/vpnkit/go/pkg/vpnkit"
 	"github.com/stretchr/testify/assert"
 
 	"testing"
@@ -169,4 +170,46 @@ func TestBindUDPVmnetdCloseLeak(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		TestBindUDPVmnetdClose(t)
 	}
+}
+
+func TestListenUDPMojave1(t *testing.T) {
+	// On Mojave this will not need vmnetd
+	l, err := listenUDP(vpnkit.Port{
+		OutIP:   net.ParseIP("0.0.0.0"),
+		OutPort: 80,
+	})
+	assert.Nil(t, err)
+	assert.Nil(t, l.Close())
+}
+
+func TestListenUDPMojave2(t *testing.T) {
+	// On Mojave this will need vmnetd
+	l, err := listenUDP(vpnkit.Port{
+		OutIP:   net.ParseIP("127.0.0.1"),
+		OutPort: 80,
+	})
+	assert.Nil(t, err)
+	assert.Nil(t, l.Close())
+}
+
+func TestListenTCPMojave1(t *testing.T) {
+	// On Mojave this will not need vmnetd
+	l, vmnetd, err := listenTCP(vpnkit.Port{
+		OutIP:   net.ParseIP("0.0.0.0"),
+		OutPort: 80,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, false, vmnetd)
+	assert.Nil(t, l.Close())
+}
+
+func TestListenTCPMojave2(t *testing.T) {
+	// On Mojave this will need vmnetd
+	l, vmnetd, err := listenTCP(vpnkit.Port{
+		OutIP:   net.ParseIP("127.0.0.1"),
+		OutPort: 80,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, true, vmnetd)
+	assert.Nil(t, l.Close())
 }

--- a/go/pkg/vpnkit/forward/vmnet_darwin_test.go
+++ b/go/pkg/vpnkit/forward/vmnet_darwin_test.go
@@ -2,10 +2,11 @@ package forward
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"net"
 	"syscall"
+
+	"github.com/stretchr/testify/assert"
 
 	"testing"
 	"time"
@@ -44,7 +45,7 @@ func TestMarshalBindIpv4(t *testing.T) {
 }
 
 func TestBindVmnetdLow(t *testing.T) {
-	for i := 0; i < 10; i ++ {
+	for i := 0; i < 10; i++ {
 		fd, err := listenVmnet(localhost, 8081, true)
 		assert.Nil(t, err)
 		assert.Nil(t, syscall.Close(int(fd)))
@@ -76,11 +77,11 @@ func TestBindVmnetd(t *testing.T) {
 	assert.Nil(t, conn.Close())
 	assert.Nil(t, f.Close())
 	time.Sleep(time.Second)
-	<- done
+	<-done
 }
 
-func TestBindVmnetdLeak(t *testing.T){
-	for i :=0; i < 10; i ++{
+func TestBindVmnetdLeak(t *testing.T) {
+	for i := 0; i < 10; i++ {
 		TestBindVmnetd(t)
 	}
 }
@@ -89,19 +90,19 @@ func TestBindVmnetdClose(t *testing.T) {
 	localhost := net.ParseIP("127.0.0.1")
 	f, err := listenTCPVmnet(localhost, 8081)
 	assert.Nil(t, err)
-	go func(){
+	go func() {
 		c, err := f.Accept()
 		if c != nil {
 			c.Close()
 		}
 		assert.Nil(t, err)
-	} ()
+	}()
 	time.Sleep(10 * time.Millisecond)
 	assert.Nil(t, closeTCPVmnet(localhost, 8081, f))
 }
 
-func TestBindVmnetdCloseLeak(t *testing.T){
-	for i := 0; i < 10; i ++{
+func TestBindVmnetdCloseLeak(t *testing.T) {
+	for i := 0; i < 10; i++ {
 		TestBindVmnetdClose(t)
 	}
 }


### PR DESCRIPTION
Previously in 32ede13e84c08bdc76ac8ea17d5e84863b89637f we added a fix for TCP where we didn't set the socket to non-blocking mode. This PR replicates the fix for UDP and adds a unit test.

Related to docker/for-mac#3775

Furthermore this PR only uses the `vmnetd` code path if the bind actually fails with permission denied. In particular on Mojave, some binds will succeed (e.g. `0.0.0.0:80`) without being root.