### PR TITLE
mux: perform an initial handshake to check the data connection

### DIFF
--- a/go/pkg/libproxy/handshake.go
+++ b/go/pkg/libproxy/handshake.go
@@ -1,0 +1,50 @@
+package libproxy
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+type handshake struct {
+	// In future we could add flags here for feature negotiation.
+	// The length is dynamic but it must be < 64k.
+	payload []byte // uninterpreted
+}
+
+const handshakeMagic = "https://github.com/moby/vpnkit multiplexer protocol\n"
+
+func unmarshalHandshake(r io.Reader) (*handshake, error) {
+	magic := make([]byte, len(handshakeMagic))
+	if err := binary.Read(r, binary.LittleEndian, &magic); err != nil {
+		return nil, err
+	}
+	if string(magic) != handshakeMagic {
+		return nil, fmt.Errorf("not a connection to a mulitplexer; received bad magic string '%s'", string(magic))
+	}
+
+	var length uint16
+	if err := binary.Read(r, binary.LittleEndian, &length); err != nil {
+		// it will be common to fail here with io.EOF
+		return nil, err
+	}
+	payload := make([]byte, length)
+	if err := binary.Read(r, binary.LittleEndian, &payload); err != nil {
+		return nil, err
+	}
+	return &handshake{
+		payload: payload,
+	}, nil
+}
+
+func (h *handshake) Write(w io.Writer) error {
+	magic := []byte(handshakeMagic)
+	if err := binary.Write(w, binary.LittleEndian, magic); err != nil {
+		return err
+	}
+	length := uint16(len(h.payload))
+	if err := binary.Write(w, binary.LittleEndian, length); err != nil {
+		return err
+	}
+	return binary.Write(w, binary.LittleEndian, h.payload)
+}

--- a/go/pkg/libproxy/handshake_test.go
+++ b/go/pkg/libproxy/handshake_test.go
@@ -1,0 +1,23 @@
+package libproxy
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestHandshakePrintParse(t *testing.T) {
+	var w bytes.Buffer
+	h := &handshake{
+		payload: []byte("this is some payload"),
+	}
+	if err := h.Write(&w); err != nil {
+		t.Fatal(err)
+	}
+	h2, err := unmarshalHandshake(&w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(h.payload) != string(h2.payload) {
+		t.Fatalf("expected '%s' got '%s", string(h.payload), string(h2.payload))
+	}
+}

--- a/go/pkg/vpnkit/control/control.go
+++ b/go/pkg/vpnkit/control/control.go
@@ -156,7 +156,11 @@ func (c *Control) Connect(path string, quit <-chan struct{}) error {
 func (c *Control) handleDataConn(rw io.ReadWriteCloser, quit <-chan struct{}) {
 	defer rw.Close()
 
-	mux := libproxy.NewMultiplexer("local", rw)
+	mux, err := libproxy.NewMultiplexer("local", rw)
+	if err != nil {
+		log.Errorf("error accepting multiplexer data connection: %v", err)
+		return
+	}
 	mux.Run()
 	c.SetMux(mux)
 	defer c.SetMux(nil)

--- a/go/pkg/vpnkit/dialer.go
+++ b/go/pkg/vpnkit/dialer.go
@@ -34,7 +34,10 @@ func (d *Dialer) setupMultiplexer() error {
 		if err != nil {
 			return err
 		}
-		d.mux = libproxy.NewMultiplexer("host", conn)
+		d.mux, err = libproxy.NewMultiplexer("host", conn)
+		if err != nil {
+			return err
+		}
 		d.mux.Run()
 	}
 	return nil


### PR DESCRIPTION
Previously if we connected to the wrong service we would output a confusing set of error messages.

Previously if the connection returned EOF (e.g. because it was forwarded by something like `docker run -p`) we would also output a confusing set of error messages.

This patch makes the constructor `NewMultiplexer` return an error, which is the result of a handshake exchange. This means that `NewMultiplexer` is now a blocking operation.

The handshake contains the magic string
```
  https://github.com/moby/vpnkit multiplexer protocol\n
```
so hopefully it will be obvious to other people what this protocol is.

For future use the handshake includes a variable length payload which could contain feature flags in the future.

Signed-off-by: David Scott <dave.scott@docker.com>