### PR TITLE
Fix a hang when channels are opened from both ends concurrently

### DIFF
--- a/go/pkg/vpnkit/control/control.go
+++ b/go/pkg/vpnkit/control/control.go
@@ -138,7 +138,7 @@ func (c *Control) ListenOnListener(l net.Listener, listenerName string, quit <-c
 			continue
 		}
 		log.Printf("accepted data connection on %s", listenerName)
-		c.handleDataConn(conn, quit)
+		c.handleDataConn(conn, quit, false)
 	}
 }
 
@@ -155,15 +155,15 @@ func (c *Control) Connect(path string, quit <-chan struct{}) error {
 			continue
 		}
 		log.Printf("connected data connection on %s %s", t.String(), path)
-		c.handleDataConn(conn, quit)
+		c.handleDataConn(conn, quit, true)
 	}
 }
 
 // handle data-plane forwarding
-func (c *Control) handleDataConn(rw io.ReadWriteCloser, quit <-chan struct{}) {
+func (c *Control) handleDataConn(rw io.ReadWriteCloser, quit <-chan struct{}, allocateBackward bool) {
 	defer rw.Close()
 
-	mux, err := libproxy.NewMultiplexer("local", rw)
+	mux, err := libproxy.NewMultiplexer("local", rw, allocateBackward)
 	if err != nil {
 		log.Errorf("error accepting multiplexer data connection: %v", err)
 		return

--- a/go/pkg/vpnkit/dialer.go
+++ b/go/pkg/vpnkit/dialer.go
@@ -34,7 +34,7 @@ func (d *Dialer) setupMultiplexer() error {
 		if err != nil {
 			return err
 		}
-		d.mux, err = libproxy.NewMultiplexer("host", conn)
+		d.mux, err = libproxy.NewMultiplexer("host", conn, true)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Channel IDs are allocated independently from both ends of the
multiplexer. Previously that meant that if both ends allocate channel
concurently, there was a clash of channel IDs leading to a channel being
stuck.

This commit fixes that by allowing to indicate that one end should
allocate ids backwards.

Signed-off-by: Simon Ferquel <simon.ferquel@docker.com>