### PR TITLE
forwards field is protected behind a mutex. Use it.

### DIFF
--- a/go/pkg/vpnkit/control/control.go
+++ b/go/pkg/vpnkit/control/control.go
@@ -101,7 +101,9 @@ func (c *Control) Unexpose(_ context.Context, port *vpnkit.Port) error {
 }
 
 func (c *Control) ListExposed(_ context.Context) ([]vpnkit.Port, error) {
-	results := make([]vpnkit.Port, len(c.forwards))
+	c.forwardsM.Lock()
+	defer c.forwardsM.Unlock()
+	var results []vpnkit.Port
 	for _, forward := range c.forwards {
 		results = append(results, forward.Port())
 	}


### PR DESCRIPTION
Signed-off-by: Guillaume Rose <guillaume.rose@docker.com>