### PR TITLE
Remove `is being closed.` logs in proxystream

### DIFF
--- a/go/pkg/libproxy/stream_proxy.go
+++ b/go/pkg/libproxy/stream_proxy.go
@@ -21,7 +21,7 @@ func ProxyStream(client, backend Conn, quit <-chan struct{}) error {
 			log.Println("error copying:", err)
 		}
 		err = to.CloseWrite()
-		if err != nil && !errIsNotConnected(err) {
+		if err != nil && !errIsNotConnected(err) && !errIsBeingClosed(err) {
 			log.Println("error CloseWrite to:", err)
 		}
 		event <- written
@@ -54,4 +54,8 @@ func errIsNotConnected(err error) bool {
 
 func errIsConnectionRefused(err error) bool {
 	return strings.HasSuffix(err.Error(), "connection refused")
+}
+
+func errIsBeingClosed(err error) bool {
+	return strings.HasSuffix(err.Error(), "is being closed.")
 }


### PR DESCRIPTION
They happen every time the client named pipe do a close and it don't hide any errors

(it's quite similar to `is not connected` filtering)
