### PR TITLE
Remove `is being closed.` logs in proxystream when copying

### DIFF
--- a/go/pkg/libproxy/stream_proxy.go
+++ b/go/pkg/libproxy/stream_proxy.go
@@ -17,7 +17,7 @@ func ProxyStream(client, backend Conn, quit <-chan struct{}) error {
 	event := make(chan int64)
 	var broker = func(to, from Conn) {
 		written, err := io.Copy(to, from)
-		if err != nil && err != io.EOF {
+		if err != nil && err != io.EOF && !errIsBeingClosed(err) {
 			log.Println("error copying:", err)
 		}
 		err = to.CloseWrite()


### PR DESCRIPTION
They happen every time the server named pipe is about closing, it's similar to EOF

Signed-off-by: ebriney <emmanuel.briney@docker.com>