### PR TITLE
Makefile: run `dune upgrade` at build-time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ vpnkit.tgz: vpnkit.exe
 
 .PHONY: vpnkit.exe
 vpnkit.exe: $(OPAMROOT)
+	opam config --root $(OPAMROOT) --switch $(OPAM_COMP) exec -- sh -c 'dune upgrade'
 	opam config --root $(OPAMROOT) --switch $(OPAM_COMP) exec -- sh -c 'jbuilder build --dev src/bin/main.exe'
 	cp _build/default/src/bin/main.exe vpnkit.exe
 


### PR DESCRIPTION
This is an attempt to work around

https://travis-ci.org/moby/vpnkit/builds/654414331

Signed-off-by: David Scott <dave.scott@docker.com>