### PR TITLE
transport: work around Unix socket path lengths on Darwin

### DIFF
--- a/go/pkg/vpnkit/transport/vsock_darwin.go
+++ b/go/pkg/vpnkit/transport/vsock_darwin.go
@@ -60,8 +60,52 @@ func toPath(a *addr) (string, error) {
 	if err != nil {
 		return "", errors.New("Unable to determine current user")
 	}
-	return filepath.Join(user.HomeDir, "Library", "Containers", "com.docker.docker", "Data", "vms", "0", fmt.Sprintf("%08x.%08x", a.cid, a.port)), nil
+	unshortened := filepath.Join(user.HomeDir, "Library", "Containers", "com.docker.docker", "Data", "vms", "0", fmt.Sprintf("%08x.%08x", a.cid, a.port))
+	return shortenUnixSocketPath(unshortened)
 }
+
+// shortenUnixSocketPath returns a path shortened so it fits inside a socket address.
+// This is needed because paths can be much larger than the space available inside a
+// socket address.
+func shortenUnixSocketPath(path string) (string, error) {
+	if len(path) <= maxDarwinSocketPathLen {
+		return path, nil
+	}
+	// absolute path is too long, attempt to use a relative path
+	p, err := relative(path)
+	if err != nil {
+		return "", err
+	}
+
+	if len(p) > maxDarwinSocketPathLen {
+		return "", fmt.Errorf("absolute and relative socket path %s longer than %d characters", p, maxDarwinSocketPathLen)
+	}
+	return p, nil
+}
+
+func relative(p string) (string, error) {
+	// Assume the parent directory exists already but the child (the socket)
+	// hasn't been created.
+	path2, err := filepath.EvalSymlinks(filepath.Dir(p))
+	if err != nil {
+		return "", err
+	}
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	dir2, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(dir2, path2)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(rel, filepath.Base(p)), nil
+}
+
+const maxDarwinSocketPathLen = 104
 
 type addr struct {
 	cid  uint32


### PR DESCRIPTION
On Darwin a Unix socket path can only be 104 bytes long. We use long paths when talking to hyperkit
(`~/Library/Containers/com.docker.docker/...`) so we often hit this limit if the user has a long username.

A common workaround is to `chdir` into the `~/Library/Containers/com.docker.docker` folder (as would happen naturally if running in a macOS sandbox) and then use relative paths.

This patch checks the path lengths and constructs a relative path if necessary.

Signed-off-by: David Scott <dave@recoil.org>