### PR TITLE
go: remove hardcoded GOARCH to support multiarch builds

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -32,7 +32,7 @@ build-dial-example-in-container: $(DEPS_DIAL_EXAMPLE)
 	docker build -t $(ORG)/dial-example:$(HASH) -f Dockerfile.dial-example .
 
 build/vpnkit-forwarder.linux: $(DEPS_FORWARDER)
-	GOOS=linux GOARCH=amd64 \
+	GOOS=linux \
 	go build -o $@ --ldflags '-s -w -extldflags "-static"' --buildmode pie \
 	$(DEPS_FORWARDER)
 
@@ -40,17 +40,17 @@ build/vpnkit-expose-port.linux: build/vpnkit-forwarder.linux
 	cp -v build/vpnkit-forwarder.linux build/vpnkit-expose-port.linux
 
 build/dial-example.linux: $(DEPS_DIAL_EXAMPLE)
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=1 \
+	GOOS=linux CGO_ENABLED=1 \
 	go build -o $@ --ldflags '-s -w' --buildmode pie \
 	$(DEPS_DIAL_EXAMPLE)
 
 build/kube-vpnkit-forwarder.linux: $(DEPS_KUBE_FORWARDER)
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=1 \
+	GOOS=linux CGO_ENABLED=1 \
 	go build -o $@ --ldflags '-s -w' --buildmode pie \
 	$(DEPS_KUBE_FORWARDER)
 
 build/vpnkit-iptables-wrapper.linux: $(DEPS_IPTABLES)
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 \
+	GOOS=linux CGO_ENABLED=0 \
 	go build -o $@ --ldflags '-s -w' --buildmode pie \
 	$(DEPS_IPTABLES)
 


### PR DESCRIPTION
Signed-off-by: David Scott <dave.scott@docker.com>