### PR TITLE
Handle random port correctly: report assigned port

### DIFF
--- a/go/pkg/vpnkit/forward/forward_test.go
+++ b/go/pkg/vpnkit/forward/forward_test.go
@@ -280,3 +280,19 @@ func TestInterfaceDoesNotExist(t *testing.T) {
 	}
 	assert.Nil(t, f)
 }
+
+func TestRandomPortsTCP(t *testing.T) {
+	maker := Maker{}
+	f, err := maker.Make(nil, vpnkit.Port{InIP: net.IPv4(127, 0, 0, 1), InPort: 2, OutIP: net.IPv4(127, 0, 0, 1), OutPort: 0, Proto: vpnkit.TCP})
+	assert.NoError(t, err)
+	defer f.Stop()
+	assert.NotEqual(t, uint16(0), f.Port().OutPort)
+}
+
+func TestRandomPortsUDP(t *testing.T) {
+	maker := Maker{}
+	f, err := maker.Make(nil, vpnkit.Port{InIP: net.IPv4(127, 0, 0, 1), InPort: 2, OutIP: net.IPv4(127, 0, 0, 1), OutPort: 0, Proto: vpnkit.UDP})
+	assert.NoError(t, err)
+	defer f.Stop()
+	assert.NotEqual(t, uint16(0), f.Port().OutPort)
+}

--- a/go/pkg/vpnkit/forward/stream.go
+++ b/go/pkg/vpnkit/forward/stream.go
@@ -15,6 +15,7 @@ type network interface {
 type listener interface {
 	accept() (libproxy.Conn, error)
 	close() error
+	port() vpnkit.Port
 }
 
 func makeStream(c common, n network) (*stream, error) {
@@ -66,4 +67,8 @@ func (s *stream) Stop() {
 	log.Printf("removing %s", s.port.String())
 	s.l.close()
 	close(s.quit)
+}
+
+func (s *stream) Port() vpnkit.Port {
+	return s.l.port()
 }

--- a/go/pkg/vpnkit/forward/udp.go
+++ b/go/pkg/vpnkit/forward/udp.go
@@ -22,9 +22,17 @@ func makeUDP(c common) (*udp, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to resolve backend address for port %s", c.port.String())
 	}
-	l, err := listenUDP(c.Port())
+	port := c.Port()
+	l, err := listenUDP(port)
 	if err != nil {
 		return nil, err
+	}
+	if port.OutPort == 0 {
+		addr, ok := l.LocalAddr().(*net.UDPAddr)
+		if ok {
+			port.OutPort = uint16(addr.Port)
+		}
+		c.port = port
 	}
 	dialer := &udpDialer{
 		ctrl: c.ctrl,

--- a/go/pkg/vpnkit/forward/unix_unix.go
+++ b/go/pkg/vpnkit/forward/unix_unix.go
@@ -30,12 +30,13 @@ func (t UnixNetwork) listen(port vpnkit.Port) (listener, error) {
 	if err != nil {
 		return nil, err
 	}
-	wrapped := unixListener{l}
+	wrapped := unixListener{l, port}
 	return &wrapped, nil
 }
 
 type unixListener struct {
 	l *net.UnixListener
+	p vpnkit.Port
 }
 
 func (l unixListener) accept() (libproxy.Conn, error) {
@@ -44,6 +45,10 @@ func (l unixListener) accept() (libproxy.Conn, error) {
 
 func (l unixListener) close() error {
 	return l.l.Close()
+}
+
+func (l unixListener) port() vpnkit.Port {
+	return l.p
 }
 
 func makeUnix(c common, n UnixNetwork) (Forward, error) {

--- a/go/pkg/vpnkit/forward/unix_windows.go
+++ b/go/pkg/vpnkit/forward/unix_windows.go
@@ -24,12 +24,13 @@ func (t UnixNetwork) listen(port vpnkit.Port) (listener, error) {
 	if err != nil {
 		return nil, err
 	}
-	wrapped := unixListener{l}
+	wrapped := unixListener{l, port}
 	return &wrapped, nil
 }
 
 type unixListener struct {
 	l net.Listener
+	p vpnkit.Port
 }
 
 func (l unixListener) accept() (libproxy.Conn, error) {
@@ -46,6 +47,10 @@ func (l unixListener) accept() (libproxy.Conn, error) {
 
 func (l unixListener) close() error {
 	return l.l.Close()
+}
+
+func (l unixListener) port() vpnkit.Port {
+	return l.p
 }
 
 func makeUnix(c common, n UnixNetwork) (Forward, error) {


### PR DESCRIPTION
This makes sure forwarded UDP and TCP services on random ports report back their randomly assigned ports.