### PR TITLE
go: use narrower UDPListener interface

### DIFF
--- a/go/pkg/vpnkit/forward/udp_darwin.go
+++ b/go/pkg/vpnkit/forward/udp_darwin.go
@@ -27,7 +27,7 @@ func listenUDP(port vpnkit.Port) (libproxy.UDPListener, error) {
 
 type wrappedCloser struct {
 	port vpnkit.Port
-	l    *net.UDPConn
+	l    libproxy.UDPListener
 }
 
 func (w *wrappedCloser) ReadFromUDP(b []byte) (int, *net.UDPAddr, error) {
@@ -40,4 +40,8 @@ func (w *wrappedCloser) WriteToUDP(b []byte, addr *net.UDPAddr) (int, error) {
 
 func (w *wrappedCloser) Close() error {
 	return closeUDPVmnet(w.port.OutIP, w.port.OutPort, w.l)
+}
+
+func (w *wrappedCloser) LocalAddr() net.Addr {
+	return w.l.LocalAddr()
 }

--- a/go/pkg/vpnkit/forward/vmnet_darwin.go
+++ b/go/pkg/vpnkit/forward/vmnet_darwin.go
@@ -109,7 +109,7 @@ func listenUDPVmnet(IP net.IP, Port uint16) (libproxy.UDPListener, error) {
 }
 
 type vmnetdUdpWrapper struct {
-	*net.UDPConn
+	libproxy.UDPListener
 	localAddr *net.UDPAddr
 }
 
@@ -117,7 +117,7 @@ func (w vmnetdUdpWrapper) LocalAddr() net.Addr {
 	return w.localAddr
 }
 
-func closeUDPVmnet(IP net.IP, Port uint16, l *net.UDPConn) error {
+func closeUDPVmnet(IP net.IP, Port uint16, l libproxy.UDPListener) error {
 	errCh := make(chan error)
 	go func() {
 		errCh <- l.Close()

--- a/go/pkg/vpnkit/forward/vmnet_darwin_test.go
+++ b/go/pkg/vpnkit/forward/vmnet_darwin_test.go
@@ -86,7 +86,7 @@ func TestBindUDPVmnetd(t *testing.T) {
 		t.FailNow()
 	}()
 	result := make([]byte, 1024)
-	n, err := f.Read(result)
+	n, _, err := f.ReadFromUDP(result)
 	assert.Nil(t, err)
 	assert.Equal(t, string(hello), string(result[0:n]))
 	done <- struct{}{}
@@ -153,7 +153,7 @@ func TestBindUDPVmnetdClose(t *testing.T) {
 	assert.Nil(t, err)
 	go func() {
 		buf := make([]byte, 1024)
-		_, err := f.Read(buf)
+		_, _, err := f.ReadFromUDP(buf)
 		assert.Nil(t, err)
 	}()
 	time.Sleep(10 * time.Millisecond)


### PR DESCRIPTION
This is smaller and easier to get than a full *net.UDPConn.

Split from #514 in case I mess up the `go.mod` transition at the same time.

Unfortunately the CI builds the Go code under Linux but the Mac CI is broken, allowing this kind of breakage to slip through.

Signed-off-by: David Scott <dave@recoil.org>