### PR TITLE
Work around build failure in uri package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ RUN opam remote add vpnkit /home/opam/src/repo/darwin
 RUN opam pin add -y -n vpnkit /home/opam/src
 RUN opam depext vpnkit -y
 RUN opam pin add -y -n tcpip https://github.com/djs55/mirage-tcpip.git#vpnkit-20180607
+# Work around uri build failure
+ENV OPAMJOBS=1
+RUN opam install re.1.9.0
+RUN opam install uri.2.2.1
 RUN opam install --deps-only vpnkit -y
 RUN opam pin remove vpnkit
 WORKDIR /home/opam/src

--- a/vpnkit.opam
+++ b/vpnkit.opam
@@ -74,4 +74,6 @@ depends: [
   "mirage-clock-lwt" {= "2.0.0"}
   "mirage-clock-unix" {= "2.0.0"}
   "mirage-random" {= "1.1.0"}
+  "re" {= "1.9.0"}
+  "uri" {= "2.2.1"}
 ]


### PR DESCRIPTION
The failure looks like:
```
ocamlc lib/.uri.objs/byte/uri_re.{cmi,cmo,cmt} (exit 2)
(cd _build/default && /home/opam/.opam/4.07/bin/ocamlc.opt -w -40 -g -bin-annot -I lib/.uri.objs/byte -no-alias-deps -o lib/.uri.objs/byte/uri_re.cmo -c -impl lib/.wrapped_compat/Uri_re.ml-gen)
File "lib/.wrapped_compat/Uri_re.ml-gen", line 1, characters 99-110:
Error: Unbound module Uri__Uri_re
```

I suspect it's due to a missed dependency within the code itself, probably due to the old packages and `dune`/`jbuilder` version. Building the package separately seems to hide the problem, which is enough until we can upgrade a lot of the dependencies.

Signed-off-by: David Scott <dave@recoil.org>