### PR TITLE
circleci: remove `brew update` which takes 5 minutes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,6 @@ jobs:
       TERM: vt100
     steps:
       - checkout
-      - run: brew update
       - run: brew install wget
       - run: brew install pkg-config
       - run: brew install dylibbundler


### PR DESCRIPTION
Let's see if we can speed up the Mac CI.

Signed-off-by: David Scott <dave@recoil.org>