### PR TITLE
Improve dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,25 @@
-FROM ocaml/opam2:alpine-3.10-ocaml-4.07 as build
+FROM ocaml/opam2:alpine-3.10-ocaml-4.10 as build
+
+RUN opam pin add fd-send-recv.2.0.1 https://github.com/xapi-project/ocaml-fd-send-recv/archive/v2.0.1.tar.gz
+# A small fork of the tcpip stack
+RUN opam pin add tcpip.3.3.0 "https://github.com/djs55/mirage-tcpip.git#vpnkit-20180607" -n
+# This has been released in version 2 but with some other incompatible changes
+RUN opam pin add hvsock.1.0.1 "git://github.com/djs55/ocaml-hvsock.git#relative-paths" -n
+
 ADD . /home/opam/src
-# Latest packages plus some overrides are in this repo:
-RUN opam remote add vpnkit /home/opam/src/repo/darwin
 RUN opam pin add -y -n vpnkit /home/opam/src
 RUN opam depext vpnkit -y
-RUN opam pin add -y -n tcpip https://github.com/djs55/mirage-tcpip.git#vpnkit-20180607
-# Work around uri build failure
+
+# Work around uri build failure (maybe remove when we update jbuilder/dune)
 ENV OPAMJOBS=1
 RUN opam install re.1.9.0
 RUN opam install uri.2.2.1
-RUN opam install --deps-only vpnkit -y
-RUN opam pin remove vpnkit
-WORKDIR /home/opam/src
-RUN opam exec -- sudo dune build src/bin/main.exe
+ENV OPAMJOBS=8
 
-FROM scratch
+RUN opam install --deps-only vpnkit -y
+
+WORKDIR /home/opam/src
+RUN opam exec -- sudo dune build --profile release
+
+FROM alpine:latest
 COPY --from=build /home/opam/src/_build/default/src/bin/main.exe /vpnkit

--- a/src/hostnet/hostnet_dns.ml
+++ b/src/hostnet/hostnet_dns.ml
@@ -41,7 +41,7 @@ module Policy(Files: Sig.FILES) = struct
   module IntMap =
     Map.Make(struct
       type t = int
-      let compare (a: int) (b: int) = Pervasives.compare a b
+      let compare (a: int) (b: int) = Stdlib.compare a b
     end)
 
   let google_dns =

--- a/vpnkit.opam
+++ b/vpnkit.opam
@@ -47,7 +47,7 @@ depends: [
   "hvsock" {>= "1.0.1"}
   "asl"
   "win-eventlog"
-  "fd-send-recv" {>= "1.0.3"}
+  "fd-send-recv" {>= "2.0.0"}
   "logs"
   "fmt"
   "astring"


### PR DESCRIPTION
- update to OCaml 4.10
- use the upstream version 2 https://github.com/ocaml/opam-repository with some `opam pin`s, rather than an old subset of the ancient version 1 metadata in the repo
- increase concurrency (after workaround for `Uri`/`Re` problem)