### PR TITLE
Improve / simplify logging

### DIFF
--- a/src/bin/bind.ml
+++ b/src/bin/bind.ml
@@ -16,9 +16,9 @@ module Make(Socket: Sig.SOCKETS) = struct
 
   module Channel = Mirage_channel_lwt.Make(Socket.Stream.Unix)
 
-  let err_eof = Lwt_result.fail (`Msg "error: got EOF")
-  let err_read e = failf "error while reading: %a" Channel.pp_error e
-  let err_flush e = failf "error while flushing: %a" Channel.pp_write_error e
+  let err_eof = Lwt_result.fail (`Msg "EOF")
+  let err_read e = failf "while reading: %a" Channel.pp_error e
+  let err_flush e = failf "while flushing: %a" Channel.pp_write_error e
 
   let with_read x f =
     x >>= function

--- a/src/bin/dune
+++ b/src/bin/dune
@@ -1,7 +1,7 @@
 (executable
  (name main)
  (libraries cmdliner ofs logs.fmt hostnet hvsock hvsock.lwt datakit-server-9p
-   win-eventlog asl fd-send-recv duration mirage-clock-unix mirage-random)
+   fd-send-recv duration mirage-clock-unix mirage-random)
  (flags
   :standard
   (:include flags.sexp))

--- a/src/bin/logging.ml
+++ b/src/bin/logging.ml
@@ -10,13 +10,41 @@ open Cmdliner
 let mk = Arg.enum [
     "quiet"    , Quiet;
     "eventlog" , Eventlog;
-    "asl"      , ASL
+    "asl"      , ASL;
   ]
+
+  let pp_ptime f () =
+    let open Unix in
+    let tm = Unix.gmtime (Unix.time ()) in
+    Fmt.pf f "time=\"%04d-%02d-%02dT%02d:%02d:%02dZ\"" (tm.tm_year + 1900) (tm.tm_mon + 1)
+      tm.tm_mday tm.tm_hour tm.tm_min tm.tm_sec
+
+let reporter =
+  let report src level ~over k msgf =
+    let k _ =
+      over ();
+      k ()
+    in
+    let src = Logs.Src.name src in
+    let with_stamp _h _tags k fmt =
+      let level = Logs.level_to_string (Some level) in
+
+      Fmt.kpf k Fmt.stderr
+        ("\r%a level=%a @[msg=\"%a: " ^^ fmt ^^ "\"@]@.")
+        pp_ptime ()
+        Fmt.string level
+        Fmt.string src
+
+    in
+    msgf @@ fun ?header ?tags fmt ->
+    with_stamp header tags k fmt
+  in
+  { Logs.report }
 
 let setup log_destination level =
   Logs.set_level level;
   match log_destination with
-  | Quiet    -> Logs.set_reporter (Logs_fmt.reporter ())
+  | Quiet    -> Logs.set_reporter (reporter)
   | Eventlog ->
     let eventlog = Eventlog.register "Docker.exe" in
     Logs.set_reporter (Log_eventlog.reporter ~eventlog ())

--- a/src/bin/logging.ml
+++ b/src/bin/logging.ml
@@ -1,18 +1,5 @@
 (* Based on https://github.com/moby/datakit/blob/master/src/datakit-log/datakit_log.ml *)
 
-type t =
-  | Quiet
-  | Eventlog
-  | ASL
-
-open Cmdliner
-
-let mk = Arg.enum [
-    "quiet"    , Quiet;
-    "eventlog" , Eventlog;
-    "asl"      , ASL;
-  ]
-
   let pp_ptime f () =
     let open Unix in
     let tm = Unix.gmtime (Unix.time ()) in
@@ -41,22 +28,6 @@ let reporter =
   in
   { Logs.report }
 
-let setup log_destination level =
+let setup level =
   Logs.set_level level;
-  match log_destination with
-  | Quiet    -> Logs.set_reporter (reporter)
-  | Eventlog ->
-    let eventlog = Eventlog.register "Docker.exe" in
-    Logs.set_reporter (Log_eventlog.reporter ~eventlog ())
-  | ASL ->
-    let facility = Filename.basename Sys.executable_name in
-    let client = Asl.Client.create ~ident:"Docker" ~facility () in
-    Logs.set_reporter (Log_asl.reporter ~client ())
-
-let docs = "LOG OPTIONS"
-
-let log_destination =
-  let doc =
-    Arg.info ~docs ~doc:"Destination for the logs" [ "log-destination" ]
-  in
-  Arg.(value & opt mk Quiet & doc)
+  Logs.set_reporter reporter

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -480,7 +480,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       max_connections port_forwards dns http hosts host_names gateway_names
       vm_names listen_backlog port_max_idle_time debug
       server_macaddr domain allowed_bind_addresses gateway_ip host_ip lowest_ip highest_ip
-      dhcp_json_path mtu udpv4_forwards tcpv4_forwards gateway_forwards_path gc_compact log_destination
+      dhcp_json_path mtu udpv4_forwards tcpv4_forwards gateway_forwards_path gc_compact
     =
     let level =
       let env_debug =
@@ -488,7 +488,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
         with Not_found -> false
       in
       if debug || env_debug then Some Logs.Debug else Some Logs.Info in
-    Logging.setup log_destination level;
+    Logging.setup level;
 
     if Sys.os_type = "Unix" then begin
       Log.info (fun f -> f "Increasing preemptive thread pool size to 1024 threads");
@@ -837,7 +837,7 @@ let command =
         $ host_names $ gateway_names $ vm_names $ listen_backlog $ port_max_idle_time $ debug
         $ server_macaddr $ domain $ allowed_bind_addresses $ gateway_ip $ host_ip
         $ lowest_ip $ highest_ip $ dhcp_json_path $ mtu $ udpv4_forwards $ tcpv4_forwards
-        $ gateway_forwards_path $ gc_compact $ Logging.log_destination),
+        $ gateway_forwards_path $ gc_compact),
   Term.info (Filename.basename Sys.argv.(0)) ~version:Version.git ~doc ~man
 
 let () =

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -369,12 +369,13 @@ let hvsock_addr_of_uri ~default_serviceid uri =
 
     Host.start_background_gc gc_compact;
 
-    let () = match HostsFile.watch ~path:hosts () with
-    | Ok _       -> ()
-    | Error (`Msg m) ->
-      Log.err (fun f -> f "Failed to watch hosts file %s: %s" hosts m);
-      ()
-    in
+    if hosts <> "" then begin
+      match HostsFile.watch ~path:hosts () with
+      | Ok _       -> ()
+      | Error (`Msg m) ->
+        Log.err (fun f -> f "Failed to watch hosts file %s: %s" hosts m);
+        ()
+    end;
 
     List.iter
       (fun url ->

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -24,7 +24,7 @@ let log_exception_continue description f =
   Lwt.catch
     (fun () -> f ())
     (fun e ->
-       Log.err (fun f -> f "%s: failed with %a" description Fmt.exn e);
+       Log.warn (fun f -> f "%s: failed with %a" description Fmt.exn e);
        Lwt.return ()
     )
 

--- a/src/hostnet/forward.ml
+++ b/src/hostnet/forward.ml
@@ -13,7 +13,7 @@ let log_exception_continue description f =
   Lwt.catch
     (fun () -> f ())
     (fun e ->
-       Log.err (fun f -> f "%s: caught %a" description Fmt.exn e);
+       Log.warn (fun f -> f "%s: caught %a" description Fmt.exn e);
        Lwt.return ())
 
 let allowed_addresses = ref None

--- a/src/hostnet/host.ml
+++ b/src/hostnet/host.ml
@@ -13,7 +13,7 @@ let log_exception_continue description f =
   Lwt.catch
     (fun () -> f ())
     (fun e ->
-       Log.err (fun f -> f "%s: caught %s" description (Printexc.to_string e));
+       Log.warn (fun f -> f "%s: caught %s" description (Printexc.to_string e));
        Lwt.return ()
     )
 

--- a/src/hostnet/host.ml
+++ b/src/hostnet/host.ml
@@ -10,10 +10,13 @@ module Log = (val Logs.src_log src : Logs.LOG)
 let default_read_buffer_size = 65536
 
 let log_exception_continue description f =
+  let to_string = function
+    | Failure x -> x
+    | e -> Printexc.to_string e in
   Lwt.catch
     (fun () -> f ())
     (fun e ->
-       Log.warn (fun f -> f "%s: caught %s" description (Printexc.to_string e));
+       Log.warn (fun f -> f "%s: %s" description (to_string e));
        Lwt.return ()
     )
 

--- a/src/hostnet/hostnet_dns.ml
+++ b/src/hostnet/hostnet_dns.ml
@@ -91,6 +91,8 @@ module Policy(Files: Sig.FILES) = struct
               add ~priority:2 ~config:(`Upstream servers)
           )
       ) with
+    | Error (`Msg "ENOENT") ->
+      Log.info (fun f -> f "Not watching %s because it does not exist" resolv_conf)
     | Error (`Msg m) ->
       Log.info (fun f -> f "Cannot watch %s: %s" resolv_conf m)
     | Ok _watch ->

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -1418,6 +1418,9 @@ struct
       Log.info (fun f -> f "Reading gateway forwards file from %s" path);
       Host.Files.read_file path
       >>= function
+      | Error (`Msg "ENOENT") ->
+        Log.info (fun f -> f "Not reading gateway forwards file %s becuase it does not exist" path);
+        Lwt.return_unit
       | Error (`Msg m) ->
         Log.err (fun f -> f "Failed to read gateway forwards from %s: %s." path m);
         Gateway_forwards.update [];
@@ -1444,6 +1447,8 @@ struct
               )
           )
         ) with
+      | Error (`Msg "ENOENT") ->
+        Log.info (fun f -> f "Not watching gateway forwards file %s because it does not exist" path)
       | Error (`Msg m) ->
         Log.err (fun f -> f "Failed to watch gateway forwards file %s for changes: %s" path m)
       | Ok _watch ->

--- a/src/hostnet/vmnet.ml
+++ b/src/hostnet/vmnet.ml
@@ -249,9 +249,9 @@ module Make(C: Sig.CONN) = struct
   let get_client_macaddr t =
     t.client_macaddr
 
-  let err_eof = Lwt_result.fail (`Msg "error: got EOF")
-  let err_read e = failf "error while reading: %a" Channel.pp_error e
-  let err_flush e = failf "error while flushing: %a" Channel.pp_write_error e
+  let err_eof = Lwt_result.fail (`Msg "EOF")
+  let err_read e = failf "while reading: %a" Channel.pp_error e
+  let err_flush e = failf "while flushing: %a" Channel.pp_write_error e
 
   let with_read x f =
     x >>= function

--- a/src/hostnet/vmnet.ml
+++ b/src/hostnet/vmnet.ml
@@ -518,7 +518,7 @@ module Make(C: Sig.CONN) = struct
       )
 
   let err_eof t =
-    Log.err (fun f -> f "%s.listen: read EOF so closing connection" t.log_prefix);
+    Log.info (fun f -> f "%s.listen: read EOF so closing connection" t.log_prefix);
     disconnect t >>= fun () ->
     Lwt.return false
 

--- a/vpnkit.opam
+++ b/vpnkit.opam
@@ -45,8 +45,6 @@ depends: [
   "charrua-core" {>= "0.9"}
   "charrua-client-mirage" {test & = "0.9"}
   "hvsock" {>= "1.0.1"}
-  "asl"
-  "win-eventlog"
   "fd-send-recv" {>= "2.0.0"}
   "logs"
   "fmt"


### PR DESCRIPTION
Previously we supported 3 log "destinations":
1. `quiet`: stderr
2. `asl`: the Apple System Log
3. `eventlog`: the Windows event log

This PR removes the `asl` and `eventlog` systems to simplify the build dependencies. The `eventlog` mode was never used anywhere and I'm not sure if it's implemented correctly. The `asl` mode is being used in Docker Desktop but this isn't a good idea: the system logs are difficult to filter and full of spam. It's much easier to simply log to stderr and rely on another tool to send the logs to the correct destination (e.g. `docker logs`)

At the same time the output format has been changed to resemble other Go programs for consistency, e.g.:

```
time="2021-04-17T10:56:51Z" level=info msg="usernet: Increasing preemptive thread pool size to 1024 threads"
```

Plus a few error logs have been downgraded to info where they are normal e.g. `/etc/resolv.conf` doesn't exist on Windows; receiving `EOF` from a disconnecting client is normal.