### PR TITLE
Bump base64 to >= 3.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,20 +21,20 @@ jobs:
       - run: brew install opam
       # Build the OCaml compiler
       - restore_cache:
-           key: ocaml-cache
+           key: ocaml-cache-{{ checksum "Makefile.darwin"}}
       - run: make -f Makefile.darwin ocaml
       - save_cache:
            paths:
              - /Users/distiller/.opam
-           key: ocaml-cache
+           key: ocaml-cache-{{ checksum "Makefile.darwin"}}
       # Build the OCaml dependencies, make sure the cache is cleared if the dependencies change.
       - restore_cache:
-           key: depends-cache-{{ checksum "vpnkit.opam" }}
+           key: depends-cache-{{ checksum "vpnkit.opam" }}-{{ checksum "Makefile.darwin"}}
       - run: make -f Makefile.darwin depends
       - save_cache:
            paths:
              - /Users/distiller/.opam
-           key: depends-cache-{{ checksum "vpnkit.opam" }}
+           key: depends-cache-{{ checksum "vpnkit.opam" }}-{{ checksum "Makefile.darwin"}}
       - run: make -f Makefile.darwin build
       - run: make -f Makefile.darwin artefacts
       - store_artifacts:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,10 @@ FROM ocaml/opam2:alpine-3.10-ocaml-4.10 as build
 # Not in the opam-repository metadata in the image. Remove after the image is updated:
 RUN opam pin add lwt.5.4.0 https://github.com/ocsigen/lwt/archive/5.4.0.zip -n
 RUN opam pin add fd-send-recv.2.0.1 https://github.com/xapi-project/ocaml-fd-send-recv/archive/v2.0.1.tar.gz -n
+RUN opam pin add hvsock.2.0.0 https://github.com/mirage/ocaml-hvsock/archive/2.0.0.tar.gz -n
 
 # A small fork of the tcpip stack
 RUN opam pin add tcpip.3.3.0 "https://github.com/djs55/mirage-tcpip.git#vpnkit-20210417" -n
-# This has been released in version 2 but with some other incompatible changes
-RUN opam pin add hvsock.1.0.1 "git://github.com/djs55/ocaml-hvsock.git#relative-paths" -n
 
 ADD . /home/opam/src
 RUN opam pin add -y -n vpnkit /home/opam/src

--- a/Makefile.darwin
+++ b/Makefile.darwin
@@ -11,7 +11,6 @@ depends:
 ocaml:
 	ocaml -version || opam init --compiler=4.10.0
 	opam pin add tcpip.3.3.0 "https://github.com/djs55/mirage-tcpip.git#vpnkit-20210417" -n
-	opam pin add hvsock.1.0.1 "git://github.com/djs55/ocaml-hvsock.git#relative-paths" -n
 	opam pin add vpnkit . -n
 
 artefacts: vpnkit.tgz

--- a/src/hostnet/forward.ml
+++ b/src/hostnet/forward.ml
@@ -37,7 +37,7 @@ module Port = struct
     | `Udp (ip, port) ->
       Fmt.strf "udp:%a:%d" Ipaddr.pp_hum ip port
     | `Unix path ->
-      Fmt.strf "unix:%s" (B64.encode path)
+      Fmt.strf "unix:%s" (Base64.encode_exn path)
 
   let of_string x =
     try
@@ -50,7 +50,7 @@ module Port = struct
         | "udp" -> Ok (`Udp(ip, port))
         | _ -> errorf "unknown protocol: should be tcp or udp"
         end
-      | [ "unix"; path ] -> Ok (`Unix (B64.decode path))
+      | [ "unix"; path ] -> Ok (`Unix (Base64.decode_exn path))
       | _ -> errorf "port should be of the form proto:IP:port or unix:path"
     with
     | _ -> errorf "port is not a proto:IP:port or unix:path: '%s'" x

--- a/src/hostnet/hostnet_http.ml
+++ b/src/hostnet/hostnet_http.ml
@@ -412,7 +412,7 @@ module Make
     let headers = Cohttp.Header.remove headers proxy_authorization in
     match Uri.userinfo proxy with
       | None -> headers
-      | Some s -> Cohttp.Header.add headers proxy_authorization ("Basic " ^ (B64.encode s))
+      | Some s -> Cohttp.Header.add headers proxy_authorization ("Basic " ^ (Base64.encode_exn s))
 
   let address_of_proxy ~localhost_names ~localhost_ips proxy =
     match Uri.host proxy, Uri.port proxy with

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -322,7 +322,7 @@ let test_proxy_authorization proxy () =
     | Some username, Some password ->
       Alcotest.check Alcotest.(list string) proxy_authorization
         (result.Cohttp.Request.headers |> Cohttp.Header.to_list |> List.filter (fun (k, _) -> k = proxy_authorization) |> List.map snd)
-        [ "Basic " ^ (B64.encode (username ^ ":" ^ password)) ]
+        [ "Basic " ^ (Base64.encode_exn (username ^ ":" ^ password)) ]
     | _, _ ->
       Alcotest.check Alcotest.(list string) proxy_authorization
         (result.Cohttp.Request.headers |> Cohttp.Header.to_list |> List.filter (fun (k, _) -> k = proxy_authorization) |> List.map snd)
@@ -371,7 +371,7 @@ let test_http_connect_tunnel proxy () =
               | Some username, Some password ->
                 Alcotest.check Alcotest.(list string) proxy_authorization
                   (req.Cohttp.Request.headers |> Cohttp.Header.to_list |> List.filter (fun (k, _) -> k = proxy_authorization) |> List.map snd)
-                  [ "Basic " ^ (B64.encode (username ^ ":" ^ password)) ]
+                  [ "Basic " ^ (Base64.encode_exn (username ^ ":" ^ password)) ]
               | _, _ ->
                 Alcotest.check Alcotest.(list string) proxy_authorization
                   (req.Cohttp.Request.headers |> Cohttp.Header.to_list |> List.filter (fun (k, _) -> k = proxy_authorization) |> List.map snd)
@@ -450,7 +450,7 @@ let test_http_connect_tunnel proxy () =
                 begin match Uri.user proxy, Uri.password proxy with
                 | Some username, Some password ->
                   Alcotest.check Alcotest.(list string) proxy_authorization
-                    [ "Basic " ^ (B64.encode (username ^ ":" ^ password)) ]
+                    [ "Basic " ^ (Base64.encode_exn (username ^ ":" ^ password)) ]
                     (req.Cohttp.Request.headers |> Cohttp.Header.to_list |> List.filter (fun (k, _) -> k = proxy_authorization) |> List.map snd)
                 | _, _ ->
                   Alcotest.check Alcotest.(list string) proxy_authorization

--- a/vpnkit.opam
+++ b/vpnkit.opam
@@ -34,7 +34,7 @@ depends: [
   "dns-lwt"
   "dnssd" {>= "0.2"}
   "dns-forward" {>= "0.10.0"}
-  "base64" {= "2.2.0"}
+  "base64" {>= "3.0.0"}
   "cstruct" {= "3.2.1"}
   "cstruct-lwt" {= "3.2.1"}
   "datakit-server" {>= "0.11.0"}
@@ -44,7 +44,7 @@ depends: [
   "cmdliner"
   "charrua-core" {>= "0.9"}
   "charrua-client-mirage" {test & = "0.9"}
-  "hvsock" {>= "1.0.1"}
+  "hvsock" {>= "2.0.0"}
   "fd-send-recv" {>= "2.0.0"}
   "logs"
   "fmt"


### PR DESCRIPTION
This also removes the fork of `hvsock`, replacing it with a regular v2.0.0.