### PR TITLE
Exposing a port should be idempotent and fix an ephemeral port leak

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV OPAMJOBS=8
 
 RUN opam install --deps-only vpnkit -y
 
-WORKDIR /home/opam/src
+WORKDIR /home/opam/vpnkit
 RUN opam exec -- sudo dune build --profile release
 
 FROM alpine:latest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,16 +17,7 @@ environment:
   BINDIR: 'C:\projects\vpnkit'
 
 install:
-  - cmd: git config core.symlinks true
-  - cmd: git reset --hard
-  - 'appveyor DownloadFile http://cygwin.com/setup-%CYG_ARCH%.exe -FileName setup.exe'
-  - 'setup.exe -gqnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P make,git,rsync,perl,gcc-core,gcc-g++,libncurses-devel,unzip,libmpfr-devel,patch,flexdll,libglpk-devel'
-  - '%CYG_ROOT%/bin/bash -lc "cygcheck -dc cygwin gcc-core"'
+  - cmd: echo Windows build is disabled until we can remove cygwin.
 
 build_script:
   - "%CYG_BASH% '${APPVEYOR_BUILD_FOLDER}/scripts/appveyor.sh'"
-
-artifacts:
-  - path: "vpnkit.exe"
-  - path: "OSS-LICENSES"
-  - path: "COMMIT"

--- a/go/Makefile
+++ b/go/Makefile
@@ -14,7 +14,7 @@ all: build/vpnkit-iptables-wrapper.linux build/vpnkit-forwarder.linux build/vpnk
 
 # Test
 test:
-	go test -v ./cmd/... ./pkg/...
+	go test -race -v ./cmd/... ./pkg/...
 
 # Build in linux container
 build-in-container: build-forwarder-in-container build-expose-port-in-container build-kube-forwarder-in-container build-dial-example-in-container

--- a/go/pkg/libproxy/loopbackconn.go
+++ b/go/pkg/libproxy/loopbackconn.go
@@ -19,18 +19,15 @@ import (
 type bufferedPipe struct {
 	bufs         [][]byte
 	eof          bool
-	m            *sync.Mutex
+	m            sync.Mutex
 	c            *sync.Cond
 	readDeadline time.Time
 }
 
 func newBufferedPipe() *bufferedPipe {
-	var m sync.Mutex
-	c := sync.NewCond(&m)
-	return &bufferedPipe{
-		m: &m,
-		c: c,
-	}
+	b := &bufferedPipe{}
+	b.c = sync.NewCond(&b.m)
+	return b
 }
 
 func (pipe *bufferedPipe) TryReadLocked(p []byte) (n int, err error) {

--- a/go/pkg/libproxy/multiplexed.go
+++ b/go/pkg/libproxy/multiplexed.go
@@ -461,13 +461,15 @@ func (m *multiplexer) Dial(d Destination) (Conn, error) {
 	return channel, nil
 }
 
+var ErrNotRunning = errors.New("multiplexer is not running")
+
 // Accept returns the next client connection
 func (m *multiplexer) Accept() (Conn, *Destination, error) {
 	m.metadataMutex.Lock()
 	defer m.metadataMutex.Unlock()
 	for {
 		if !m.isRunning {
-			return nil, nil, errors.New("accept: multiplexer is not running")
+			return nil, nil, ErrNotRunning
 		}
 		if len(m.pendingAccept) > 0 {
 			first := m.pendingAccept[0]

--- a/go/pkg/libproxy/multiplexed_test.go
+++ b/go/pkg/libproxy/multiplexed_test.go
@@ -489,7 +489,7 @@ func TestMuxReadWrite(t *testing.T) {
 func TestMuxConcurrent(t *testing.T) {
 	loopback := newLoopback()
 	local, remote := newLoopbackMultiplexer(t, loopback)
-	numConcurrent := 1000
+	numConcurrent := 500 // limited by the race detector
 	toWrite := 65536 * 2 // 2 * Window size
 	wg := &sync.WaitGroup{}
 	serverWriteSha := make(map[uint16]string)

--- a/go/pkg/libproxy/udp_encapsulation.go
+++ b/go/pkg/libproxy/udp_encapsulation.go
@@ -27,9 +27,9 @@ type uDPEncapsulator interface {
 // udpEncapsulator encapsulates a UDP connection and listener
 type udpEncapsulator struct {
 	conn net.Conn
-	m    *sync.Mutex
-	r    *sync.Mutex
-	w    *sync.Mutex
+	m    sync.Mutex
+	r    sync.Mutex
+	w    sync.Mutex
 	addr *net.UDPAddr
 }
 
@@ -100,14 +100,8 @@ func (u *udpEncapsulator) Connect(a *net.UDPAddr) {
 
 // newUDPConn initializes a new UDP connection
 func newUDPConn(conn net.Conn) uDPEncapsulator {
-	var m sync.Mutex
-	var r sync.Mutex
-	var w sync.Mutex
 	return &udpEncapsulator{
 		conn: conn,
-		m:    &m,
-		r:    &r,
-		w:    &w,
 	}
 }
 

--- a/go/pkg/vpnkit/client.go
+++ b/go/pkg/vpnkit/client.go
@@ -95,7 +95,12 @@ func (h *httpClient) Unexpose(_ context.Context, port *Port) error {
 	if port.Proto == Unix {
 		path = UnexposePipePath
 	}
-	res, err := h.client.Post("http://unix"+path, "application/json", &buf)
+	request, err := http.NewRequest("DELETE", "http://unix"+path, &buf)
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	res, err := h.client.Do(request)
 	if err != nil {
 		return err
 	}

--- a/go/pkg/vpnkit/client.go
+++ b/go/pkg/vpnkit/client.go
@@ -60,7 +60,12 @@ func (h *httpClient) Expose(_ context.Context, port *Port) error {
 	if port.Proto == Unix {
 		path = ExposePipePath
 	}
-	res, err := h.client.Post("http://unix"+path, "application/json", &buf)
+	request, err := http.NewRequest("PUT", "http://unix"+path, &buf)
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	res, err := h.client.Do(request)
 	if err != nil {
 		return err
 	}

--- a/go/pkg/vpnkit/control/control.go
+++ b/go/pkg/vpnkit/control/control.go
@@ -19,23 +19,18 @@ import (
 type Control struct {
 	Forwarder forward.Maker // Forwarder makes local port forwards
 	mux       libproxy.Multiplexer
-	muxM      *sync.Mutex
+	muxM      sync.Mutex
 	muxC      *sync.Cond
 	forwards  map[string]forward.Forward
-	forwardsM *sync.Mutex
+	forwardsM sync.Mutex
 }
 
 func Make() *Control {
-	var muxM sync.Mutex
-	muxC := sync.NewCond(&muxM)
-	var outsidesM sync.Mutex
-	outsides := make(map[string]forward.Forward)
-	return &Control{
-		muxM:      &muxM,
-		muxC:      muxC,
-		forwards:  outsides,
-		forwardsM: &outsidesM,
+	c := &Control{
+		forwards: make(map[string]forward.Forward),
 	}
+	c.muxC = sync.NewCond(&c.muxM)
+	return c
 }
 
 func (c *Control) SetMux(m libproxy.Multiplexer) {

--- a/go/pkg/vpnkit/control/control.go
+++ b/go/pkg/vpnkit/control/control.go
@@ -64,7 +64,8 @@ func (c *Control) Expose(_ context.Context, port *vpnkit.Port) error {
 	c.forwardsM.Lock()
 	defer c.forwardsM.Unlock()
 	if _, ok := c.forwards[key]; ok {
-		return errors.New("port already exposed: " + port.String())
+		// ensure Expose is idempotent
+		return nil
 	}
 	forward, err := c.Forwarder.Make(c, *port)
 	if err != nil {

--- a/go/pkg/vpnkit/control/control.go
+++ b/go/pkg/vpnkit/control/control.go
@@ -75,6 +75,10 @@ func (c *Control) Expose(_ context.Context, port *vpnkit.Port) error {
 			Message: err.Error(),
 		}
 	}
+	// If the request port was 0 (meaning any) we should use the concrete port
+	// in the table so that we can `Unexpose()` the results of `ListExposed()`.
+	resolvedPort := forward.Port()
+	key = portKey(&resolvedPort)
 	c.forwards[key] = forward
 	go forward.Run()
 	return nil

--- a/go/pkg/vpnkit/control/control_test.go
+++ b/go/pkg/vpnkit/control/control_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/moby/vpnkit/go/pkg/vpnkit"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExposeIdempotent(t *testing.T) {
@@ -20,4 +21,23 @@ func TestExposeIdempotent(t *testing.T) {
 	}
 	assert.Nil(t, c.Expose(context.Background(), p))
 	assert.Nil(t, c.Expose(context.Background(), p))
+}
+
+func TestExposeAnyThenListAndUnexpose(t *testing.T) {
+	c := Make()
+	p := &vpnkit.Port{
+		Proto:   vpnkit.TCP,
+		OutIP:   net.ParseIP("127.0.0.1"),
+		InIP:    net.ParseIP("127.0.0.1"),
+		OutPort: 0, // Any port will do
+		InPort:  8080,
+	}
+	assert.Nil(t, c.Expose(context.Background(), p))
+	all, err := c.ListExposed(context.Background())
+	require.Nil(t, err)
+	require.Len(t, all, 1)
+	assert.Nil(t, c.Unexpose(context.Background(), &all[0]))
+	all, err = c.ListExposed(context.Background())
+	require.Nil(t, err)
+	assert.Len(t, all, 0)
 }

--- a/go/pkg/vpnkit/control/control_test.go
+++ b/go/pkg/vpnkit/control/control_test.go
@@ -1,0 +1,23 @@
+package control
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/moby/vpnkit/go/pkg/vpnkit"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExposeIdempotent(t *testing.T) {
+	c := Make()
+	p := &vpnkit.Port{
+		Proto:   vpnkit.TCP,
+		OutIP:   net.ParseIP("127.0.0.1"),
+		InIP:    net.ParseIP("127.0.0.1"),
+		OutPort: 8080,
+		InPort:  8080,
+	}
+	assert.Nil(t, c.Expose(context.Background(), p))
+	assert.Nil(t, c.Expose(context.Background(), p))
+}

--- a/go/pkg/vpnkit/http/http.go
+++ b/go/pkg/vpnkit/http/http.go
@@ -52,9 +52,17 @@ func NewServer(path string, impl vpnkit.Implementation) (Server, error) {
 	e.POST(vpnkit.ExposePipePath, func(c echo.Context) error {
 		return h.ExposePipe(c)
 	})
+	e.DELETE(vpnkit.UnexposePortPath, func(c echo.Context) error {
+		return h.UnexposePort(c)
+	})
+	// for backwards compat
 	e.POST(vpnkit.UnexposePortPath, func(c echo.Context) error {
 		return h.UnexposePort(c)
 	})
+	e.DELETE(vpnkit.UnexposePipePath, func(c echo.Context) error {
+		return h.UnexposePipe(c)
+	})
+	// for backwards compat
 	e.POST(vpnkit.UnexposePipePath, func(c echo.Context) error {
 		return h.UnexposePipe(c)
 	})

--- a/go/pkg/vpnkit/http/http.go
+++ b/go/pkg/vpnkit/http/http.go
@@ -38,9 +38,17 @@ func NewServer(path string, impl vpnkit.Implementation) (Server, error) {
 		impl,
 	}
 
+	e.PUT(vpnkit.ExposePortPath, func(c echo.Context) error {
+		return h.ExposePort(c)
+	})
+	// for backwards compat
 	e.POST(vpnkit.ExposePortPath, func(c echo.Context) error {
 		return h.ExposePort(c)
 	})
+	e.PUT(vpnkit.ExposePipePath, func(c echo.Context) error {
+		return h.ExposePipe(c)
+	})
+	// for backwards compat
 	e.POST(vpnkit.ExposePipePath, func(c echo.Context) error {
 		return h.ExposePipe(c)
 	})

--- a/scripts/appveyor.sh
+++ b/scripts/appveyor.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env sh
 
+echo Build is disabled.
+exit 0
+
 set -eu
 
 cd "${APPVEYOR_BUILD_FOLDER}"


### PR DESCRIPTION
Previously attempting to expose an existing port would return an error, which becomes an HTTP 500 internal server error.

This patch makes exposing a port idempotent, just like un-exposing a port already is.

Previously there was a port leak if the user requested any port (`0`) because we would store `0` in our map, and then look up the real port in `Unexpose` and fail to find it.

To make the API clearer, we switch to `PUT` and `DELETE` (instead of `POST`) but for backwards compatibility retain the `POST` handlers.

Minor additional updates:
- switch from `*sync.Mutex` to `sync.Mutex` where we are already using a pointer receiver, since the `nil` value is a valid mutex
- run the unit tests with the race detector enabled
- avoid logging as errors 3 expected conditions (all variations of an `EOF` on shutdown)