### PR TITLE
Update base image and cleanup Dockerfile for kube-vpnkit-forwarder

### DIFF
--- a/go/Dockerfile.kube-forwarder
+++ b/go/Dockerfile.kube-forwarder
@@ -1,15 +1,11 @@
-FROM linuxkit/alpine:77f48acc94bdda04e7be1e501a234c2b5c0d6593 AS mirror
+FROM golang:1.16-alpine AS builder
+
+WORKDIR /go/src/github.com/moby/vpnkit/go
+COPY . /go/src/github.com/moby/vpnkit
 
 RUN apk add --no-cache go musl-dev gcc
-
-COPY . /go/src/github.com/moby/vpnkit
-WORKDIR /go/src/github.com/moby/vpnkit/go
-RUN go-compile.sh /go/src/github.com/moby/vpnkit/go/cmd/kube-vpnkit-forwarder
+RUN GOPATH=/go CGO_ENABLED=1 go build -buildmode pie -ldflags "-linkmode=external -s -extldflags \"-fno-PIC -static\"" -o /kube-vpnkit-forwarder /go/src/github.com/moby/vpnkit/go/cmd/kube-vpnkit-forwarder/main.go
 
 FROM scratch
-ENTRYPOINT []
-CMD []
-WORKDIR /
-COPY --from=mirror /go/bin/kube-vpnkit-forwarder /usr/bin/kube-vpnkit-forwarder
-COPY --from=mirror /go/bin/kube-vpnkit-forwarder /usr/bin/kube-vpnkit-forwarder
-CMD ["/usr/bin/kube-vpnkit-forwarder"]
+COPY --from=builder /kube-vpnkit-forwarder /kube-vpnkit-forwarder
+CMD ["/kube-vpnkit-forwarder"]


### PR DESCRIPTION
Update `Dockerfile.kube-forwarder` to use golang:1.16-alpine as parent image.