### PR TITLE
Set O_CLOEXEC on received file descriptors

### DIFF
--- a/go/pkg/vpnkit/forward/tcp.go
+++ b/go/pkg/vpnkit/forward/tcp.go
@@ -51,7 +51,7 @@ func (l *tcpListener) accept() (libproxy.Conn, error) {
 }
 
 func (l *tcpListener) close() error {
-	return closeTCP(l.p, l.vmnetd, l.l)
+	return l.l.Close()
 }
 
 func makeTCP(c common, n TCPNetwork) (Forward, error) {

--- a/go/pkg/vpnkit/forward/tcp.go
+++ b/go/pkg/vpnkit/forward/tcp.go
@@ -14,7 +14,7 @@ import (
 type TCPNetwork struct{}
 
 func (t TCPNetwork) listen(port vpnkit.Port) (listener, error) {
-	l, vmnetd, err := listenTCP(port)
+	l, err := listenTCP(port)
 	if err != nil {
 		return nil, err
 	}
@@ -25,17 +25,15 @@ func (t TCPNetwork) listen(port vpnkit.Port) (listener, error) {
 		}
 	}
 	wrapped := &tcpListener{
-		l:      l,
-		vmnetd: vmnetd,
-		p:      port,
+		l: l,
+		p: port,
 	}
 	return wrapped, nil
 }
 
 type tcpListener struct {
-	l      net.Listener
-	vmnetd bool
-	p      vpnkit.Port
+	l net.Listener
+	p vpnkit.Port
 }
 
 func (l *tcpListener) accept() (libproxy.Conn, error) {

--- a/go/pkg/vpnkit/forward/tcp_darwin.go
+++ b/go/pkg/vpnkit/forward/tcp_darwin.go
@@ -21,10 +21,3 @@ func listenTCP(port vpnkit.Port) (net.Listener, bool, error) {
 	}
 	return l, false, err
 }
-
-func closeTCP(port vpnkit.Port, vmnetd bool, l net.Listener) error {
-	if vmnetd {
-		return closeTCPVmnet(port.OutIP, port.OutPort, l)
-	}
-	return l.Close()
-}

--- a/go/pkg/vpnkit/forward/tcp_darwin.go
+++ b/go/pkg/vpnkit/forward/tcp_darwin.go
@@ -8,7 +8,7 @@ import (
 	"github.com/moby/vpnkit/go/pkg/vpnkit"
 )
 
-func listenTCP(port vpnkit.Port) (*net.TCPListener, bool, error) {
+func listenTCP(port vpnkit.Port) (net.Listener, bool, error) {
 	l, err := net.ListenTCP("tcp", &net.TCPAddr{
 		IP:   port.OutIP,
 		Port: int(port.OutPort),
@@ -22,7 +22,7 @@ func listenTCP(port vpnkit.Port) (*net.TCPListener, bool, error) {
 	return l, false, err
 }
 
-func closeTCP(port vpnkit.Port, vmnetd bool, l *net.TCPListener) error {
+func closeTCP(port vpnkit.Port, vmnetd bool, l net.Listener) error {
 	if vmnetd {
 		return closeTCPVmnet(port.OutIP, port.OutPort, l)
 	}

--- a/go/pkg/vpnkit/forward/tcp_darwin.go
+++ b/go/pkg/vpnkit/forward/tcp_darwin.go
@@ -8,7 +8,7 @@ import (
 	"github.com/moby/vpnkit/go/pkg/vpnkit"
 )
 
-func listenTCP(port vpnkit.Port) (net.Listener, bool, error) {
+func listenTCP(port vpnkit.Port) (net.Listener, error) {
 	l, err := net.ListenTCP("tcp", &net.TCPAddr{
 		IP:   port.OutIP,
 		Port: int(port.OutPort),
@@ -17,7 +17,7 @@ func listenTCP(port vpnkit.Port) (net.Listener, bool, error) {
 	if err != nil && isPermissionDenied(err) {
 		// fall back to vmnetd
 		l, err := listenTCPVmnet(port.OutIP, port.OutPort)
-		return l, true, err
+		return l, err
 	}
-	return l, false, err
+	return l, err
 }

--- a/go/pkg/vpnkit/forward/tcp_linux.go
+++ b/go/pkg/vpnkit/forward/tcp_linux.go
@@ -13,7 +13,3 @@ func listenTCP(port vpnkit.Port) (net.Listener, bool, error) {
 	})
 	return l, false, err
 }
-
-func closeTCP(port vpnkit.Port, _ bool, l net.Listener) error {
-	return l.Close()
-}

--- a/go/pkg/vpnkit/forward/tcp_linux.go
+++ b/go/pkg/vpnkit/forward/tcp_linux.go
@@ -6,10 +6,10 @@ import (
 	"github.com/moby/vpnkit/go/pkg/vpnkit"
 )
 
-func listenTCP(port vpnkit.Port) (net.Listener, bool, error) {
+func listenTCP(port vpnkit.Port) (net.Listener, error) {
 	l, err := net.ListenTCP("tcp", &net.TCPAddr{
 		IP:   port.OutIP,
 		Port: int(port.OutPort),
 	})
-	return l, false, err
+	return l, err
 }

--- a/go/pkg/vpnkit/forward/tcp_linux.go
+++ b/go/pkg/vpnkit/forward/tcp_linux.go
@@ -6,7 +6,7 @@ import (
 	"github.com/moby/vpnkit/go/pkg/vpnkit"
 )
 
-func listenTCP(port vpnkit.Port) (*net.TCPListener, bool, error) {
+func listenTCP(port vpnkit.Port) (net.Listener, bool, error) {
 	l, err := net.ListenTCP("tcp", &net.TCPAddr{
 		IP:   port.OutIP,
 		Port: int(port.OutPort),
@@ -14,6 +14,6 @@ func listenTCP(port vpnkit.Port) (*net.TCPListener, bool, error) {
 	return l, false, err
 }
 
-func closeTCP(port vpnkit.Port, _ bool, l *net.TCPListener) error {
+func closeTCP(port vpnkit.Port, _ bool, l net.Listener) error {
 	return l.Close()
 }

--- a/go/pkg/vpnkit/forward/tcp_windows.go
+++ b/go/pkg/vpnkit/forward/tcp_windows.go
@@ -13,7 +13,3 @@ func listenTCP(port vpnkit.Port) (net.Listener, bool, error) {
 	})
 	return l, false, err
 }
-
-func closeTCP(port vpnkit.Port, _ bool, l net.Listener) error {
-	return l.Close()
-}

--- a/go/pkg/vpnkit/forward/tcp_windows.go
+++ b/go/pkg/vpnkit/forward/tcp_windows.go
@@ -6,10 +6,10 @@ import (
 	"github.com/moby/vpnkit/go/pkg/vpnkit"
 )
 
-func listenTCP(port vpnkit.Port) (net.Listener, bool, error) {
+func listenTCP(port vpnkit.Port) (net.Listener, error) {
 	l, err := net.ListenTCP("tcp", &net.TCPAddr{
 		IP:   port.OutIP,
 		Port: int(port.OutPort),
 	})
-	return l, false, err
+	return l, err
 }

--- a/go/pkg/vpnkit/forward/tcp_windows.go
+++ b/go/pkg/vpnkit/forward/tcp_windows.go
@@ -6,7 +6,7 @@ import (
 	"github.com/moby/vpnkit/go/pkg/vpnkit"
 )
 
-func listenTCP(port vpnkit.Port) (*net.TCPListener, bool, error) {
+func listenTCP(port vpnkit.Port) (net.Listener, bool, error) {
 	l, err := net.ListenTCP("tcp", &net.TCPAddr{
 		IP:   port.OutIP,
 		Port: int(port.OutPort),
@@ -14,6 +14,6 @@ func listenTCP(port vpnkit.Port) (*net.TCPListener, bool, error) {
 	return l, false, err
 }
 
-func closeTCP(port vpnkit.Port, _ bool, l *net.TCPListener) error {
+func closeTCP(port vpnkit.Port, _ bool, l net.Listener) error {
 	return l.Close()
 }

--- a/go/pkg/vpnkit/forward/udp_darwin.go
+++ b/go/pkg/vpnkit/forward/udp_darwin.go
@@ -20,28 +20,7 @@ func listenUDP(port vpnkit.Port) (libproxy.UDPListener, error) {
 		if err != nil {
 			return nil, err
 		}
-		return &wrappedCloser{port, l}, nil
+		return l, nil
 	}
 	return l, err
-}
-
-type wrappedCloser struct {
-	port vpnkit.Port
-	l    libproxy.UDPListener
-}
-
-func (w *wrappedCloser) ReadFromUDP(b []byte) (int, *net.UDPAddr, error) {
-	return w.l.ReadFromUDP(b)
-}
-
-func (w *wrappedCloser) WriteToUDP(b []byte, addr *net.UDPAddr) (int, error) {
-	return w.l.WriteToUDP(b, addr)
-}
-
-func (w *wrappedCloser) Close() error {
-	return closeUDPVmnet(w.port.OutIP, w.port.OutPort, w.l)
-}
-
-func (w *wrappedCloser) LocalAddr() net.Addr {
-	return w.l.LocalAddr()
 }

--- a/go/pkg/vpnkit/forward/vmnet_darwin.go
+++ b/go/pkg/vpnkit/forward/vmnet_darwin.go
@@ -16,7 +16,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func listenTCPVmnet(IP net.IP, Port uint16) (*net.TCPListener, error) {
+func listenTCPVmnet(IP net.IP, Port uint16) (net.Listener, error) {
 	// I don't think it's possible to make a net.TCPListener from a raw file descriptor
 	// so we use a hack: we create a net.TCPListener listening on a random port and then
 	// use the `SyscallConn` low-level interface to replace the file descriptor with a
@@ -51,7 +51,7 @@ func listenTCPVmnet(IP net.IP, Port uint16) (*net.TCPListener, error) {
 	return l, err
 }
 
-func closeTCPVmnet(IP net.IP, Port uint16, l *net.TCPListener) error {
+func closeTCPVmnet(IP net.IP, Port uint16, l net.Listener) error {
 	errCh := make(chan error)
 	go func() {
 		errCh <- l.Close()

--- a/go/pkg/vpnkit/forward/vmnet_darwin_test.go
+++ b/go/pkg/vpnkit/forward/vmnet_darwin_test.go
@@ -177,13 +177,7 @@ func TestBindUDPVmnetdClose(t *testing.T) {
 	localhost := net.ParseIP("127.0.0.1")
 	f, err := listenUDPVmnet(localhost, 8081)
 	assert.Nil(t, err)
-	go func() {
-		buf := make([]byte, 1024)
-		_, _, err := f.ReadFromUDP(buf)
-		assert.Nil(t, err)
-	}()
-	time.Sleep(10 * time.Millisecond)
-	assert.Nil(t, closeUDPVmnet(localhost, 8081, f))
+	assert.Nil(t, f.Close())
 }
 
 func TestBindTCPVmnetdCloseLeak(t *testing.T) {

--- a/go/pkg/vpnkit/forward/vmnet_darwin_test.go
+++ b/go/pkg/vpnkit/forward/vmnet_darwin_test.go
@@ -139,14 +139,13 @@ func TestBindTCPVmnetdClose(t *testing.T) {
 	f, err := listenTCPVmnet(localhost, 8081)
 	assert.Nil(t, err)
 	go func() {
-		c, err := f.Accept()
+		c, _ := f.Accept()
 		if c != nil {
 			c.Close()
 		}
-		assert.Nil(t, err)
 	}()
 	time.Sleep(10 * time.Millisecond)
-	assert.Nil(t, closeTCPVmnet(localhost, 8081, f))
+	assert.Nil(t, f.Close())
 }
 
 func TestBindTCPForkExec(t *testing.T) {

--- a/go/pkg/vpnkit/forward/vmnet_darwin_test.go
+++ b/go/pkg/vpnkit/forward/vmnet_darwin_test.go
@@ -213,22 +213,20 @@ func TestListenUDPMojave2(t *testing.T) {
 
 func TestListenTCPMojave1(t *testing.T) {
 	// On Mojave this will not need vmnetd
-	l, vmnetd, err := listenTCP(vpnkit.Port{
+	l, err := listenTCP(vpnkit.Port{
 		OutIP:   net.ParseIP("0.0.0.0"),
 		OutPort: 80,
 	})
 	assert.Nil(t, err)
-	assert.Equal(t, false, vmnetd)
 	assert.Nil(t, l.Close())
 }
 
 func TestListenTCPMojave2(t *testing.T) {
 	// On Mojave this will need vmnetd
-	l, vmnetd, err := listenTCP(vpnkit.Port{
+	l, err := listenTCP(vpnkit.Port{
 		OutIP:   net.ParseIP("127.0.0.1"),
 		OutPort: 80,
 	})
 	assert.Nil(t, err)
-	assert.Equal(t, true, vmnetd)
 	assert.Nil(t, l.Close())
 }

--- a/go/pkg/vpnkit/forward/vmnet_darwin_test.go
+++ b/go/pkg/vpnkit/forward/vmnet_darwin_test.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os/exec"
 	"syscall"
 
 	"github.com/moby/vpnkit/go/pkg/vpnkit"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"testing"
 	"time"
@@ -145,6 +147,30 @@ func TestBindTCPVmnetdClose(t *testing.T) {
 	}()
 	time.Sleep(10 * time.Millisecond)
 	assert.Nil(t, closeTCPVmnet(localhost, 8081, f))
+}
+
+func TestBindTCPForkExec(t *testing.T) {
+	localhost := net.ParseIP("127.0.0.1")
+	f, err := listenTCPVmnet(localhost, 8081)
+	require.Nil(t, err)
+	// Port is in use:
+	_, err = listenTCPVmnet(localhost, 8081)
+	assert.NotNil(t, err)
+	// A subprocess should not capture the fd:
+	cat := exec.Command("cat")
+	input, err := cat.StdinPipe()
+	require.Nil(t, err)
+	require.Nil(t, cat.Start())
+
+	// Close the port in the parent
+	require.Nil(t, f.Close())
+	// Reopen the port in the parent. If the child has captured the fd this should fail
+	f, err = listenTCPVmnet(localhost, 8081)
+	require.Nil(t, err)
+	assert.Nil(t, f.Close())
+	require.Nil(t, input.Close())
+	// This should allow the cat process to terminate.
+	assert.Nil(t, cat.Wait())
 }
 
 func TestBindUDPVmnetdClose(t *testing.T) {


### PR DESCRIPTION
By default Go sets `O_CLOEXEC` on file descriptors it creates. This ensures that they aren't accidentally inherited over fork+exec. 

When binding a port on the host we first try `net.Listen`. On modern macOS this works for
- unprivileged ports (> 1024)
- privileged ports on `INADDR_ANY` (all IPs)

Unfortunately it doesn't work for privileged ports on specific IPs, such as `127.0.0.1:80`. For these cases we contact a helper process which runs as root, which binds the port and then uses `sendmsg` to transmit it to us. Unfortunately when we `recvmsg` a file descriptor, the resulting descriptor does not have `O_CLOEXEC` set, so it is captured by future subprocesses. Even if the parent process calls `close()`, the port is still in use by the subprocesses and can't be re-bound. This caused the failure seen in https://github.com/docker/for-mac/issues/5649

The solution is to ensure all file descriptors have `O_CLOEXEC` set. On Linux there's a `sendmsg` flag to set the flag atomically on received fds, but this is missing on Darwin. The best we can do is to call `fcntl` to set the flag ourselves after receiving the fd. Unfortunately this means there's a small race window where a fork would inherit the fd, but this shouldn't happen very often in practice.

Go will call `fcntl` for us if we "adopt" the file descriptor using `os.NewFile` and then use `net.FileListener` and `net.FilePacketConn`. This allows us to remove a lot of complicated wrapping code and allows us to remove a workaround for `Close` hanging when blocked in `Accept`, caused by the state of the file descriptor not being correct. This required some minor changes to types (`net.Listener` rather than `*net.TCPListener`) but it's worth it.

It's possible to work around this problem in other ways in the client code, for example:

1. always speculatively closing file descriptors after `fork` but before `exec`. This can be expensive with high `ulimit` values, if there is no API to enumerate open fds. I'm not sure it can be done easily in Go where the `exec.Command` API is high-level.
2. ban running long-lived subprocesses in your program. Restructure the code so that the long-lived subprocesses are managed by a separate process which doesn't bind ports.

Signed-off-by: David Scott <dave@recoil.org>