### PR TITLE
transport: allow named pipe SecurityDescriptor to be set

### DIFF
--- a/go/pkg/vpnkit/transport/transport.go
+++ b/go/pkg/vpnkit/transport/transport.go
@@ -10,6 +10,10 @@ type Transport interface {
 	Dial(_ context.Context, path string) (net.Conn, error)
 	Listen(path string) (net.Listener, error)
 	String() string
+	// SetSecurityDescriptor for Windows named pipes in SDDL format, see
+	// https://docs.microsoft.com/en-us/windows/win32/secauthz/security-descriptor-definition-language
+	// For example to allow Administrator and System: "D:P(A;;GA;;;BA)(A;;GA;;;SY)".
+	SetSecurityDescriptor(sddl string)
 }
 
 // Choose a transport based on a path.

--- a/go/pkg/vpnkit/transport/unix_unix.go
+++ b/go/pkg/vpnkit/transport/unix_unix.go
@@ -42,6 +42,8 @@ func (_ *unix) String() string {
 	return "Unix domain socket"
 }
 
+func (_ *unix) SetSecurityDescriptor(string) {}
+
 // shortenUnixSocketPath returns a path shortened so it fits inside a socket address.
 // This is needed because paths can be much larger than the space available inside a
 // socket address.

--- a/go/pkg/vpnkit/transport/unix_unix_test.go
+++ b/go/pkg/vpnkit/transport/unix_unix_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package transport
 
 import (

--- a/go/pkg/vpnkit/transport/unix_windows.go
+++ b/go/pkg/vpnkit/transport/unix_windows.go
@@ -13,6 +13,7 @@ func NewUnixTransport() Transport {
 }
 
 type unix struct {
+	securityDescriptor string // SecurityDescriptor will apply to all the pipes.
 }
 
 func (_ *unix) Dial(_ context.Context, path string) (net.Conn, error) {
@@ -20,14 +21,19 @@ func (_ *unix) Dial(_ context.Context, path string) (net.Conn, error) {
 	return winio.DialPipe(path, &timeout)
 }
 
-func (_ *unix) Listen(path string) (net.Listener, error) {
+func (u *unix) Listen(path string) (net.Listener, error) {
 	return winio.ListenPipe(path, &winio.PipeConfig{
-		MessageMode:      true,  // Use message mode so that CloseWrite() is supported
-		InputBufferSize:  65536, // Use 64KB buffers to improve performance
-		OutputBufferSize: 65536,
+		SecurityDescriptor: u.securityDescriptor,
+		MessageMode:        true,  // Use message mode so that CloseWrite() is supported
+		InputBufferSize:    65536, // Use 64KB buffers to improve performance
+		OutputBufferSize:   65536,
 	})
 }
 
 func (_ *unix) String() string {
 	return "Windows named pipe"
+}
+
+func (u *unix) SetSecurityDescriptor(sddl string) {
+	u.securityDescriptor = sddl
 }

--- a/go/pkg/vpnkit/transport/unix_windows_test.go
+++ b/go/pkg/vpnkit/transport/unix_windows_test.go
@@ -1,0 +1,25 @@
+package transport
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoSDDL(t *testing.T) {
+	u := NewUnixTransport()
+	// default security descriptor
+	pipe := `\\.\pipe\mobyVpnkitTest`
+	l, err := u.Listen(pipe)
+	require.Nil(t, err)
+	go func() {
+		c, err := l.Accept()
+		require.Nil(t, err)
+		assert.Nil(t, c.Close())
+	}()
+	c, err := u.Dial(context.Background(), pipe)
+	require.Nil(t, err)
+	assert.Nil(t, c.Close())
+}

--- a/go/pkg/vpnkit/transport/vsock_darwin.go
+++ b/go/pkg/vpnkit/transport/vsock_darwin.go
@@ -55,6 +55,8 @@ func (_ *vs) String() string {
 	return "Hyperkit AF_VSOCK"
 }
 
+func (_ *vs) SetSecurityDescriptor(string) {}
+
 func toPath(a *addr) (string, error) {
 	user, err := user.Current()
 	if err != nil {

--- a/go/pkg/vpnkit/transport/vsock_linux.go
+++ b/go/pkg/vpnkit/transport/vsock_linux.go
@@ -42,6 +42,8 @@ func (_ *vs) String() string {
 	return "Linux AF_VSOCK"
 }
 
+func (_ *vs) SetSecurityDescriptor(string) {}
+
 type addr struct {
 	cid  uint32
 	port uint32

--- a/go/pkg/vpnkit/transport/vsock_windows.go
+++ b/go/pkg/vpnkit/transport/vsock_windows.go
@@ -38,6 +38,8 @@ func (_ *hvs) String() string {
 	return "Windows AF_HYPERV"
 }
 
+func (_ *hvs) SetSecurityDescriptor(string) {}
+
 type addr struct {
 	vmID  hvsock.GUID
 	svcID hvsock.GUID


### PR DESCRIPTION
This is needed on some Windows machines to set the ACLs on the named pipes to ensure we can connect to them.

Signed-off-by: David Scott <dave.scott@docker.com>