### PR TITLE
Fix warning 16 (optional argument cannot be erased)

### DIFF
--- a/src/hostnet/vmnet.ml
+++ b/src/hostnet/vmnet.ml
@@ -324,7 +324,7 @@ module Make(C: Sig.CONN) = struct
       Lwt_result.fail (`Msg "Client requested unsupported protocol version")
 
 
-  let client_negotiate ~uuid ?preferred_ip ~fd =
+  let client_negotiate ~uuid ?preferred_ip ~fd () =
     let buf = Cstruct.create Init.sizeof in
     let (_: Cstruct.t) = Init.marshal Init.default buf in
     Channel.write_buffer fd buf;
@@ -436,7 +436,7 @@ module Make(C: Sig.CONN) = struct
   let client_of_fd ~uuid ?preferred_ip ~server_macaddr flow =
     let open Lwt_result.Infix in
     let channel = Channel.create flow in
-    client_negotiate ~uuid ?preferred_ip ~fd:channel
+    client_negotiate ~uuid ?preferred_ip ~fd:channel ()
     >>= fun vif ->
     let t =
       make ~client_macaddr:server_macaddr

--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -34,7 +34,7 @@ module Dns_policy = struct
   module IntMap =
     Map.Make(struct
       type t = int let
-      compare (a: int) (b: int) = Pervasives.compare a b
+      compare (a: int) (b: int) = Stdlib.compare a b
     end)
 
   let t = ref (IntMap.add 0 google_dns IntMap.empty)

--- a/src/hostnet_test/test_nat.ml
+++ b/src/hostnet_test/test_nat.ml
@@ -68,7 +68,7 @@ end
 
 module UdpServer = struct
   module PortSet =
-    Set.Make(struct type t = int let compare = Pervasives.compare end)
+    Set.Make(struct type t = int let compare = Stdlib.compare end)
 
   type t = {
     port: int;


### PR DESCRIPTION
```
File "src/hostnet/vmnet.ml", line 327, characters 30-42:
327 |   let client_negotiate ~uuid ?preferred_ip ~fd =
                                    ^^^^^^^^^^^^
Error (warning 16 [unerasable-optional-argument]): this optional argument cannot be erased.
```

Signed-off-by: David Scott <dave@recoil.org>