### PR TITLE
WIP: re-enable appveyor for Windows vpnkit.exe builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,8 @@ RUN opam pin add hvsock.2.0.0 https://github.com/mirage/ocaml-hvsock/archive/2.0
 
 # Can be removed after we upgrade tcpip
 RUN opam pin configurator --dev-repo -n
-# Fix for Apple Silicon codesign issue
-RUN opam pin add omake "https://github.com/ocaml-omake/omake.git#gerd/disable-parallel-bootstrap" -n
-# Fix for OCaml 4.12 build
-RUN opam pin add uwt "https://github.com/fdopen/uwt.git#c43349bf3689181756feb341e3896d4a0a695523" -n
-RUN sudo apk add libtool autoconf automake # missing depexts
+RUN opam pin add luv.0.5.8 https://github.com/aantron/luv/releases/download/0.5.8/luv-0.5.8.tar.gz -n
+RUN opam pin add luv_unix.0.5.8 https://github.com/aantron/luv/releases/download/0.5.8/luv-0.5.8.tar.gz -n
 # A small fork of the tcpip stack
 RUN opam pin add tcpip.3.3.0 "https://github.com/djs55/mirage-tcpip.git#vpnkit-20210417" -n
 

--- a/Makefile
+++ b/Makefile
@@ -1,56 +1,8 @@
-REPO_ROOT=$(shell git rev-parse --show-toplevel)
-ifeq ($(OS),Windows_NT)
-  OPAM_COMP?=4.07.0+mingw64c
-  OPAM_REPO?=repo/win32
-  OPAMROOT?=$(shell cygpath -w "$(REPO_ROOT)/_build/opam")
-else
-  OPAM_COMP?=4.07.0
-  OPAM_REPO?=repo/darwin
-  OPAMROOT?=$(REPO_ROOT)/_build/opam
-endif
-
-LICENSEDIRS=$(REPO_ROOT)/repo/licenses
-BINDIR?=$(shell pwd)
-
-BINARIES := vpnkit.exe
-
-ARTEFACTS = COMMIT OSS-LICENSES
-ifeq ($(OS),Windows_NT)
-	ARTEFACTS += vpnkit.exe
-else
-	ARTEFACTS += vpnkit.tgz
-endif
-
-all: $(OPAMROOT) $(BINARIES)
-
-$(OPAMROOT):
-	OPAMROOT=$(OPAMROOT) OPAM_COMP=$(OPAM_COMP) OPAM_REPO=$(OPAM_REPO) ./scripts/depends.sh
-
-.PHONY: install
-install: $(BINARIES)
-	cp $(BINARIES) '$(BINDIR)'
-
-.PHONY: uninstall
-uninstall:
-	cd '$(BINDIR)' && for BINARY in $(BINARIES) ; do \
-		rm -f $$BINARY ; \
-	done
-
-.PHONY: artefacts
-artefacts: $(ARTEFACTS)
-
-vpnkit.tgz: vpnkit.exe
-	mkdir -p _build/root/Contents/Resources/bin
-	cp vpnkit.exe _build/root/Contents/Resources/bin/vpnkit
-	dylibbundler -od -b \
-		-x _build/root/Contents/Resources/bin/vpnkit \
-		-d _build/root/Contents/Resources/lib \
-		-p @executable_path/../lib
-	tar -C _build/root -cvzf vpnkit.tgz Contents
+all: vpnkit.exe
 
 .PHONY: vpnkit.exe
-vpnkit.exe: $(OPAMROOT)
-	opam config --root $(OPAMROOT) --switch $(OPAM_COMP) exec -- sh -c 'jbuilder build --dev src/bin/main.exe'
+vpnkit.exe:
+	dune build src/bin/main.exe
 	cp _build/default/src/bin/main.exe vpnkit.exe
 
 %: %.in
@@ -59,46 +11,18 @@ vpnkit.exe: $(OPAMROOT)
 	@mv $@.tmp $@
 
 .PHONY: test
-test: $(OPAMROOT)
-	opam config --root $(OPAMROOT) --switch $(OPAM_COMP) exec -- sh -c 'jbuilder build --dev src/hostnet_test/main.exe'
+test:
+	dune runtest --no-buffer
+	dune build src/hostnet_test/main.exe
 	cp -r go/test_inputs _build/default/src/hostnet_test/
 # One test requires 1026 file descriptors
 	ulimit -n 1500 && ./_build/default/src/hostnet_test/main.exe
-
-# Published as an artifact.
-.PHONY: OSS-LICENSES
-OSS-LICENSES:
-	echo "  GEN     " $@
-	mkdir -p $(LICENSEDIRS)
-	opam config --root $(OPAMROOT) --switch $(OPAM_COMP) exec -- sh -c 'cd $(LICENSEDIRS) && $(REPO_ROOT)/repo/opam-licenses.sh vpnkit'
-	$(REPO_ROOT)/repo/list-licenses.sh $(LICENSEDIRS) > $@.tmp
-	mv $@.tmp $@
-
-# Published as an artifact.
-.PHONY: COMMIT
-COMMIT:
-	@echo "  GEN     " $@
-	@git rev-parse HEAD > $@.tmp
-	@mv $@.tmp $@
 
 .PHONY: clean
 clean:
 	rm -rf _build
 	rm -f vpnkit.exe
 	rm -f vpnkit.tgz
-
-REPO=../../mirage/opam-repository
-PACKAGES=$(REPO)/packages
-# until we have https://github.com/ocaml/opam-publish/issues/38
-pkg-%:
-	topkg opam pkg -n $*
-	mkdir -p $(PACKAGES)/$*
-	cp -r _build/$*.* $(PACKAGES)/$*/
-	cd $(PACKAGES) && git add $*
-
-PKGS=$(basename $(wildcard *.opam))
-opam-pkg:
-	$(MAKE) $(PKGS:%=pkg-%)
 
 e2e-vpnkit-tap-vsockd:
 	docker build -t vpnkit-host .

--- a/Makefile.darwin
+++ b/Makefile.darwin
@@ -15,10 +15,8 @@ ocaml:
 	ocaml -version || opam init --compiler=4.12.0
 	# Can be removed after we upgrade tcpip
 	opam pin configurator --dev-repo -n
-	# Fix for Apple Silicon codesign issue
-	opam pin add omake "https://github.com/ocaml-omake/omake.git#gerd/disable-parallel-bootstrap" -n
-	# Fix for OCaml 4.12 build
-	opam pin add uwt "https://github.com/fdopen/uwt.git#c43349bf3689181756feb341e3896d4a0a695523" -n
+	opam pin add luv.0.5.8 https://github.com/aantron/luv/releases/download/0.5.8/luv-0.5.8.tar.gz -n
+	opam pin add luv_unix.0.5.8 https://github.com/aantron/luv/releases/download/0.5.8/luv-0.5.8.tar.gz -n
 	opam pin add tcpip.3.3.0 "https://github.com/djs55/mirage-tcpip.git#vpnkit-20210417" -n
 	opam pin add vpnkit . -n
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,22 +2,43 @@ platform:
   - x64
 
 environment:
-  CYG_ROOT: "C:\\cygwin64"
-  CYG_CACHE: C:/cygwin64/var/cache/setup
-  CYG_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
-  CYG_BASH: "%CYG_ROOT%\\bin\\bash -lc"
-  CYG_ARCH: "x86_64"
-  CYGWIN: "winsymlinks:native"
-  CUSTOM_OPAM: "1"
-  OPAM_COMP: "4.07.0+mingw64c"
-  OPAM_LINT: "false"
-  OPAMYES: 1
-  OPAMCOLORS: 1
-  OPAMVERBOSE: 1
-  BINDIR: 'C:\projects\vpnkit'
+  - CYG_ARCH: x86_64
+  - CYG_ROOT: C:/cygwin64
+  - CYG_CACHE: C:/cygwin64/var/cache/setup
+  - CYG_SH: C:/cygwin64/bin/bash -lc
+  - CYG_INSTALL: C:/cygwin64/setup-x86_64.exe -q -P
+  - CYG_PATH: C:/cygwin64/bin/cygpath -u
+  - CYGWIN: "winsymlinks:native"
+  - OPAMYES: 1
+  - OPAMCOLORS: 1
+  - OPAMVERBOSE: 1
+  - BINDIR: 'C:\projects\vpnkit'
+
+init:
+  - git config --global core.symlinks true
+  - git config --global core.autocrlf input
+  - '%CYG_SH% "cygcheck -dc cygwin"'
+  - '%CYG_INSTALL% "wget"'
+  - '%CYG_SH% "wget rawgit.com/transcode-open/apt-cyg/master/apt-cyg"'
+  - '%CYG_SH% "install apt-cyg /bin"'
+  - '%CYG_SH% "apt-cyg install make autoconf automake gcc-core opam-installer ocaml"'
+
+cache:
+  - '%CYG_CACHE%'
+  - '%HOME%/.opam' -> vpnkit.opam
 
 install:
   - cmd: echo Windows build is disabled until we can remove cygwin.
 
 build_script:
-  - "%CYG_BASH% '${APPVEYOR_BUILD_FOLDER}/scripts/appveyor.sh'"
+  - "%CYG_SH% make -f '${APPVEYOR_BUILD_FOLDER}/Makefile.darwin' ocaml"
+  - "%CYG_SH% make -f '${APPVEYOR_BUILD_FOLDER}/Makefile.darwin' depends"
+  - "%CYG_SH% make -f '${APPVEYOR_BUILD_FOLDER}/Makefile.darwin' build"
+  - "%CYG_SH% make -f '${APPVEYOR_BUILD_FOLDER}/Makefile.darwin' artefacts"
+  - "%CYG_SH% make -f '${APPVEYOR_BUILD_FOLDER}/Makefile.darwin' COMMIT"
+  - "%CYG_SH% make -f '${APPVEYOR_BUILD_FOLDER}/Makefile.darwin' OSS-LICENSES"
+
+artifacts:
+  - path: "vpnkit.exe"
+  - path: "OSS-LICENSES"
+  - path: "COMMIT"

--- a/src/bin/bind.ml
+++ b/src/bin/bind.ml
@@ -36,13 +36,6 @@ module Make(Socket: Sig.SOCKETS) = struct
     c: Channel.t;
   }
 
-  let register_connection = Socket.register_connection
-  let deregister_connection = Socket.deregister_connection
-  let set_max_connections = Socket.set_max_connections
-  let get_num_connections = Socket.get_num_connections
-  let connections = Socket.connections
-  exception Too_many_connections = Socket.Too_many_connections
-
   let of_fd fd =
     let buf = Cstruct.create Init.sizeof in
     let (_: Cstruct.t) = Init.marshal Init.default buf in
@@ -109,7 +102,7 @@ module Make(Socket: Sig.SOCKETS) = struct
           if local_port < 1024 && not is_windows then
             request_privileged_port ipv4 local_port false >>= function
             | Error (`Msg x) -> Lwt.fail_with x
-            | Ok fd          -> Lwt.return (Socket.Datagram.Udp.of_bound_fd fd)
+            | Ok fd          -> Socket.Datagram.Udp.of_bound_fd fd
           else
             bind ?description (local_ip, local_port)
         | _ -> bind ?description (local_ip, local_port)
@@ -126,7 +119,7 @@ module Make(Socket: Sig.SOCKETS) = struct
           if local_port < 1024 && not is_windows then
             request_privileged_port ipv4 local_port true >>= function
             | Error (`Msg x) -> Lwt.fail_with x
-            | Ok fd          -> Lwt.return (Socket.Stream.Tcp.of_bound_fd fd)
+            | Ok fd          -> Socket.Stream.Tcp.of_bound_fd fd
           else
             bind ?description (local_ip, local_port)
         | _ -> bind ?description (local_ip, local_port)

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -77,7 +77,9 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       let i = String.sub path 3 (String.length path - 3) in
       try
         let fd = file_descr_of_int @@ int_of_string i in
-        Lwt.return (Ok (Host.Sockets.Stream.Unix.of_bound_fd fd))
+        Host.Sockets.Stream.Unix.of_bound_fd fd
+        >>= fun x ->
+        Lwt.return (Ok x)
       with _ ->
         Log.err (fun f -> f "Failed to parse command-line argument [%s] expected fd:<int>" path);
         Lwt.return (Error (`Msg "Failed to parase command-line argument"))
@@ -291,7 +293,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       Log.warn (fun f ->
           f "The argument max-connections is nolonger supported, use the \
              database key slirp/max-connections instead"));
-    Host.Sockets.set_max_connections max_connections;
+    Connection_limit.set_max max_connections;
 
     Log.info (fun f -> f "Starting port forwarding control 9P server on %s" port_control_url);
     let uri = Uri.of_string port_control_url in
@@ -370,11 +372,14 @@ let hvsock_addr_of_uri ~default_serviceid uri =
     Host.start_background_gc gc_compact;
 
     if hosts <> "" then begin
-      match HostsFile.watch ~path:hosts () with
-      | Ok _       -> ()
-      | Error (`Msg m) ->
-        Log.err (fun f -> f "Failed to watch hosts file %s: %s" hosts m);
-        ()
+      Lwt.async (fun () ->
+        HostsFile.watch ~path:hosts ()
+        >>= function
+        | Ok _       -> Lwt.return_unit
+        | Error (`Msg m) ->
+          Log.err (fun f -> f "Failed to watch hosts file %s: %s" hosts m);
+          Lwt.return_unit
+      )
     end;
 
     List.iter
@@ -491,10 +496,6 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       if debug || env_debug then Some Logs.Debug else Some Logs.Info in
     Logging.setup level;
 
-    if Sys.os_type = "Unix" then begin
-      Log.info (fun f -> f "Increasing preemptive thread pool size to 1024 threads");
-      Uwt_preemptive.set_bounds (0, 1024);
-    end;
 
     let host_names = List.map Dns.Name.of_string @@ Astring.String.cuts ~sep:"," host_names in
     let gateway_names = List.map Dns.Name.of_string @@ Astring.String.cuts ~sep:"," gateway_names in

--- a/src/hostnet/connection_limit.ml
+++ b/src/hostnet/connection_limit.ml
@@ -1,0 +1,74 @@
+let src =
+  let src =
+    Logs.Src.create "Connection_limit" ~doc:"Track and limit open connections"
+  in
+  Logs.Src.set_level src (Some Logs.Info);
+  src
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+(* Ensure the table is safe to access from both the Luv event loop and the Lwt event loop. *)
+let m = Mutex.create ()
+
+let with_mutex m f =
+  Mutex.lock m;
+  try
+    let result = f () in
+    Mutex.unlock m;
+    result
+  with e ->
+    Mutex.unlock m;
+    raise e
+
+let max = ref None
+
+let next =
+  let idx = ref 0 in
+  fun () ->
+    let next = !idx in
+    incr idx;
+    next
+
+let table = Hashtbl.create 511
+
+let set_max x =
+  with_mutex m (fun () ->
+      (match x with
+      | None -> Log.info (fun f -> f "Removed connection limit")
+      | Some limit ->
+          Log.info (fun f -> f "Updated connection limit to %d" limit));
+      max := x)
+
+let get_num_connections () = with_mutex m (fun () -> Hashtbl.length table)
+
+let connections () =
+  with_mutex m (fun () ->
+      let xs = Hashtbl.fold (fun _ c acc -> c :: acc) table [] in
+      Vfs.File.ro_of_string (String.concat "\n" xs))
+
+let register_no_limit description =
+  with_mutex m (fun () ->
+      let idx = next () in
+      Hashtbl.replace table idx description;
+      idx)
+
+let register =
+  with_mutex m (fun () ->
+      let last_error_log = ref 0. in
+      fun description ->
+        match !max with
+        | Some m when Hashtbl.length table >= m ->
+            let now = Unix.gettimeofday () in
+            if now -. !last_error_log > 30. then (
+              (* Avoid hammering the logging system *)
+              Log.warn (fun f ->
+                  f "Exceeded maximum number of forwarded connections (%d)" m);
+              last_error_log := now);
+            Error (`Msg "too many open connections")
+        | _ -> Ok (register_no_limit description))
+
+let deregister idx =
+  with_mutex m (fun () ->
+      if not (Hashtbl.mem table idx) then
+        Log.warn (fun f -> f "Deregistered connection %d more than once" idx);
+      Hashtbl.remove table idx)

--- a/src/hostnet/connection_limit.mli
+++ b/src/hostnet/connection_limit.mli
@@ -1,0 +1,21 @@
+val set_max : int option -> unit
+(** [set_max None] disables connection limits.
+    [set_max (Some x)] sets the connection limit to [x] *)
+
+val register_no_limit : string -> int
+(** [register_no_limit description] registers a connection and returns an ID, ignoring any limit *)
+
+val register : string -> (int, [ `Msg of string ]) result
+(** [register description] attempts to register a connection and returns an ID if we haven't
+    reached the connection limit. *)
+
+val deregister : int -> unit
+(** [deregister id] deregister the connection with ID [id] *)
+
+(** For debugging, testing and diagnostics: *)
+
+val connections : unit -> Vfs.File.t
+(** [connections ()] returns a snapshot of the active connections for diagnostics. *)
+
+val get_num_connections : unit -> int
+(** [get_num_connections ()] returns the current number of active connections *)

--- a/src/hostnet/dune
+++ b/src/hostnet/dune
@@ -1,11 +1,13 @@
 (library
  (name hostnet)
+ (inline_tests)
+ (preprocess (pps ppx_inline_test))
  (libraries base64 cstruct logs ipaddr mirage-flow-lwt ppx_sexp_conv
    pcap-format tcpip.ethif tcpip.arpv4 tcpip.ipv4 tcpip.icmpv4 tcpip.udp
-   tcpip.tcp tcpip.stack-direct charrua-core.server dns dns_lwt ofs uwt
-   uwt.ext uwt.preemptive threads astring datakit-server dns_forward tar
+   tcpip.tcp tcpip.stack-direct charrua-core.server dns dns_lwt ofs luv
+   luv_unix lwt.unix threads astring datakit-server dns_forward tar
    mirage-vnetif uuidm cohttp-lwt mirage-channel ezjsonm
    mirage-protocols-lwt duration mirage-time-lwt mirage-clock-lwt
-   mirage-random tcpip.unix forwarder cstructs)
+   mirage-random tcpip.unix forwarder cstructs sha)
  (foreign_stubs (language c) (names stubs_utils))
  (wrapped false))

--- a/src/hostnet/host.mli
+++ b/src/hostnet/host.mli
@@ -1,6 +1,6 @@
 include Sig.HOST
 
-val start_background_gc: int option -> unit
+val start_background_gc : int option -> unit
 (** [start_background_gc interval] starts a background thread which compacts
     the heap every [interval] seconds. An immediate compact can be triggered
     by sending SIGUSR1 *)

--- a/src/hostnet/hostnet_dns.ml
+++ b/src/hostnet/hostnet_dns.ml
@@ -79,8 +79,8 @@ module Policy(Files: Sig.FILES) = struct
 
   (* Watch for the /etc/resolv.file *)
   let resolv_conf = "/etc/resolv.conf"
-  let () =
-    match Files.watch_file resolv_conf (fun () ->
+  let _ : unit Lwt.t =
+    Files.watch_file resolv_conf (fun () ->
         Lwt.async (fun () ->
             Files.read_file resolv_conf
             >>= function
@@ -97,13 +97,17 @@ module Policy(Files: Sig.FILES) = struct
                 Lwt.return_unit
               end
         )
-      ) with
+      )
+    >>= function
     | Error (`Msg "ENOENT") ->
-      Log.info (fun f -> f "Not watching %s because it does not exist" resolv_conf)
+      Log.info (fun f -> f "Not watching %s because it does not exist" resolv_conf);
+      Lwt.return_unit
     | Error (`Msg m) ->
-      Log.info (fun f -> f "Cannot watch %s: %s" resolv_conf m)
+      Log.info (fun f -> f "Cannot watch %s: %s" resolv_conf m);
+      Lwt.return_unit
     | Ok _watch ->
-      Log.info (fun f -> f "Will watch %s for changes" resolv_conf)
+      Log.info (fun f -> f "Will watch %s for changes" resolv_conf);
+      Lwt.return_unit
 
 end
 

--- a/src/hostnet/hostnet_icmp.mli
+++ b/src/hostnet/hostnet_icmp.mli
@@ -26,7 +26,7 @@ module Make
   type t
   (** An ICMP NAT implementation *)
 
-  val create: ?max_idle_time:int64 -> Clock.t -> t
+  val create: ?max_idle_time:int64 -> Clock.t -> t Lwt.t
   (** Create an ICMP NAT implementation which will keep "NAT rules" alive until
       they become idle for the given [?max_idle_time] *)
 

--- a/src/hostnet/hostnet_udp.ml
+++ b/src/hostnet/hostnet_udp.ml
@@ -172,11 +172,6 @@ struct
         >>= fun () ->
         Lwt.return true
       ) (function
-      | Unix.Unix_error(e, _, _) when
-          Uwt.of_unix_error e = Uwt.ECANCELED ->
-        Log.debug (fun f ->
-            f "Hostnet_udp %s: shutting down listening thread" (description d));
-        Lwt.return false
       | e ->
         Log.err (fun f ->
             f "Hostnet_udp %s: caught unexpected exception %a"
@@ -234,7 +229,8 @@ struct
                   >>= fun () ->
                   Udp.bind ~description:(description datagram) (Ipaddr.(V4 V4.any), 0)
                   >>= fun server ->
-                  let external_address = Udp.getsockname server in
+                  Udp.getsockname server
+                  >>= fun external_address ->
                   let last_use = Clock.elapsed_ns t.clock in
                   let flow = { description = d; src = datagram.src; server; external_address; last_use } in
                   Hashtbl.replace t.table datagram.src flow;

--- a/src/hostnet/hosts.mli
+++ b/src/hostnet/hosts.mli
@@ -11,12 +11,12 @@ module Make(Files: Sig.FILES): sig
 
   type watch
 
-  val watch: ?path:string -> unit -> (watch, [ `Msg of string ]) result
+  val watch: ?path:string -> unit -> (watch, [ `Msg of string ]) result Lwt.t
   (** Start watching the hosts file, updating the [etc_hosts] binding in the
       background. The [?path] argument allows the location of the hosts file
       to be overriden. *)
 
-  val unwatch: watch -> unit
+  val unwatch: watch -> unit Lwt.t
   (** Stop watching the hosts file *)
 
 end

--- a/src/hostnet/luv_lwt.ml
+++ b/src/hostnet/luv_lwt.ml
@@ -1,0 +1,176 @@
+module Result = struct
+  include Result
+
+  let get_ok = function Error _ -> invalid_arg "result is Error _" | Ok x -> x
+end
+
+module type Notification = sig
+  type t
+  (** Wake up and run code in a remote event loop *)
+
+  val create : (unit -> unit) -> t
+
+  val send : t -> unit
+end
+
+module Lwt_notification : Notification = struct
+  type t = int
+  (** Run code in an Lwt event loop *)
+
+  let create cb = Lwt_unix.make_notification cb
+
+  let send = Lwt_unix.send_notification
+end
+
+module Luv_notification : Notification = struct
+  type t = [ `Async ] Luv.Handle.t
+  (** Run code in the default Luv event loop *)
+
+  let create cb = Luv.Async.init (fun _t -> cb ()) |> Result.get_ok
+
+  let send t = Luv.Async.send t |> Result.get_ok
+end
+
+module type Remote_work_queue = sig
+  type 'a t
+
+  val make : ('a -> unit) -> 'a t
+
+  val push : 'a t -> 'a -> unit
+
+  val length : 'a t -> int
+end
+
+module Work_queue (N : Notification) : Remote_work_queue = struct
+  type 'a t = {
+    pending : 'a Queue.t;
+    run : 'a -> unit;
+    mutable n : N.t option;
+    (* Note: if this is only used from a single-threaded Lwt or Luv context, then
+       the mutex is unnecessary. The tests below use pthreads so require the mutex. *)
+    m : Mutex.t;
+  }
+  (** A thread-safe queue of pending jobs which will be run in a remote event loop *)
+
+  let flush t () =
+    (* Called in the remote event loop to run pending jobs .*)
+    Mutex.lock t.m;
+    let to_run = Queue.copy t.pending in
+    Queue.clear t.pending;
+    Mutex.unlock t.m;
+    Queue.iter t.run to_run
+
+  let push t x =
+    (* Called on an arbitrary thread to queue a remote job. *)
+    Mutex.lock t.m;
+    (* We only need to send a notification if the queue is currently empty, otherwise
+       one has already been sent. *)
+    let to_send = Queue.is_empty t.pending in
+    Queue.push x t.pending;
+    Mutex.unlock t.m;
+    if to_send then N.send (Option.get t.n)
+
+  let length t =
+    Mutex.lock t.m;
+    let result = Queue.length t.pending in
+    Mutex.unlock t.m;
+    result
+
+  let make run =
+    let t =
+      {
+        pending = Queue.create ();
+        run;
+        n = None;
+        (* initialized below *)
+        m = Mutex.create ();
+      }
+    in
+    t.n <- Some (N.create (flush t));
+    t
+end
+
+module Run_in_lwt = Work_queue (Lwt_notification)
+module Run_in_luv = Work_queue (Luv_notification)
+
+let to_luv_default_loop = Run_in_luv.make (fun f -> f ())
+
+let to_lwt_default_loop = Run_in_lwt.make (fun f -> f ())
+
+let in_lwt_async f = Run_in_lwt.push to_lwt_default_loop f
+
+let in_luv_async = Run_in_luv.push to_luv_default_loop
+
+let in_luv f =
+  let t, u = Lwt.task () in
+  let wakeup_later x = in_lwt_async (fun () -> Lwt.wakeup_later u x) in
+  in_luv_async (fun () -> f wakeup_later);
+  t
+
+let run t =
+  (* Hopefully it's ok to create the async handle in this thread, even though the
+     main loop runs in another thread. *)
+  let stop_default_loop =
+    Luv.Async.init (fun h ->
+        Luv.Loop.stop (Luv.Loop.default ());
+        Luv.Handle.close h ignore)
+    |> Result.get_ok
+  in
+  let luv = Thread.create (fun () -> ignore (Luv.Loop.run () : bool)) () in
+  (* With the luv event loop running in the background, we can evaluate [t] *)
+  let result = Lwt_main.run t in
+  Luv.Async.send stop_default_loop |> Result.get_ok;
+  Thread.join luv;
+  result
+
+let%test "wakeup one task from a luv callback" =
+  let t, u = Lwt.task () in
+  let luv = Thread.create (fun () -> in_lwt_async (Lwt.wakeup_later u)) () in
+  Thread.join luv;
+  Lwt_main.run t;
+  true
+
+let%test "wakeup lots of tasks from a luv callback" =
+  let n = 1000 in
+  let tasks = Array.init n (fun _ -> Lwt.task ()) |> Array.to_list in
+  List.iteri
+    (fun i (_, u) ->
+      let (_ : Thread.t) =
+        Thread.create
+          (fun i ->
+            (* Introduce jitter *)
+            Thread.delay 0.5;
+            in_lwt_async (fun () -> Lwt.wakeup_later u i))
+          i
+      in
+      ())
+    tasks;
+  Lwt_main.run
+    (let open Lwt.Infix in
+    let ts = List.map fst tasks in
+    Lwt_list.fold_left_s
+      (fun acc b_t -> b_t >>= fun b -> Lwt.return (acc + b))
+      0 ts)
+  = n * (n - 1) / 2
+
+let src =
+  let src = Logs.Src.create "Luv" ~doc:"Host interface based on Luv" in
+  Logs.Src.set_level src (Some Logs.Info);
+  src
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+let (_ : Thread.t) =
+  Thread.create
+    (fun () ->
+      Log.info (fun f -> f "monitoring queue lengths");
+      while true do
+        Log.info (fun f ->
+            f "run_in_luv queue length = %d"
+              (Run_in_luv.length to_luv_default_loop));
+        Log.info (fun f ->
+            f "run_in_lwt queue length = %d"
+              (Run_in_lwt.length to_lwt_default_loop));
+        Thread.delay 2.
+      done)
+    ()

--- a/src/hostnet/luv_lwt.mli
+++ b/src/hostnet/luv_lwt.mli
@@ -1,0 +1,54 @@
+(* Both Lwt and Luv have their own schedulers which we run on separate Threads.
+
+   This module contains helper functions to call from one scheduler/Thread context to
+   the other.
+
+   A typical example would be:
+
+
+*)
+
+val in_luv : (('a -> unit) -> unit) -> 'a Lwt.t
+(** [in_luv f] is called from Lwt to run [f return] in the default Luv event loop.
+    The function [return] may be used to return values to the Lwt caller.
+    Example:
+
+```
+let do_some_io () : unit Lwt.t =
+    Luv_lwt.in_luv (fun result ->
+        (* Now we're in the Luv event loop *)
+        Luv.Do.something _ begin function
+        | Error err -> return (Error (`Msg (Luv.Error.strerror err)))
+        | Ok () -> return (Ok ())
+        end
+    )
+```
+    *)
+
+(* To run in the Lwt main loop, use Lwt_preemptive.run_in_main *)
+
+val in_luv_async : (unit -> unit) -> unit
+(** [in_luv_async f] is called from Lwt to run [f ()] in the default Luv event loop.
+    This is useful for cases where we don't need to wait for the results.
+*)
+
+val in_lwt_async : (unit -> unit) -> unit
+(** [run_in_lwt f] is called from Luv to run [f ()] in the default Lwt event loop.
+    Example:
+
+```
+let handle_connection client () =
+    Lwt.async (fun () -> ...)
+
+let accept_forever () =
+    ...
+    begin match Luv.Stream.accept ~server:fd ~client with
+    | Error err -> ...
+    | Ok () ->
+        Luv_lwt.in_lwt_async (handle_connection client);
+        accept_forever ()
+    end
+*)
+
+val run : 'a Lwt.t -> 'a
+(** [run t] evaluates [t] with the default Luv event loop. *)

--- a/src/hostnet/vmnet.ml
+++ b/src/hostnet/vmnet.ml
@@ -564,9 +564,6 @@ module Make(C: Sig.CONN) = struct
        let callback buf =
          Lwt.catch (fun () -> t.callback buf)
            (function
-           | Host.Sockets.Too_many_connections ->
-             (* No need to log this again *)
-             Lwt.return_unit
            | e ->
              let now = Unix.gettimeofday () in
              if (now -. !last_error_log) > 30. then begin

--- a/src/hostnet_test/dune
+++ b/src/hostnet_test/dune
@@ -1,5 +1,5 @@
 (executable
  (name main)
  (libraries hostnet cmdliner alcotest logs.fmt protocol-9p mirage_dns
-   uwt.preemptive mirage-clock-unix charrua-client-mirage forwarder sha)
+   mirage-clock-unix charrua-client-mirage forwarder sha)
  (preprocess no_preprocessing))

--- a/src/hostnet_test/forwarding.ml
+++ b/src/hostnet_test/forwarding.ml
@@ -124,7 +124,8 @@ module ForwardServer = struct
   let port =
     Host.Sockets.Stream.Tcp.bind (Ipaddr.V4 Ipaddr.V4.localhost, 0)
     >>= fun server ->
-    let _, local_port = Host.Sockets.Stream.Tcp.getsockname server in
+    Host.Sockets.Stream.Tcp.getsockname server
+    >>= fun (_, local_port) ->
     Host.Sockets.Stream.Tcp.listen server accept;
     Lwt.return local_port
 
@@ -158,7 +159,8 @@ module PortsServer = struct
     let ports = Ports.make clock in
     Host.Sockets.Stream.Tcp.bind (Ipaddr.V4 localhost, 0)
     >>= fun server ->
-    let _, port = Host.Sockets.Stream.Tcp.getsockname server in
+    Host.Sockets.Stream.Tcp.getsockname server
+    >>= fun (_, port) ->
     Host.Sockets.Stream.Tcp.listen server
       (fun conn ->
          Server.connect ports conn ()
@@ -263,8 +265,9 @@ module LocalTCPServer = struct
 
   let create () =
     Host.Sockets.Stream.Tcp.bind (Ipaddr.V4 localhost, 0)
-    >|= fun server ->
-    let _, local_port = Host.Sockets.Stream.Tcp.getsockname server in
+    >>= fun server ->
+    Host.Sockets.Stream.Tcp.getsockname server
+    >|= fun (_, local_port) ->
     Host.Sockets.Stream.Tcp.listen server accept;
     { local_port; server }
 
@@ -304,8 +307,9 @@ module LocalUDPServer = struct
 
   let create () =
     Host.Sockets.Datagram.Udp.bind (Ipaddr.V4 localhost, 0)
-    >|= fun server ->
-    let _, local_port = Host.Sockets.Datagram.Udp.getsockname server in
+    >>= fun server ->
+    Host.Sockets.Datagram.Udp.getsockname server
+    >|= fun (_, local_port) ->
     Log.info (fun f -> f "UDP local_port=%d" local_port);
     echo server;
     { local_port; server }

--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -175,8 +175,9 @@ let set_slirp_stack c =
 
 let start_stack config () =
   Host.Sockets.Stream.Tcp.bind (Ipaddr.V4 Ipaddr.V4.localhost, 0)
-  >|= fun server ->
-  let _, port = Host.Sockets.Stream.Tcp.getsockname server in
+  >>= fun server ->
+  Host.Sockets.Stream.Tcp.getsockname server
+  >|= fun (_, port) ->
   Log.info (fun f -> f "Bound vpnkit server to localhost:%d" port);
   Host.Sockets.Stream.Tcp.listen server (fun flow ->
       Log.info (fun f -> f "Server connecting   TCP/IP stack");

--- a/src/hostnet_test/test_dns.ml
+++ b/src/hostnet_test/test_dns.ml
@@ -184,7 +184,8 @@ module Server = struct
             Lwt.return_unit
           end
       );
-    let _, realport = Udp.getsockname server in
+    Udp.getsockname server
+    >>= fun (_, realport) ->
     let t = { ip; port = realport; server } in
     Lwt.finalize (fun () -> f t.port) (fun () -> Udp.shutdown t.server)
 end

--- a/src/hostnet_test/test_half_close.ml
+++ b/src/hostnet_test/test_half_close.ml
@@ -17,7 +17,8 @@ module Server = struct
   let create on_accept =
     Host.Sockets.Stream.Tcp.bind (Ipaddr.V4 Ipaddr.V4.localhost, 0)
     >>= fun server ->
-    let _, port = Host.Sockets.Stream.Tcp.getsockname server in
+    Host.Sockets.Stream.Tcp.getsockname server
+    >>= fun (_, port) ->
     Host.Sockets.Stream.Tcp.listen server on_accept;
     Lwt.return { server; port }
   let destroy t =

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -82,7 +82,8 @@ module Server = struct
   let create on_accept =
     Host.Sockets.Stream.Tcp.bind (Ipaddr.V4 Ipaddr.V4.localhost, 0)
     >>= fun server ->
-    let _, port = Host.Sockets.Stream.Tcp.getsockname server in
+    Host.Sockets.Stream.Tcp.getsockname server
+    >>= fun (_, port) ->
     Host.Sockets.Stream.Tcp.listen server on_accept;
     Lwt.return { server; port }
   let destroy t =

--- a/src/hostnet_test/test_nat.ml
+++ b/src/hostnet_test/test_nat.ml
@@ -35,7 +35,8 @@ module EchoServer = struct
   let create () =
     Host.Sockets.Datagram.Udp.bind (Ipaddr.(V4 V4.localhost), 0)
     >>= fun server ->
-    let _, local_port = Host.Sockets.Datagram.Udp.getsockname server in
+    Host.Sockets.Datagram.Udp.getsockname server
+    >>= fun (_, local_port) ->
     (* Start a background echo thread. This will naturally fail when the
        file descriptor is closed underneath it from `shutdown` *)
     let seen_addresses = [] in
@@ -401,7 +402,8 @@ let test_nat_punch () =
           Cstruct.set_uint8 buffer 0 2;
           Host.Sockets.Datagram.Udp.bind (Ipaddr.(V4 V4.localhost), 0)
           >>= fun client ->
-          let _, source_port = Host.Sockets.Datagram.Udp.getsockname client in
+          Host.Sockets.Datagram.Udp.getsockname client
+          >>= fun (_, source_port) ->
           let address = List.hd (EchoServer.get_seen_addresses echoserver) in
           let _, dest_port = address in
           let rec loop remaining =

--- a/vpnkit.opam
+++ b/vpnkit.opam
@@ -23,14 +23,16 @@ build: [
 
 depends: [
   "dune" {build}
-  "alcotest"
-  "ounit"
-  "charrua-client-mirage" { = "0.9"}
+  "alcotest" {build}
+  "ounit" {build}
+  "ppx_inline_test" {build}
+  "charrua-client-mirage" { = "0.9" }
   "result"
   "tar" {>= "0.8.0"}
   "ipaddr" {= "2.9.0"}
   "lwt" {= "5.4.0"}
-  "uwt" {>= "0.0.4"}
+  "luv"
+  "luv_unix"
   "tcpip" {>= "3.3.0"}
   "base64" {>= "3.0.0"}
   "cstruct" {= "3.7.0"}
@@ -60,7 +62,7 @@ depends: [
   "mirage-vnetif" {>= "0.4.0"}
   "uuidm"
   "ezjsonm"
-  "sha"
+  "sha" {test}
   "stringext"
   "mirage-clock" {= "1.3.0"}
   "mirage-clock-lwt" {= "2.0.0"}


### PR DESCRIPTION
This is based on #539

It builds locally for me with `luv` rather than `uwt`. I also found some advice to use `apt-cyg` to install cygwin packages. There seems to be an opam 2 (`opam-installer`) and an `ocaml` 4.10 package already.

If this works then I think I'll rename `Makefile.darwin` into `Makefile` for all 3 platforms.