### PR TITLE
Don't calculate high_ip in DHCP configuration and zap outdated comment

### DIFF
--- a/src/hostnet/hostnet_dhcp.ml
+++ b/src/hostnet/hostnet_dhcp.ml
@@ -40,17 +40,12 @@ module Make (Clock: Mirage_clock_lwt.MCLOCK) (Netif: Mirage_net_lwt.S) = struct
   (* given some MACs and IPs, construct a usable DHCP configuration *)
   let make ~configuration:c clock netif =
     let open Dhcp_server.Config in
-    (* FIXME: We need a DHCP range to make the DHCP server happy, even though we
-       intend only to serve IPs to one downstream host.
-       see https://github.com/haesbaert/charrua-core/issues/27 - this may be
-       resolved in the future *)
-    let low_ip, high_ip =
+    let low_ip =
       let open Ipaddr.V4 in
       let all_static_ips = [ c.Configuration.gateway_ip; c.Configuration.lowest_ip ] in
       let highest = maximum_ip all_static_ips in
-      let i32 = to_int32 highest in
-      of_int32 @@ Int32.succ i32, of_int32 @@ Int32.succ @@ Int32.succ i32 in
-    let ip_list = [ c.Configuration.gateway_ip; low_ip; high_ip; c.Configuration.highest_ip ] in
+      of_int32 @@ Int32.succ (to_int32 highest) in
+    let ip_list = [ c.Configuration.gateway_ip; low_ip; c.Configuration.highest_ip ] in
     let prefix = smallest_prefix c.Configuration.lowest_ip ip_list 32 in
     (* Use the dhcp.json in preference, otherwise fall back to the DNS configuration *)
     let domain_search = match !global_dhcp_configuration with
@@ -95,7 +90,6 @@ module Make (Clock: Mirage_clock_lwt.MCLOCK) (Netif: Mirage_net_lwt.S) = struct
         ip_addr = c.Configuration.gateway_ip;
         mac_addr = c.Configuration.server_macaddr;
         network = prefix;
-        (* FIXME: this needs https://github.com/haesbaert/charrua-core/pull/31 *)
         range = Some (c.Configuration.lowest_ip, c.Configuration.lowest_ip); (* allow one dynamic client *)
       } in
 


### PR DESCRIPTION
This is a left over from when charrua would only work if there was a delta of at
least one between min and max addresses.

Also zap two outdated comments related to the same issue.

I can't really test this code since I have no environment so please be careful.

Relevant commits
https://github.com/mirage/charrua/commit/3c1995bab9679c0105c962d269bec92806868ffa
https://github.com/mirage/charrua/commit/0bb4464f41dab7fadc37bdda606fe76edaefc6d3