### PR TITLE
HTTP: add an optional allow list to the proxy

### DIFF
--- a/go/pkg/vpnkit/config.go
+++ b/go/pkg/vpnkit/config.go
@@ -29,7 +29,9 @@ type HTTPConfiguration struct {
 	Exclude               string   `json:"exclude,omitempty"`
 	TransparentHTTPPorts  []int    `json:"transparent_http_ports"`
 	TransparentHTTPSPorts []int    `json:"transparent_https_ports"`
+	AllowEnabled          bool     `json:"allow_enabled"`
 	Allow                 []string `json:"allow"`
+	AllorErrorMsg         string   `json:"allow_error_msg"`
 }
 
 func (h HTTPConfiguration) Write(w io.Writer) error {

--- a/go/pkg/vpnkit/config.go
+++ b/go/pkg/vpnkit/config.go
@@ -24,11 +24,12 @@ func (d DHCPConfiguration) Write(w io.Writer) error {
 
 // HTTPConfiguration configures the built-in HTTP proxy.
 type HTTPConfiguration struct {
-	HTTP                  string `json:"http,omitempty"`
-	HTTPS                 string `json:"https,omitempty"`
-	Exclude               string `json:"exclude,omitempty"`
-	TransparentHTTPPorts  []int  `json:"transparent_http_ports"`
-	TransparentHTTPSPorts []int  `json:"transparent_https_ports"`
+	HTTP                  string   `json:"http,omitempty"`
+	HTTPS                 string   `json:"https,omitempty"`
+	Exclude               string   `json:"exclude,omitempty"`
+	TransparentHTTPPorts  []int    `json:"transparent_http_ports"`
+	TransparentHTTPSPorts []int    `json:"transparent_https_ports"`
+	Allow                 []string `json:"allow"`
 }
 
 func (h HTTPConfiguration) Write(w io.Writer) error {

--- a/scripts/licenses.ml
+++ b/scripts/licenses.ml
@@ -503,8 +503,8 @@ src/arp_packet.ml mirage/arpv4.mli mirage/arpv4.ml
   }
   | "base.v0.14.2" | "base.v0.14.3"
   | "csexp.1.5.1"
-  | "dune.2.9.1" | "dune.2.9.2" | "dune.2.9.3"
-  | "dune-configurator.2.9.1" | "dune-configurator.2.9.3"
+  | "dune.2.9.1" | "dune.2.9.2" | "dune.2.9.3" | "dune.3.0.2" | "dune.3.0.3"
+  | "dune-configurator.2.9.1" | "dune-configurator.2.9.3" | "dune-configurator.3.0.2" | "dune-configurator.3.0.3"
   | "ocaml-compiler-libs.v0.12.4"
   | "ocaml-syntax-shims.1.0.0"
   | "parsexp.v0.14.2"

--- a/src/bin/logging.ml
+++ b/src/bin/logging.ml
@@ -2,9 +2,11 @@
 
   let pp_ptime f () =
     let open Unix in
-    let tm = Unix.gmtime (Unix.time ()) in
-    Fmt.pf f "time=\"%04d-%02d-%02dT%02d:%02d:%02dZ\"" (tm.tm_year + 1900) (tm.tm_mon + 1)
-      tm.tm_mday tm.tm_hour tm.tm_min tm.tm_sec
+    let s = Unix.gettimeofday () in
+    let tm = Unix.gmtime s in
+    let nsecs = Float.rem s Float.one *. 1e9 |> int_of_float in
+    Fmt.pf f "time=\"%04d-%02d-%02dT%02d:%02d:%02d.%09dZ\"" (tm.tm_year + 1900) (tm.tm_mon + 1)
+      tm.tm_mday tm.tm_hour tm.tm_min tm.tm_sec nsecs
 
 let reporter =
   let report src level ~over k msgf =

--- a/src/hostnet/hostnet_http.ml
+++ b/src/hostnet/hostnet_http.ml
@@ -196,38 +196,41 @@ module Make
   let default_error_msg = "Connections to %s are forbidden by policy. Please contact your IT administrator."
 
   let of_json j =
-    let open Ezjsonm in
-    let http =
-      try Some (get_string @@ find j [ "http" ])
-      with Not_found -> None
-    in
-    let https =
-      try Some (get_string @@ find j [ "https" ])
-      with Not_found -> None
-    in
-    let exclude =
-      try Match.of_string @@ get_string @@ find j [ "exclude" ]
-      with Not_found -> Match.none
-    in
-    let transparent_http_ports =
-      try get_list get_int @@ find j [ "transparent_http_ports" ]
-      with Not_found -> [ 80 ] in
-    let transparent_https_ports =
-      try get_list get_int @@ find j [ "transparent_https_ports" ]
-      with Not_found -> [ 443 ] in
-    let allow_enabled =
-      try (get_bool @@ find j [ "allow_enabled" ])
-      with Not_found -> false
-    in
-    let allow =
-      try List.map Match.One.of_string @@ get_list get_string @@ find j [ "allow" ]
-      with Not_found -> [] in
-    let allow_error_msg =
-      try get_string @@ find j [ "allow_error_msg" ]
-      with Not_found -> default_error_msg in
-    let http = match http with None -> None | Some x -> proxy_of_string x in
-    let https = match https with None -> None | Some x -> proxy_of_string x in
-    Lwt.return (Ok { http; https; exclude; transparent_http_ports; transparent_https_ports; allow_enabled; allow; allow_error_msg })
+    try
+      let open Ezjsonm in
+      let http =
+        try Some (get_string @@ find j [ "http" ])
+        with Not_found -> None
+      in
+      let https =
+        try Some (get_string @@ find j [ "https" ])
+        with Not_found -> None
+      in
+      let exclude =
+        try Match.of_string @@ get_string @@ find j [ "exclude" ]
+        with Not_found -> Match.none
+      in
+      let transparent_http_ports =
+        try get_list get_int @@ find j [ "transparent_http_ports" ]
+        with Not_found -> [ 80 ] in
+      let transparent_https_ports =
+        try get_list get_int @@ find j [ "transparent_https_ports" ]
+        with Not_found -> [ 443 ] in
+      let allow_enabled =
+        try (get_bool @@ find j [ "allow_enabled" ])
+        with Not_found -> false
+      in
+      let allow =
+        try List.map Match.One.of_string @@ get_list get_string @@ find j [ "allow" ]
+        with Not_found -> [] in
+      let allow_error_msg =
+        try get_string @@ find j [ "allow_error_msg" ]
+        with Not_found -> default_error_msg in
+      let http = match http with None -> None | Some x -> proxy_of_string x in
+      let https = match https with None -> None | Some x -> proxy_of_string x in
+      Lwt.return (Ok { http; https; exclude; transparent_http_ports; transparent_https_ports; allow_enabled; allow; allow_error_msg })
+    with e ->
+      Lwt.return (Error (`Msg (Printf.sprintf "parsing json: %s" (Printexc.to_string e))))
 
   let to_string t = Ezjsonm.to_string ~minify:false @@ to_json t
 

--- a/src/hostnet/hostnet_http.mli
+++ b/src/hostnet/hostnet_http.mli
@@ -1,4 +1,4 @@
-module Exclude: sig
+module Match: sig
   type t
   (** A request destination which should bypass the proxy *)
 

--- a/src/hostnet/hostnet_http.mli
+++ b/src/hostnet/hostnet_http.mli
@@ -25,7 +25,7 @@ sig
 
   val create: ?http:string -> ?https:string -> ?exclude:string
     -> ?transparent_http_ports:int list -> ?transparent_https_ports:int list
-    -> ?allow:string list
+    -> ?allow_enabled:bool -> ?allow:string list -> ?allow_error_msg:string
     -> unit ->
     (t, [`Msg of string]) result Lwt.t
   (** Create a transparent HTTP forwarding instance which forwards

--- a/src/hostnet/hostnet_http.mli
+++ b/src/hostnet/hostnet_http.mli
@@ -25,11 +25,14 @@ sig
 
   val create: ?http:string -> ?https:string -> ?exclude:string
     -> ?transparent_http_ports:int list -> ?transparent_https_ports:int list
+    -> ?allow:string list
     -> unit ->
     (t, [`Msg of string]) result Lwt.t
   (** Create a transparent HTTP forwarding instance which forwards
       HTTP to the proxy [http], HTTPS to the proxy [https] or connects
-      directly if the URL matches [exclude]. *)
+      directly if the URL matches [exclude].
+      If an allow list is provided then host names not on the list will
+      be rejected. *)
 
   val of_json: Ezjsonm.value -> (t, [`Msg of string]) result Lwt.t
   (** [of_json json] decodes [json] into a proxy configuration *)

--- a/src/hostnet_test/suite.ml
+++ b/src/hostnet_test/suite.ml
@@ -310,7 +310,7 @@ let test_tcp = [
 let tests =
   Hosts_test.tests @ Forwarding.tests @ test_dhcp
   @ Test_dns.suite
-  @ test_tcp @ Test_nat.tests @ Test_http.tests @ Test_http.Exclude.tests
+  @ test_tcp @ Test_nat.tests @ Test_http.tests @ Test_http.Match.tests
   @ Test_half_close.tests @ Test_ping.tests
   @ Test_bridge.tests @ Test_forward_protocol.suite
 

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -538,7 +538,13 @@ let test_http_connect_tunnel proxy () =
                 Lwt.wakeup_later forwarded_u ();
                 Lwt.return_unit
           ) (fun server ->
-            let json = Ezjsonm.from_string "{ }" in
+            let json = Ezjsonm.from_string {|
+            {
+                  "allow_enabled": true,
+                  "allow": [ "localhost" ],
+                  "allow_error_msg": "stop connecting to %s"
+            }
+                    |} in
             Slirp_stack.Slirp_stack.Debug.update_http_json json ()
             >>= function
             | Error (`Msg m) -> failwith ("Failed to enable HTTP proxy: " ^ m)
@@ -593,9 +599,61 @@ let test_http_connect_tunnel proxy () =
       )
     end
 
+  let test_http_proxy_connect_rejected () =
+    Host.Main.run begin
+    Slirp_stack.with_stack ~pcap:"test_http_proxy_connect_rejected.pcap" (fun _ stack ->
+      let json = Ezjsonm.from_string {|
+{
+      "allow_enabled": true,
+      "allow": [ "not-localhost" ],
+      "allow_error_msg": "stop connecting to %s"
+}
+        |} in
+      Slirp_stack.Slirp_stack.Debug.update_http_json json ()
+      >>= function
+      | Error (`Msg m) -> failwith ("Failed to enable HTTP proxy: " ^ m)
+      | Ok () ->
+        let open Slirp_stack in
+        Client.TCPV4.create_connection (Client.tcpv4 stack.t) (primary_dns_ip, 3128)
+        >>= function
+        | Error _ ->
+          Log.err (fun f -> f "Failed to connect to %s:3128" (Ipaddr.V4.to_string primary_dns_ip));
+          failwith "test_proxy_connect_rejected: connect failed"
+        | Ok flow ->
+          Log.info (fun f -> f "Connected to %s:3128" (Ipaddr.V4.to_string primary_dns_ip));
+          let oc = Outgoing.C.create flow in
+          let request =
+            let connect = Cohttp.Request.make ~meth:`CONNECT (Uri.make ()) in
+            let resource = Fmt.str "localhost:%d" 1234 in
+            { connect with Cohttp.Request.resource }
+          in
+          Outgoing.Request.write ~flush:true (fun _writer -> Lwt.return_unit) request oc
+          >>= fun () ->
+          Outgoing.Response.read oc
+          >>= function
+          | `Eof ->
+            failwith "test_proxy_connect_rejected: EOF on HTTP CONNECT"
+          | `Invalid x ->
+            failwith ("test_proxy_connect_rejected: Invalid HTTP response: " ^ x)
+          | `Ok res ->
+            if res.Cohttp.Response.status = `OK then failwith "test_proxy_connect_rejected: HTTP CONNECT accepted";
+            if res.Cohttp.Response.status <> `Forbidden
+            then failwith "test_proxy_connect_rejected: HTTP CONNECT did not fail with forbidden";
+            Lwt.return (`Result ())
+    )
+      >|= function
+      | `Timeout  -> failwith "HTTP interception failed"
+      | `Result x -> x
+    end
+
   let test_http_proxy_connect_fail () =
     Host.Main.run begin
       Slirp_stack.with_stack ~pcap:"test_http_proxy_connect_fail.pcap" (fun _ stack ->
+        let json = Ezjsonm.from_string "{ }" in
+        Slirp_stack.Slirp_stack.Debug.update_http_json json ()
+        >>= function
+        | Error (`Msg m) -> failwith ("Failed to enable HTTP proxy: " ^ m)
+        | Ok () ->
         let open Slirp_stack in
         Client.TCPV4.create_connection (Client.tcpv4 stack.t) (primary_dns_ip, 3128)
         >>= function
@@ -1012,12 +1070,14 @@ let proxy_urls = [
 ) Slirp_stack.names_for_localhost)
 
 let tests = [
-
   "HTTP: interception",
   [ "", `Quick, test_interception "http://127.0.0.1" ];
 
   "HTTP proxy: CONNECT",
   [ "check that HTTP CONNECT requests through the proxy", `Quick, test_http_proxy_connect ];
+
+  "HTTP proxy: CONNECT rejected",
+  [ "check that HTTP CONNECT requests must match the allow list", `Quick, test_http_proxy_connect_rejected ];
 
   "HTTP proxy: CONNECT fails",
   [ "check that HTTP CONNECT fails if the port is not found", `Quick, test_http_proxy_connect_fail ];

--- a/src/hostnet_test/test_http.ml
+++ b/src/hostnet_test/test_http.ml
@@ -7,58 +7,58 @@ let src =
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
-module Exclude = struct
+module Match = struct
 
   let test_ip_match () =
-    let exclude = Hostnet_http.Exclude.of_string "10.0.0.1" in
-    assert (Hostnet_http.Exclude.matches "10.0.0.1" exclude)
+    let exclude = Hostnet_http.Match.of_string "10.0.0.1" in
+    assert (Hostnet_http.Match.matches "10.0.0.1" exclude)
 
   let test_cidr_match () =
-    let exclude = Hostnet_http.Exclude.of_string "10.0.0.0/24" in
-    assert (Hostnet_http.Exclude.matches "10.0.0.1" exclude)
+    let exclude = Hostnet_http.Match.of_string "10.0.0.0/24" in
+    assert (Hostnet_http.Match.matches "10.0.0.1" exclude)
 
   let test_cidr_no_match () =
-    let exclude = Hostnet_http.Exclude.of_string "10.0.0.0/24" in
-    assert (not(Hostnet_http.Exclude.matches
+    let exclude = Hostnet_http.Match.of_string "10.0.0.0/24" in
+    assert (not(Hostnet_http.Match.matches
                   "192.168.0.1"
                   exclude))
 
   let test_domain_match () =
-    let exclude = Hostnet_http.Exclude.of_string "mit.edu" in
-    assert (Hostnet_http.Exclude.matches
+    let exclude = Hostnet_http.Match.of_string "mit.edu" in
+    assert (Hostnet_http.Match.matches
                   "dave.mit.edu"
                   exclude)
 
   let test_domain_star_match () =
-    let exclude = Hostnet_http.Exclude.of_string "*.mit.edu" in
-    assert (Hostnet_http.Exclude.matches
+    let exclude = Hostnet_http.Match.of_string "*.mit.edu" in
+    assert (Hostnet_http.Match.matches
                   "dave.mit.edu"
                   exclude)
 
   let test_domain_dot_match () =
-    let exclude = Hostnet_http.Exclude.of_string ".mit.edu" in
-    assert (Hostnet_http.Exclude.matches
+    let exclude = Hostnet_http.Match.of_string ".mit.edu" in
+    assert (Hostnet_http.Match.matches
                   "dave.mit.edu"
                   exclude)
 
   let test_domain_no_match () =
-    let exclude = Hostnet_http.Exclude.of_string "mit.edu" in
-    assert (not(Hostnet_http.Exclude.matches
+    let exclude = Hostnet_http.Match.of_string "mit.edu" in
+    assert (not(Hostnet_http.Match.matches
                   "www.mobyproject.org"
                   exclude))
 
   let test_list () =
-    let exclude = Hostnet_http.Exclude.of_string "*.local, 169.254.0.0/16" in
-    assert (Hostnet_http.Exclude.matches
+    let exclude = Hostnet_http.Match.of_string "*.local, 169.254.0.0/16" in
+    assert (Hostnet_http.Match.matches
                   "dave.local"
                   exclude);
-    assert (Hostnet_http.Exclude.matches
+    assert (Hostnet_http.Match.matches
                   "169.254.0.1"
                   exclude);
-    assert (not(Hostnet_http.Exclude.matches
+    assert (not(Hostnet_http.Match.matches
                   "10.0.0.1"
                   exclude));
-    assert (not(Hostnet_http.Exclude.matches
+    assert (not(Hostnet_http.Match.matches
                   "www.mobyproject.org"
                   exclude))
 


### PR DESCRIPTION
This allows an admin to set an allow list, such that requests for other domains / CIDRs / IPs will be blocked.

It re-uses the existing HTTP exclude matching functions.

There is still some work needed to distinguish the case `None` and `Some []` in the .json configuration.