### PR TITLE
go: fix typo in struct field name

### DIFF
--- a/go/pkg/vpnkit/config.go
+++ b/go/pkg/vpnkit/config.go
@@ -31,7 +31,7 @@ type HTTPConfiguration struct {
 	TransparentHTTPSPorts []int    `json:"transparent_https_ports"`
 	AllowEnabled          bool     `json:"allow_enabled"`
 	Allow                 []string `json:"allow"`
-	AllorErrorMsg         string   `json:"allow_error_msg"`
+	AllowErrorMsg         string   `json:"allow_error_msg"`
 }
 
 func (h HTTPConfiguration) Write(w io.Writer) error {


### PR DESCRIPTION
Signed-off-by: David Scott <dave@recoil.org>