### PR TITLE
appveyor: ensure we generate the COMMIT artefact

### DIFF
--- a/scripts/appveyor.sh
+++ b/scripts/appveyor.sh
@@ -4,6 +4,7 @@ set -e
 
 cd "${APPVEYOR_BUILD_FOLDER}"
 
+rm -f _build/default/COMMIT
 opam exec -- dune build COMMIT
 opam exec -- dune build licenses.json
 opam exec -- dune build vpnkit.exe


### PR DESCRIPTION
Previous builds seemed to have a cached COMMIT file. Dune doesn't have a "PHONY" concept as far as I can see, perhaps it was a mistake to move this code in there.