### PR TITLE
switch: request a large enough buffer for the MTU

### DIFF
--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -1158,7 +1158,7 @@ struct
                 (Macaddr.to_string eth_src) (Macaddr.to_string eth_dst));
           (* pass to virtual network *)
           begin
-            Vnet.write vnet_switch t.vnet_client_id ~size:Ethernet.Packet.sizeof_ethernet (fun toBuf ->
+            Vnet.write vnet_switch t.vnet_client_id ~size:c.Configuration.mtu (fun toBuf ->
               Cstruct.blit buf 0 toBuf 0 (Cstruct.length buf);
               Cstruct.length buf)
             >|= function


### PR DESCRIPTION
Previously we used "sizeof_ethernet" which is the "size of the Ethernet header" (!) Most of the time the buffer is big enough anyway, but this explains the occasional Cstrict.blit errors in the log when a 14 byte buffer is used.

Signed-off-by: David Scott <dave@recoil.org>