### PR TITLE
Unlisten sockets after they disconnect

### DIFF
--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -354,6 +354,8 @@ struct
                let dst = Stack_tcp_wire.src id in
                Stack_tcp.input t.tcp4 ~src ~dst buf
             ) (fun () ->
+                let src_port = Stack_tcp_wire.src_port id in
+                Stack_tcp.unlisten t.tcp4 ~port:src_port;
                 t.pending <- Tcp.Id.Set.remove id t.pending;
                 Lwt.return_unit;
               )


### PR DESCRIPTION
After a successful connection forwarding to a server, if the server
disappears, a tentative to connect the server again will be accepted by
vpnkit even if vpnkit failed to reach the server.
Ensure this does not occur by calling unlisten.
Add test for valid and invalid connection cases

Signed-off-by: Frédéric Dalleau <frederic.dalleau@docker.com>