### PR TITLE
libproxy: allow read/write buffers to be set

### DIFF
--- a/go/pkg/libproxy/multiplexed_test.go
+++ b/go/pkg/libproxy/multiplexed_test.go
@@ -506,6 +506,9 @@ func TestMuxConcurrent(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer server.Close()
+			// Set the read/write buffer sizes to unusual values.
+			server.SetReadBuffer(defaultWindowSize - 1)
+			server.SetWriteBuffer(defaultWindowSize - 1)
 			done, sha := writeRandomBuffer(server, toWrite)
 			m.Lock()
 			serverWriteSha[destination.Port] = sha

--- a/go/pkg/libproxy/udp_encapsulation.go
+++ b/go/pkg/libproxy/udp_encapsulation.go
@@ -3,6 +3,7 @@ package libproxy
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"io"
 	"net"
 	"sync"
@@ -19,7 +20,7 @@ type UDPListener interface {
 
 // UDPEncapsulator implements net.Conn and reads and writes UDP datagrams framed within a stream connection
 type uDPEncapsulator interface {
-	Conn
+	MultiplexedConn
 	ReadFromUDP(b []byte) (int, *net.UDPAddr, error)
 	WriteToUDP(b []byte, addr *net.UDPAddr) (int, error)
 }
@@ -88,6 +89,14 @@ func (u *udpEncapsulator) SetDeadline(t time.Time) error {
 
 func (u *udpEncapsulator) SetReadDeadline(t time.Time) error {
 	return u.conn.SetReadDeadline(t)
+}
+
+func (u *udpEncapsulator) SetReadBuffer(b uint) error {
+	return errors.New("udpEncapsulator.SetReadBuffer not supported")
+}
+
+func (u *udpEncapsulator) SetWriteBuffer(b uint) error {
+	return errors.New("udpEncapsulator.SetWriteBuffer not supported")
 }
 
 func (u *udpEncapsulator) SetWriteDeadline(t time.Time) error {

--- a/go/pkg/vpnkit/forward/forward_test.go
+++ b/go/pkg/vpnkit/forward/forward_test.go
@@ -25,12 +25,12 @@ func (m *mockMux) IsRunning() bool {
 	return true
 }
 
-func (m *mockMux) Dial(d libproxy.Destination) (libproxy.Conn, error) {
+func (m *mockMux) Dial(d libproxy.Destination) (libproxy.MultiplexedConn, error) {
 	m.dialed = &d
 	return nil, errors.New("unimplemented Dial")
 }
 
-func (m *mockMux) Accept() (libproxy.Conn, *libproxy.Destination, error) {
+func (m *mockMux) Accept() (libproxy.MultiplexedConn, *libproxy.Destination, error) {
 	return nil, nil, errors.New("unimplemented Accept")
 }
 


### PR DESCRIPTION
If the link has high latency then it's useful to use larger buffers

Signed-off-by: David Scott <dave.scott@docker.com>