### PR TITLE
libproxy: ability to Close(), expose NewLoopback()

### DIFF
--- a/go/pkg/libproxy/loopbackconn.go
+++ b/go/pkg/libproxy/loopbackconn.go
@@ -143,7 +143,8 @@ type loopback struct {
 	simulateLatency time.Duration
 }
 
-func newLoopback() *loopback {
+// NewLoopback creates a bidirectional buffered connection, intended for testing.
+func NewLoopback() *loopback {
 	write := newBufferedPipe()
 	read := newBufferedPipe()
 	return &loopback{
@@ -151,6 +152,8 @@ func newLoopback() *loopback {
 		read:  read,
 	}
 }
+
+var _ io.ReadWriteCloser = &loopback{}
 
 func (l *loopback) LocalAddr() net.Addr {
 	return &addrLoopback{}

--- a/go/pkg/libproxy/loopbackconn_test.go
+++ b/go/pkg/libproxy/loopbackconn_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestWrite(t *testing.T) {
 	// Check that writes don't block
-	l := newLoopback()
+	l := NewLoopback()
 	n, err := l.Write([]byte("hello"))
 	if err != nil {
 		t.Fatal(err)
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) {
 
 func TestWriteRead(t *testing.T) {
 	// Check that read works after write
-	local := newLoopback()
+	local := NewLoopback()
 	n, err := local.Write([]byte("hello"))
 	if err != nil {
 		t.Fatal(err)
@@ -32,7 +32,7 @@ func TestWriteRead(t *testing.T) {
 
 func TestWriteCloseWriteRead(t *testing.T) {
 	// test that write, closewrite, read doesn't drop data
-	local := newLoopback()
+	local := NewLoopback()
 	n, err := local.Write([]byte("hello"))
 	if err != nil {
 		t.Fatal(err)
@@ -54,7 +54,7 @@ func TestWriteCloseWriteRead(t *testing.T) {
 
 func TestWriteCloseRead(t *testing.T) {
 	// test that write, closewrite, read doesn't drop data
-	local := newLoopback()
+	local := NewLoopback()
 	n, err := local.Write([]byte("hello"))
 	if err != nil {
 		t.Fatal(err)

--- a/go/pkg/libproxy/multiplexed.go
+++ b/go/pkg/libproxy/multiplexed.go
@@ -381,6 +381,9 @@ func NewMultiplexer(label string, conn io.ReadWriteCloser, allocateBackwards boo
 
 // Close the underlying transport.
 func (m *multiplexer) Close() error {
+	m.metadataMutex.Lock()
+	m.isRunning = false
+	m.metadataMutex.Unlock()
 	return m.conn.Close()
 }
 
@@ -492,14 +495,16 @@ func (m *multiplexer) Run() {
 	m.isRunning = true
 	m.metadataMutex.Unlock()
 	go func() {
-		if err := m.run(); err != nil {
-			if err == io.EOF {
-				// This is expected when the data connection is broken
-				log.Infof("disconnected data connection: multiplexer is offline")
-			} else {
-				log.Printf("Multiplexer main loop failed with %v", err)
-				m.DumpState(log.Writer())
-			}
+		err := m.run()
+		m.metadataMutex.Lock()
+		expected := err == io.EOF || !m.isRunning
+		m.metadataMutex.Unlock()
+		if expected {
+			// This is expected when the data connection is broken
+			log.Infof("disconnected data connection: multiplexer is offline")
+		} else if err != nil {
+			log.Printf("Multiplexer main loop failed with %v", err)
+			m.DumpState(log.Writer())
 		}
 		m.metadataMutex.Lock()
 		m.isRunning = false

--- a/go/pkg/libproxy/multiplexed_test.go
+++ b/go/pkg/libproxy/multiplexed_test.go
@@ -45,7 +45,7 @@ func newMultiplexer(name string, conn io.ReadWriteCloser, allocateBackwards bool
 }
 
 func TestNew(t *testing.T) {
-	loopback := newLoopback()
+	loopback := NewLoopback()
 	local, remote := newLoopbackMultiplexer(t, loopback)
 	client, err := local.Dial(Destination{
 		Proto: TCP,
@@ -68,7 +68,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
-	loopback := newLoopback()
+	loopback := NewLoopback()
 	local, remote := newLoopbackMultiplexer(t, loopback)
 	// There was a bug where the second iteration failed because the main loop had deadlocked
 	// when it received a Close message.
@@ -95,7 +95,7 @@ func TestClose(t *testing.T) {
 }
 
 func TestUDPEncapsulationIsTransparent(t *testing.T) {
-	loopback := newLoopback()
+	loopback := NewLoopback()
 	local, remote := newLoopbackMultiplexer(t, loopback)
 
 	client, err := local.Dial(Destination{
@@ -135,7 +135,7 @@ func TestUDPEncapsulationIsTransparent(t *testing.T) {
 }
 
 func TestCloseClose(t *testing.T) {
-	loopback := newLoopback()
+	loopback := NewLoopback()
 	local, remote := newLoopbackMultiplexer(t, loopback)
 	// There was a bug where the second iteration failed because the main loop had deadlocked
 	// when it received a Close message.
@@ -168,7 +168,7 @@ func TestCloseClose(t *testing.T) {
 }
 
 func TestCloseWriteCloseWrite(t *testing.T) {
-	loopback := newLoopback()
+	loopback := NewLoopback()
 	local, remote := newLoopbackMultiplexer(t, loopback)
 	// There was a bug where the second iteration failed because the main loop had deadlocked
 	// when it received a Close message.
@@ -201,7 +201,7 @@ func TestCloseWriteCloseWrite(t *testing.T) {
 }
 
 func TestCloseCloseWrite(t *testing.T) {
-	loopback := newLoopback()
+	loopback := NewLoopback()
 	local, remote := newLoopbackMultiplexer(t, loopback)
 	// There was a bug where the second iteration failed because the main loop had deadlocked
 	// when it received a Close message.
@@ -234,7 +234,7 @@ func TestCloseCloseWrite(t *testing.T) {
 }
 
 func TestCloseWriteWrite(t *testing.T) {
-	loopback := newLoopback()
+	loopback := NewLoopback()
 	local, remote := newLoopbackMultiplexer(t, loopback)
 	client, err := local.Dial(Destination{
 		Proto: TCP,
@@ -270,7 +270,7 @@ func TestCloseWriteWrite(t *testing.T) {
 }
 
 func TestCloseThenWrite(t *testing.T) {
-	loopback := newLoopback()
+	loopback := NewLoopback()
 	local, remote := newLoopbackMultiplexer(t, loopback)
 	// There was a bug where the second iteration failed because the main loop had deadlocked
 	// when it received a Close message.
@@ -311,7 +311,7 @@ func TestCloseThenWrite(t *testing.T) {
 }
 
 func TestReadDeadline(t *testing.T) {
-	loopback := newLoopback()
+	loopback := NewLoopback()
 	local, remote := newLoopbackMultiplexer(t, loopback)
 	client, err := local.Dial(Destination{
 		Proto: TCP,
@@ -342,7 +342,7 @@ func TestReadDeadline(t *testing.T) {
 }
 
 func TestWriteDeadline(t *testing.T) {
-	loopback := newLoopback()
+	loopback := NewLoopback()
 	local, remote := newLoopbackMultiplexer(t, loopback)
 	client, err := local.Dial(Destination{
 		Proto: TCP,
@@ -473,7 +473,7 @@ func TestMuxCorners(t *testing.T) {
 	for _, toWriteClient := range interesting {
 		for _, toWriteServer := range interesting {
 			log.Printf("Client will write %d and server will write %d", toWriteClient, toWriteServer)
-			loopback := newLoopback()
+			loopback := NewLoopback()
 			local, remote := newLoopbackMultiplexer(t, loopback)
 			muxReadWrite(t, local, remote, toWriteClient, toWriteServer)
 		}
@@ -481,13 +481,13 @@ func TestMuxCorners(t *testing.T) {
 }
 
 func TestMuxReadWrite(t *testing.T) {
-	loopback := newLoopback()
+	loopback := NewLoopback()
 	local, remote := newLoopbackMultiplexer(t, loopback)
 	muxReadWrite(t, local, remote, 1048576, 1048576)
 }
 
 func TestMuxConcurrent(t *testing.T) {
-	loopback := newLoopback()
+	loopback := NewLoopback()
 	local, remote := newLoopbackMultiplexer(t, loopback)
 	numConcurrent := 500 // limited by the race detector
 	toWrite := 65536 * 2 // 2 * Window size
@@ -611,7 +611,7 @@ func TestWindow(t *testing.T) {
 	// Check that one connection blocked on a window update doesn't preclude
 	// other connections from working i.e. the lowlevel connection handler isn't
 	// itself blocked in a write()
-	loopback := newLoopback()
+	loopback := NewLoopback()
 	local, remote := newLoopbackMultiplexer(t, loopback)
 
 	done := writeAndBlock(t, local, remote)
@@ -629,7 +629,7 @@ func TestWindow(t *testing.T) {
 }
 
 func TestEOF(t *testing.T) {
-	loopback := newLoopback()
+	loopback := NewLoopback()
 	if err := loopback.OtherEnd().Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -640,7 +640,7 @@ func TestEOF(t *testing.T) {
 }
 
 func TestCrossChannelOpening(t *testing.T) {
-	loopback := newLoopback()
+	loopback := NewLoopback()
 	muxHost, muxGuest := newLoopbackMultiplexer(t, loopback)
 	acceptG := &errgroup.Group{}
 	acceptG.Go(func() error {

--- a/go/pkg/libproxy/multiplexed_test.go
+++ b/go/pkg/libproxy/multiplexed_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -52,19 +54,13 @@ func TestNew(t *testing.T) {
 		IP:    net.ParseIP("127.0.0.1"),
 		Port:  8080,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 	server, _, err := remote.Accept()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := client.Close(); err != nil {
-		t.Fatal(err)
-	}
-	if err := server.Close(); err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
+	assert.Nil(t, client.Close())
+	assert.Nil(t, server.Close())
+	assert.Nil(t, local.Close())
+	assert.Nil(t, remote.Close())
 }
 
 func TestClose(t *testing.T) {


### PR DESCRIPTION
- `Close()` allows us to cleanly shutdown the multiplexer (similar to `Close()` on a `net.Listener`)
- `NewLoopback()` satisfies the interface of the multiplexer, which makes it easier to write test cases in downstream projects