### PR TITLE
appveyor: choose a cygwin mirror

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ environment:
     PINS: "vpnkit:."
     PACKAGE: "vpnkit"
     OPAM_SWITCH: 4.08.0+mingw64c
+    CYG_MIRROR: https://mirrors.kernel.org/sourceware/cygwin/
 
 install:
   - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/$env:FORK_USER/ocaml-ci-scripts/$env:FORK_BRANCH/appveyor-install.ps1"))


### PR DESCRIPTION
The instructions[1] say

> The mirror for this task must be specified manually.

[1] https://github.com/ocaml/ocaml-ci-scripts/blob/master/README-appveyor.md

Signed-off-by: David Scott <dave@recoil.org>