### PR TITLE
Add a mechanism to forward outgoing TCP via a Unix domain socket

### DIFF
--- a/go/pkg/tunnel/forwards.go
+++ b/go/pkg/tunnel/forwards.go
@@ -1,0 +1,65 @@
+package tunnel
+
+import (
+	"encoding/json"
+	"net"
+
+	"github.com/pkg/errors"
+)
+
+// Forward traffic for the given IP destination to the tunnel server on the Unix domain socket path.
+type Forward struct {
+	Protocol  Protocol   // Protocol to be forwarded.
+	DstPrefix *net.IPNet // Traffic matching this network prefix will be sent via the tunnel.
+	DstPort   int        // Traffic with this destination port will be sent via the tunnel.
+	Path      string     // Path of the tunnel server.
+}
+
+const EveryPort = 0 // EveryPort should be sent through the tunnel
+
+// UnmarshalForwards returns a parsed forwards specification.
+func UnmarshalForwards(b []byte) ([]Forward, error) {
+	var raw []forward
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return nil, errors.Wrap(err, "unmarshalling forwards")
+	}
+	var results []Forward
+	for _, f := range raw {
+		protocol, err := readProtocol(f.Protocol)
+		if err != nil {
+			return nil, err
+		}
+		_, net, err := net.ParseCIDR(f.DstPrefix)
+		if err != nil {
+			return nil, errors.Wrapf(err, "parsing IP network %s", f.DstPrefix)
+		}
+		results = append(results, Forward{
+			Protocol:  protocol,
+			DstPrefix: net,
+			DstPort:   f.DstPort,
+			Path:      f.Path,
+		})
+	}
+	return results, nil
+}
+
+// MarshalForwards returns a forwards specification in json format.
+func MarshalForwards(all []Forward) ([]byte, error) {
+	var raw []forward
+	for _, f := range all {
+		raw = append(raw, forward{
+			Protocol:  string(f.Protocol),
+			DstPrefix: f.DstPrefix.String(),
+			DstPort:   f.DstPort,
+			Path:      f.Path,
+		})
+	}
+	return json.Marshal(raw)
+}
+
+type forward struct {
+	Protocol  string `json:"protocol"`
+	DstPrefix string `json:"dst_prefix"`
+	DstPort   int    `json:"dst_port"`
+	Path      string `json:"path"`
+}

--- a/go/pkg/tunnel/tunnel.go
+++ b/go/pkg/tunnel/tunnel.go
@@ -1,0 +1,97 @@
+package tunnel
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"net"
+
+	"github.com/pkg/errors"
+)
+
+type Protocol string
+
+const (
+	TCP = Protocol("tcp")
+	UDP = Protocol("udp")
+)
+
+// Request to open a tunnel.
+type Request struct {
+	Protocol Protocol
+	DstIP    net.IP // DstIP is the Destination IP address.
+	DstPort  int    // DstPort is the Destination Port.
+	SrcIP    net.IP // SrcIP is the Source IP address.
+	SrcPort  int    // SrcPort is the Source Port.
+}
+
+// ReadRequest from vpnkit to open a tunnel to a remote service.
+func ReadRequest(r io.Reader) (*Request, error) {
+	var len uint16
+	if err := binary.Read(r, binary.LittleEndian, &len); err != nil {
+		return nil, errors.Wrap(err, "reading request length")
+	}
+	buf := make([]byte, len)
+	if err := binary.Read(r, binary.LittleEndian, &buf); err != nil {
+		return nil, errors.Wrap(err, "reading request")
+	}
+	var req request
+	if err := json.Unmarshal(buf, &req); err != nil {
+		return nil, errors.Wrap(err, "parsing request json")
+	}
+	var result Request
+	var err error
+	result.Protocol, err = readProtocol(req.Protocol)
+	if err != nil {
+		return nil, err
+	}
+	result.Protocol = Protocol(req.Protocol)
+	result.DstIP = net.ParseIP(req.DstIP)
+	if result.DstIP == nil {
+		return nil, errors.New("invalid DstIP " + req.DstIP)
+	}
+	result.DstPort = req.DstPort
+	result.SrcIP = net.ParseIP(req.SrcIP)
+	if result.SrcIP == nil {
+		return nil, errors.New("invalid SrcIP " + req.SrcIP)
+	}
+	result.SrcPort = req.SrcPort
+	return &result, nil
+}
+
+func readProtocol(p string) (Protocol, error) {
+	switch p {
+	case "tcp":
+		return TCP, nil
+	case "udp":
+		return UDP, nil
+	}
+	return "", errors.New("unknown protocol: " + p)
+}
+
+// Matches protocol definition in src/hostnet/forwards.ml
+type request struct {
+	Protocol string `json:"protocol"`
+	DstIP    string `json:"dst_ip"`
+	DstPort  int    `json:"dst_port"`
+	SrcIP    string `json:"src_ip"`
+	SrcPort  int    `json:"src_port"`
+}
+
+// Response to the tunnel open request.
+type Response struct {
+	Accepted bool `json:"accepted"` // Accepted is true if the tunnel is now connected.
+}
+
+func (r *Response) Write(w io.Writer) error {
+	buf, err := json.Marshal(r)
+	if err != nil {
+		return errors.Wrap(err, "marsalling response")
+	}
+	len := uint16(len(buf))
+	if err := binary.Write(w, binary.LittleEndian, len); err != nil {
+		return errors.Wrap(err, "writing length")
+	}
+	_, err = w.Write(buf)
+	return errors.Wrap(err, "writing payload")
+}

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -483,7 +483,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       max_connections port_forwards dns http hosts host_names gateway_names
       vm_names listen_backlog port_max_idle_time debug
       server_macaddr domain allowed_bind_addresses gateway_ip host_ip lowest_ip highest_ip
-      dhcp_json_path mtu udpv4_forwards tcpv4_forwards gateway_forwards_path gc_compact
+      dhcp_json_path mtu udpv4_forwards tcpv4_forwards gateway_forwards_path forwards_path gc_compact
     =
     let level =
       let env_debug =
@@ -543,6 +543,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
       udpv4_forwards;
       tcpv4_forwards;
       gateway_forwards_path;
+      forwards_path;
       pcap_snaplen;
     } in
     match socket_url with
@@ -816,6 +817,14 @@ let gateway_forwards_path =
   in
   Arg.(value & opt (some string) None doc)
 
+let forwards_path =
+  let doc =
+    Arg.info ~doc:
+      "Path of forwards configuration file"
+      [ "forwards" ]
+  in
+  Arg.(value & opt (some string) None doc)
+
 let gc_compact =
   let doc =
     Arg.info ~doc:
@@ -837,7 +846,7 @@ let command =
         $ host_names $ gateway_names $ vm_names $ listen_backlog $ port_max_idle_time $ debug
         $ server_macaddr $ domain $ allowed_bind_addresses $ gateway_ip $ host_ip
         $ lowest_ip $ highest_ip $ dhcp_json_path $ mtu $ udpv4_forwards $ tcpv4_forwards
-        $ gateway_forwards_path $ gc_compact),
+        $ gateway_forwards_path $ forwards_path $ gc_compact),
   Term.info (Filename.basename Sys.argv.(0)) ~version:Version.git ~doc ~man
 
 let () =

--- a/src/hostnet/configuration.ml
+++ b/src/hostnet/configuration.ml
@@ -57,11 +57,12 @@ type t = {
   udpv4_forwards: Gateway_forwards.t;
   tcpv4_forwards: Gateway_forwards.t;
   gateway_forwards_path: string option;
+  forwards_path: string option;
   pcap_snaplen: int;
 }
 
 let to_string t =
-  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns_path = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; gateway_ip = %s; host_ip = %s; lowest_ip = %s; highest_ip = %s; dhcp_json_path = %s; dhcp_configuration = %s; mtu = %d; http_intercept = %s; http_intercept_path = %s; port_max_idle_time = %s; host_names = %s; gateway_names = %s; vm_names = %s; udpv4_forwards = %s; tcpv4_forwards = %s; gateway_forwards_path = %s; pcap_snaplen = %d"
+  Printf.sprintf "server_macaddr = %s; max_connection = %s; dns_path = %s; dns = %s; resolver = %s; domain = %s; allowed_bind_addresses = %s; gateway_ip = %s; host_ip = %s; lowest_ip = %s; highest_ip = %s; dhcp_json_path = %s; dhcp_configuration = %s; mtu = %d; http_intercept = %s; http_intercept_path = %s; port_max_idle_time = %s; host_names = %s; gateway_names = %s; vm_names = %s; udpv4_forwards = %s; tcpv4_forwards = %s; gateway_forwards_path = %s; forwards_path = %s; pcap_snaplen = %d"
     (Macaddr.to_string t.server_macaddr)
     (match t.max_connections with None -> "None" | Some x -> string_of_int x)
     (match t.dns_path with None -> "None" | Some x -> x)
@@ -85,6 +86,7 @@ let to_string t =
     (Gateway_forwards.to_string t.udpv4_forwards)
     (Gateway_forwards.to_string t.tcpv4_forwards)
     (match t.gateway_forwards_path with None -> "None" | Some x -> x)
+    (match t.forwards_path with None -> "None" | Some x -> x)
     t.pcap_snaplen
 
 let no_dns_servers =
@@ -132,6 +134,7 @@ let default = {
   udpv4_forwards = [];
   tcpv4_forwards = [];
   gateway_forwards_path = None;
+  forwards_path = None;
   pcap_snaplen = default_pcap_snaplen;
 }
 

--- a/src/hostnet/forwards.ml
+++ b/src/hostnet/forwards.ml
@@ -416,3 +416,72 @@ module Stream = struct
       | `Forwarded flow -> Forwarded.shutdown_read flow
   end
 end
+
+module Test (Clock : Mirage_clock.MCLOCK) = struct
+  module Remote = Read_some (Host.Sockets.Stream.Unix)
+
+  module Proxy =
+    Mirage_flow_combinators.Proxy (Clock) (Remote) (Host.Sockets.Stream.Tcp)
+
+  module Handshake = Handshake (Remote)
+  open Lwt.Infix
+
+  type server = Host.Sockets.Stream.Unix.server
+
+  let start_forwarder path =
+    Host.Sockets.Stream.Unix.bind path >>= fun s ->
+    Host.Sockets.Stream.Unix.listen s (fun flow ->
+        Log.info (fun f -> f "accepted flow");
+        let local = Remote.connect flow in
+        Handshake.Request.read local >>= function
+        | Error e ->
+            Log.info (fun f ->
+                f "reading handshake request %a" Handshake.Message.pp_error e);
+            Lwt.return_unit
+        | Ok h -> (
+            let req = Handshake.Request.to_string h in
+            Log.info (fun f -> f "%s: connecting" req);
+            Host.Sockets.Stream.Tcp.connect
+              (h.Handshake.Request.dst_ip, h.Handshake.Request.dst_port)
+            >>= function
+            | Error (`Msg m) -> (
+                Log.info (fun f -> f "%s: %s" req m);
+                Handshake.Response.write local
+                  { Handshake.Response.accepted = false }
+                >>= function
+                | Error e ->
+                    Log.info (fun f ->
+                        f "%s: writing handshake response %a" req
+                          Remote.pp_write_error e);
+                    Lwt.return_unit
+                | Ok () ->
+                    Log.info (fun f -> f "%s: returned handshake response" req);
+                    Lwt.return_unit)
+            | Ok remote ->
+                Log.info (fun f -> f "%s: connected" req);
+                Lwt.finalize
+                  (fun () ->
+                    Handshake.Response.write local
+                      { Handshake.Response.accepted = true }
+                    >>= function
+                    | Error e ->
+                        Log.info (fun f ->
+                            f "%s: writing handshake response %a" req
+                              Remote.pp_write_error e);
+                        Lwt.return_unit
+                    | Ok () -> (
+                        Log.info (fun f -> f "%s: proxying data" req);
+                        Proxy.proxy local remote >>= function
+                        | Error e ->
+                            Log.info (fun f ->
+                                f "%s: TCP proxy failed with %a" req
+                                  Proxy.pp_error e);
+                            Lwt.return_unit
+                        | Ok (_l_stats, _r_stats) -> Lwt.return_unit))
+                  (fun () ->
+                    Log.info (fun f -> f "%s: disconnecting from remote" req);
+                    Host.Sockets.Stream.Tcp.close remote)));
+    Lwt.return s
+
+  let shutdown = Host.Sockets.Stream.Unix.shutdown
+end

--- a/src/hostnet/forwards.ml
+++ b/src/hostnet/forwards.ml
@@ -1,0 +1,100 @@
+let src =
+  let src =
+    Logs.Src.create "forwards" ~doc:"Forwards TCP/UDP streams to local services"
+  in
+  Logs.Src.set_level src (Some Logs.Info);
+  src
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+module Protocol = struct
+  type t = [ `Tcp ]
+  (* consider UDP later *)
+
+  open Ezjsonm
+
+  let to_json t = string (match t with `Tcp -> "tcp")
+
+  let of_json j =
+    match get_string j with
+    | "tcp" -> `Tcp
+    | _ -> raise (Parse_error (j, "protocol should be tcp"))
+end
+
+type forward = {
+  protocol : Protocol.t;
+  dst_prefix : Ipaddr.Prefix.t;
+  dst_port : int;
+  path : string; (* unix domain socket path *)
+}
+
+let forward_to_json t =
+  let open Ezjsonm in
+  dict
+    [
+      ("protocol", Protocol.to_json t.protocol);
+      ("dst_prefix", string (Ipaddr.Prefix.to_string t.dst_prefix));
+      ("dst_port", int t.dst_port);
+      ("path", string t.path);
+    ]
+
+let forward_of_json j =
+  let open Ezjsonm in
+  let protocol = Protocol.of_json @@ find j [ "protocol" ] in
+  let dst_port = get_int @@ find j [ "dst_port" ] in
+  let path = get_string @@ find j [ "path" ] in
+  let dst_prefix =
+    match Ipaddr.Prefix.of_string @@ get_string @@ find j [ "dst_prefix" ] with
+    | Error (`Msg m) ->
+        raise (Parse_error (j, "dst_ip should be an IP prefix: " ^ m))
+    | Ok x -> x
+  in
+  { protocol; dst_prefix; dst_port; path }
+
+type t = forward list
+
+let to_json = Ezjsonm.list forward_to_json
+let of_json = Ezjsonm.get_list forward_of_json
+let to_string x = Ezjsonm.to_string @@ to_json x
+
+let of_string x =
+  try Ok (of_json @@ Ezjsonm.from_string x) with
+  | Ezjsonm.Parse_error (_v, msg) -> Error (`Msg msg)
+  | e -> Error (`Msg (Printf.sprintf "parsing %s: %s" x (Printexc.to_string e)))
+
+let dynamic = ref []
+let static = ref []
+let all = ref []
+
+let set_static xs =
+  static := xs;
+  all := !static @ !dynamic;
+  Log.info (fun f -> f "New Forward configuration: %s" (to_string !all))
+
+let update xs =
+  dynamic := xs;
+  all := !static @ !dynamic;
+  Log.info (fun f -> f "New Forward configuration: %s" (to_string !all))
+
+module Tcp = struct
+  let any_port = 0
+
+  let mem (dst_ip, dst_port) =
+    List.exists
+      (fun f ->
+        f.protocol = `Tcp
+        && Ipaddr.Prefix.mem dst_ip f.dst_prefix
+        && (f.dst_port = any_port || f.dst_port = dst_port))
+      !all
+
+  let find (dst_ip, dst_port) =
+    let f =
+      List.find
+        (fun f ->
+          f.protocol = `Tcp
+          && Ipaddr.Prefix.mem dst_ip f.dst_prefix
+          && (f.dst_port = any_port || f.dst_port = dst_port))
+        !all
+    in
+    f.path
+end

--- a/src/hostnet/forwards.ml
+++ b/src/hostnet/forwards.ml
@@ -76,6 +76,180 @@ let update xs =
   all := !static @ !dynamic;
   Log.info (fun f -> f "New Forward configuration: %s" (to_string !all))
 
+(* Extend a SHUTDOWNABLE flow with a `read_some` API, as used by "channel".
+   Ideally we would use channel, but we need to access the underlying flow
+   without leaving data trapped in the buffer. *)
+module type Read_some = sig
+  include Mirage_flow_combinators.SHUTDOWNABLE
+
+  val read_some :
+    flow -> int -> (Cstructs.t Mirage_flow.or_eof, error) result Lwt.t
+end
+
+module Read_some (FLOW : Mirage_flow_combinators.SHUTDOWNABLE) : sig
+  include Read_some
+
+  val connect : FLOW.flow -> flow
+end = struct
+  (* A flow with a buffer, filled by "read_some" and then drained by "read" *)
+  type flow = { mutable remaining : Cstruct.t; flow : FLOW.flow }
+
+  let connect flow = { remaining = Cstruct.create 0; flow }
+
+  type error = FLOW.error
+
+  let pp_error = FLOW.pp_error
+
+  type write_error = FLOW.write_error
+
+  let pp_write_error = FLOW.pp_write_error
+
+  let read_some flow len =
+    let open Lwt.Infix in
+    let rec loop acc len =
+      if Cstruct.length flow.remaining = 0 && len > 0 then
+        FLOW.read flow.flow >>= function
+        | Error e -> Lwt.return (Error e)
+        | Ok (`Data buf) ->
+            flow.remaining <- buf;
+            loop acc len
+        | Ok `Eof -> Lwt.return (Ok `Eof)
+      else if Cstruct.length flow.remaining < len then (
+        let take = flow.remaining in
+        flow.remaining <- Cstruct.create 0;
+        loop (take :: acc) (len - Cstruct.length take))
+      else
+        let take, leave = Cstruct.split flow.remaining len in
+        flow.remaining <- leave;
+        Lwt.return @@ Ok (`Data (List.rev (take :: acc)))
+    in
+    loop [] len
+
+  let read flow =
+    if Cstruct.length flow.remaining > 0 then (
+      let result = flow.remaining in
+      flow.remaining <- Cstruct.create 0;
+      Lwt.return @@ Ok (`Data result))
+    else FLOW.read flow.flow
+
+  let write flow = FLOW.write flow.flow
+  let writev flow = FLOW.writev flow.flow
+  let close flow = FLOW.close flow.flow
+  let shutdown_write flow = FLOW.shutdown_write flow.flow
+  let shutdown_read flow = FLOW.shutdown_read flow.flow
+end
+
+module Handshake (FLOW : Read_some) = struct
+  (* A Message is a buffer prefixed with a uint16 length field. *)
+  module Message = struct
+    open Lwt.Infix
+
+    let pp_error ppf = function
+      | `Flow e -> FLOW.pp_error ppf e
+      | `Eof -> Fmt.string ppf "EOF while reading handshake"
+
+    let read flow =
+      FLOW.read_some flow 2 >>= function
+      | Error e -> Lwt.return (Error (`Flow e))
+      | Ok `Eof -> Lwt.return (Error `Eof)
+      | Ok (`Data bufs) -> (
+          let buf = Cstructs.to_cstruct bufs in
+          let len = Cstruct.LE.get_uint16 buf 0 in
+          FLOW.read_some flow len >>= function
+          | Error e -> Lwt.return (Error (`Flow e))
+          | Ok `Eof -> Lwt.return (Error `Eof)
+          | Ok (`Data bufs) -> Lwt.return (Ok (Cstructs.to_cstruct bufs)))
+
+    let write flow t =
+      let len = Cstruct.create 2 in
+      Cstruct.LE.set_uint16 len 0 (Cstruct.length t);
+      FLOW.writev flow [ len; t ]
+  end
+
+  module Request = struct
+    type t = {
+      protocol : Protocol.t;
+      src_ip : Ipaddr.t;
+      src_port : int;
+      dst_ip : Ipaddr.t;
+      dst_port : int;
+    }
+
+    open Ezjsonm
+
+    let of_json j =
+      let protocol = Protocol.of_json @@ find j [ "protocol" ] in
+      let src_ip =
+        match Ipaddr.of_string @@ get_string @@ find j [ "src_ip" ] with
+        | Error (`Msg m) ->
+            raise (Parse_error (j, "src_ip should be an IP address: " ^ m))
+        | Ok x -> x
+      in
+      let src_port = get_int @@ find j [ "src_port" ] in
+      let dst_ip =
+        match Ipaddr.of_string @@ get_string @@ find j [ "dst_ip" ] with
+        | Error (`Msg m) ->
+            raise (Parse_error (j, "dst_ip should be an IP address: " ^ m))
+        | Ok x -> x
+      in
+      let dst_port = get_int @@ find j [ "dst_port" ] in
+      { protocol; src_ip; src_port; dst_ip; dst_port }
+
+    let to_json t =
+      let open Ezjsonm in
+      dict
+        [
+          ("protocol", Protocol.to_json t.protocol);
+          ("src_ip", string (Ipaddr.to_string t.src_ip));
+          ("src_port", int t.src_port);
+          ("dst_ip", string (Ipaddr.to_string t.dst_ip));
+          ("dst_port", int t.dst_port);
+        ]
+
+    let to_string t = Ezjsonm.to_string @@ to_json t
+
+    open Lwt.Infix
+
+    let read flow =
+      Message.read flow >>= function
+      | Error (`Flow e) -> Lwt.return (Error (`Flow e))
+      | Error `Eof -> Lwt.return (Error `Eof)
+      | Ok buf ->
+          let j = Ezjsonm.from_string @@ Cstruct.to_string buf in
+          Lwt.return (Ok (of_json j))
+
+    let write flow t =
+      Message.write flow @@ Cstruct.of_string @@ Ezjsonm.to_string @@ to_json t
+  end
+
+  module Response = struct
+    type t = { accepted : bool }
+
+    open Ezjsonm
+
+    let of_json j =
+      let accepted = get_bool @@ find j [ "accepted" ] in
+      { accepted }
+
+    let to_json t =
+      let open Ezjsonm in
+      dict [ ("accepted", bool t.accepted) ]
+
+    open Lwt.Infix
+
+    let read flow =
+      Message.read flow >>= function
+      | Error (`Flow e) -> Lwt.return (Error (`Flow e))
+      | Error `Eof -> Lwt.return (Error `Eof)
+      | Ok buf ->
+          let j = Ezjsonm.from_string @@ Cstruct.to_string buf in
+          Lwt.return (Ok (of_json j))
+
+    let write flow t =
+      Message.write flow @@ Cstruct.of_string @@ Ezjsonm.to_string @@ to_json t
+  end
+end
+
 module Tcp = struct
   let any_port = 0
 
@@ -97,4 +271,148 @@ module Tcp = struct
         !all
     in
     f.path
+end
+
+module Unix = struct
+  module FLOW = Host.Sockets.Stream.Unix
+  module Remote = Read_some (FLOW)
+  module Handshake = Handshake (Remote)
+
+  type flow = { flow : Remote.flow }
+
+  let connect ?read_buffer_size:_ (dst_ip, dst_port) =
+    let open Lwt.Infix in
+    let path = Tcp.find (dst_ip, dst_port) in
+    let req = Fmt.str "%a, %d -> %s" Ipaddr.pp dst_ip dst_port path in
+    Log.info (fun f -> f "%s: connecting" req);
+    FLOW.connect path >>= function
+    | Error (`Msg m) -> Lwt.return (Error (`Msg m))
+    | Ok flow -> (
+        Log.info (fun f -> f "%s: writing handshake" req);
+        let remote = Remote.connect flow in
+        Handshake.Request.write remote
+          {
+            Handshake.Request.protocol = `Tcp;
+            src_ip = Ipaddr.V4 Ipaddr.V4.any;
+            src_port = 0;
+            dst_ip;
+            dst_port;
+          }
+        >>= function
+        | Error e ->
+            Log.info (fun f ->
+                f "%s: %a, returning RST" req Remote.pp_write_error e);
+            Remote.close remote >>= fun () ->
+            Lwt.return
+              (Error
+                 (`Msg
+                   (Fmt.str "writing handshake: %a" Remote.pp_write_error e)))
+        | Ok () -> (
+            Log.info (fun f -> f "%s: reading handshake" req);
+            Handshake.Response.read remote >>= function
+            | Error e ->
+                Log.info (fun f ->
+                    f "%s: %a, returning RST" req Handshake.Message.pp_error e);
+                Remote.close remote >>= fun () ->
+                Lwt.return
+                  (Error
+                     (`Msg
+                       (Fmt.str "reading handshake: %a"
+                          Handshake.Message.pp_error e)))
+            | Ok { Handshake.Response.accepted = false } ->
+                Log.info (fun f -> f "%s: request rejected" req);
+                Remote.close remote >>= fun () ->
+                Lwt.return (Error (`Msg "ECONNREFUSED"))
+            | Ok { Handshake.Response.accepted = true } ->
+                Log.info (fun f -> f "%s: forwarding connection" req);
+                Lwt.return (Ok { flow = remote })))
+
+  type error = Remote.error
+
+  let pp_error = Remote.pp_error
+
+  type write_error = Remote.write_error
+
+  let pp_write_error = Remote.pp_write_error
+  let read flow = Remote.read flow.flow
+  let write flow = Remote.write flow.flow
+  let writev flow = Remote.writev flow.flow
+  let close flow = Remote.close flow.flow
+  let shutdown_write flow = Remote.shutdown_write flow.flow
+  let shutdown_read flow = Remote.shutdown_read flow.flow
+end
+
+module Stream = struct
+  module Tcp = struct
+    type address = Ipaddr.t * int
+
+    module Direct = Host.Sockets.Stream.Tcp
+    module Forwarded = Unix
+
+    type flow = [ `Direct of Direct.flow | `Forwarded of Forwarded.flow ]
+
+    open Lwt.Infix
+
+    let connect ?read_buffer_size:_ (ip, port) =
+      if Tcp.mem (ip, port) then
+        Unix.connect (ip, port) >>= function
+        | Ok flow -> Lwt.return (Ok (`Forwarded flow))
+        | Error e -> Lwt.return (Error e)
+      else
+        Direct.connect (ip, port) >>= function
+        | Ok flow -> Lwt.return (Ok (`Direct flow))
+        | Error e -> Lwt.return (Error e)
+
+    type error = [ `Direct of Direct.error | `Forwarded of Forwarded.error ]
+
+    let pp_error ppf = function
+      | `Direct err -> Direct.pp_error ppf err
+      | `Forwarded err -> Forwarded.pp_error ppf err
+
+    type write_error =
+      [ `Closed
+      | `Direct of Direct.write_error
+      | `Forwarded of Forwarded.write_error ]
+
+    let pp_write_error ppf = function
+      | `Closed -> Fmt.string ppf "Closed"
+      | `Direct err -> Direct.pp_write_error ppf err
+      | `Forwarded err -> Forwarded.pp_write_error ppf err
+
+    let wrap_direct_error t =
+      t >>= function
+      | Ok x -> Lwt.return (Ok x)
+      | Error err -> Lwt.return (Error (`Direct err))
+
+    let wrap_forwarded_error t =
+      t >>= function
+      | Ok x -> Lwt.return (Ok x)
+      | Error err -> Lwt.return (Error (`Forwarded err))
+
+    let read = function
+      | `Direct flow -> wrap_direct_error @@ Direct.read flow
+      | `Forwarded flow -> wrap_forwarded_error @@ Forwarded.read flow
+
+    let write flow bufs =
+      match flow with
+      | `Direct flow -> wrap_direct_error @@ Direct.write flow bufs
+      | `Forwarded flow -> wrap_forwarded_error @@ Forwarded.write flow bufs
+
+    let writev flow bufs =
+      match flow with
+      | `Direct flow -> wrap_direct_error @@ Direct.writev flow bufs
+      | `Forwarded flow -> wrap_forwarded_error @@ Forwarded.writev flow bufs
+
+    let close = function
+      | `Direct flow -> Direct.close flow
+      | `Forwarded flow -> Forwarded.close flow
+
+    let shutdown_write = function
+      | `Direct flow -> Direct.shutdown_write flow
+      | `Forwarded flow -> Forwarded.shutdown_write flow
+
+    let shutdown_read = function
+      | `Direct flow -> Direct.shutdown_read flow
+      | `Forwarded flow -> Forwarded.shutdown_read flow
+  end
 end

--- a/src/hostnet/forwards.mli
+++ b/src/hostnet/forwards.mli
@@ -28,3 +28,7 @@ module Tcp : sig
   val find : Ipaddr.t * int -> string
   (** [find dst_ip dst_port] returns the internal path to forward the TCP connection to. *)
 end
+
+module Stream : sig
+  module Tcp : Sig.FLOW_CLIENT with type address = Ipaddr.t * int
+end

--- a/src/hostnet/forwards.mli
+++ b/src/hostnet/forwards.mli
@@ -1,0 +1,30 @@
+module Protocol : sig
+  type t = [ `Tcp ]
+  (* consider UDP later *)
+end
+
+type forward = {
+  protocol : Protocol.t;
+  dst_prefix : Ipaddr.Prefix.t;
+  dst_port : int;
+  path : string; (* unix domain socket path *)
+}
+
+type t = forward list
+
+val to_string : t -> string
+val of_string : string -> (t, [ `Msg of string ]) result
+
+val set_static : t -> unit
+(** update the static forwarding table *)
+
+val update : t -> unit
+(** update the dynamic forwarding table *)
+
+module Tcp : sig
+  val mem : Ipaddr.t * int -> bool
+  (** [mem dst_ip dst_port] is true if there is a rule to forward TCP to [dst_ip,dst_port]. *)
+
+  val find : Ipaddr.t * int -> string
+  (** [find dst_ip dst_port] returns the internal path to forward the TCP connection to. *)
+end

--- a/src/hostnet/forwards.mli
+++ b/src/hostnet/forwards.mli
@@ -32,3 +32,10 @@ end
 module Stream : sig
   module Tcp : Sig.FLOW_CLIENT with type address = Ipaddr.t * int
 end
+
+module Test (Clock : Mirage_clock.MCLOCK) : sig
+  type server
+
+  val start_forwarder : string -> server Lwt.t
+  val shutdown : server -> unit Lwt.t
+end

--- a/src/hostnet/hostnet_http.ml
+++ b/src/hostnet/hostnet_http.ml
@@ -98,7 +98,7 @@ module Make
     (Ip: Tcpip.Ip.S with type ipaddr = Ipaddr.V4.t)
     (Udp: Tcpip.Udp.S with type ipaddr = Ipaddr.V4.t)
     (Tcp:Mirage_flow_combinators.SHUTDOWNABLE)
-    (Socket: Sig.SOCKETS)
+    (Remote: Sig.FLOW_CLIENT with type address = Ipaddr.t * int)
     (Dns_resolver: Sig.DNS)
 = struct
 
@@ -237,7 +237,7 @@ module Make
     module Response = Cohttp.Response.Make(IO)
   end
   module Outgoing = struct
-    module C = Mirage_channel.Make(Socket.Stream.Tcp)
+    module C = Mirage_channel.Make(Remote)
     module IO = Cohttp_mirage_io.Make(C)
     module Request = Cohttp.Request.Make(IO)
     module Response = Cohttp.Response.Make(IO)
@@ -295,7 +295,7 @@ module Make
             Lwt.return false
           )
         >>= fun continue ->
-        if continue then loop () else Socket.Stream.Tcp.shutdown_write remote
+        if continue then loop () else Remote.shutdown_write remote
       in
       loop () in
     Lwt.join [
@@ -505,7 +505,7 @@ module Make
                     let request = Cohttp.Request.make ~meth:`CONNECT ~headers uri in
                     { request with Cohttp.Request.resource = host ^ ":" ^ (string_of_int port) }
                   in
-                  Socket.Stream.Tcp.connect address >>= function
+                  Remote.connect address >>= function
                   | Error _ ->
                     Log.warn (fun f ->
                         f "Failed to connect to %s" (string_of_address address));
@@ -538,7 +538,7 @@ module Make
                                         (Cohttp.Response.sexp_of_t res)));
                           let incoming = Incoming.C.create flow in
                           proxy_bytes ~incoming ~outgoing ~flow ~remote
-                      ) (fun () -> Socket.Stream.Tcp.close remote)
+                      ) (fun () -> Remote.close remote)
               ) (fun () -> Tcp.close flow)
           ) (fun e ->
             Log.warn (fun f -> f "tunnel_https_over_connect caught exception: %s" (Printexc.to_string e));
@@ -662,7 +662,7 @@ module Make
             (Sexplib.Sexp.to_string_hum
               (Cohttp.Request.sexp_of_t req))
           );
-      begin Socket.Stream.Tcp.connect next_hop_address >>= function
+      begin Remote.connect next_hop_address >>= function
       | Error _ ->
         let message = match ty with
           | `Origin -> Printf.sprintf "unable to connect to %s. Do you need an HTTP proxy?" (string_of_address next_hop_address)
@@ -714,7 +714,7 @@ module Make
                 (Cohttp.Request.sexp_of_t req))
             );
             proxy_request ~description ~incoming ~outgoing ~flow ~remote ~req
-        ) (fun () -> Socket.Stream.Tcp.close remote)
+        ) (fun () -> Remote.close remote)
       end
 
   (* A regular, non-transparent HTTP proxy implementation.

--- a/src/hostnet/hostnet_http.mli
+++ b/src/hostnet/hostnet_http.mli
@@ -14,7 +14,7 @@ module Make
     (Ip: Tcpip.Ip.S with type ipaddr = Ipaddr.V4.t)
     (Udp: Tcpip.Udp.S with type ipaddr = Ipaddr.V4.t)
     (Tcp: Mirage_flow_combinators.SHUTDOWNABLE)
-    (Socket: Sig.SOCKETS)
+    (Remote: Sig.FLOW_CLIENT with type address = Ipaddr.t * int)
     (Dns_resolver: Sig.DNS) :
 sig
 

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -104,7 +104,7 @@ struct
     Hostnet_dns.Make(Stack_ipv4)(Stack_udp)(Stack_tcp)(Host.Sockets)(Host.Dns)
       (Host.Time)(Clock)(Recorder)
   module Http_forwarder =
-    Hostnet_http.Make(Stack_ipv4)(Stack_udp)(Stack_tcp)(Host.Sockets.Stream.Tcp)(Host.Dns)
+    Hostnet_http.Make(Stack_ipv4)(Stack_udp)(Stack_tcp)(Forwards.Stream.Tcp)(Host.Dns)
 
   module Udp_nat = Hostnet_udp.Make(Host.Sockets)(Clock)(Host.Time)
   module Icmp_nat = Hostnet_icmp.Make(Host.Sockets)(Clock)(Host.Time)

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -104,7 +104,7 @@ struct
     Hostnet_dns.Make(Stack_ipv4)(Stack_udp)(Stack_tcp)(Host.Sockets)(Host.Dns)
       (Host.Time)(Clock)(Recorder)
   module Http_forwarder =
-    Hostnet_http.Make(Stack_ipv4)(Stack_udp)(Stack_tcp)(Host.Sockets)(Host.Dns)
+    Hostnet_http.Make(Stack_ipv4)(Stack_udp)(Stack_tcp)(Host.Sockets.Stream.Tcp)(Host.Dns)
 
   module Udp_nat = Hostnet_udp.Make(Host.Sockets)(Clock)(Host.Time)
   module Icmp_nat = Hostnet_icmp.Make(Host.Sockets)(Clock)(Host.Time)


### PR DESCRIPTION
This is based on the existing "gateway forwards" mechanism which allowed traffic sent to the gateway to be forwarded.

A `forwards.json` can be dynamically updated with IP network matches and Unix domain socket / Windows named pipe paths. When a SYN arrives, a request is sent on the Unix domain socket, allowing the server to reject or accept the request. Assuming the connection is accepted, the handshake is completed and traffic flows.