### PR TITLE
Ensure uname subprocess is cleaned up

### DIFF
--- a/src/bin/config/discover.ml
+++ b/src/bin/config/discover.ml
@@ -4,7 +4,7 @@ let os_type () =
     (* We want to differentiate between Linux and Darwin/macOS *)
     let ic = Unix.open_process_in "uname" in
     let line = input_line ic in
-    close_in ic;
+    let _ = Unix.close_process_in ic in
     line
   | x -> x
 


### PR DESCRIPTION
Adds a fix to the `uname` command / subprocess spawned which was not cleaned up / reaped appropriately on Darwin.
The result was a zombie process / resource leak that lingered in the process table.

Fixes #592
