### PR TITLE
luv: calling read_start after close can segfault

### DIFF
--- a/src/hostnet/host.ml
+++ b/src/hostnet/host.ml
@@ -573,9 +573,18 @@ module Sockets = struct
                 | Ok () -> return ()))
         else Lwt.return_unit
 
-      let read_into t buf = read_into t.fd buf
-      let read t = read t.fd
-      let writev t bufs = writev t.fd bufs
+      let read_into t buf =
+        if t.closed
+        then (Log.info (fun f -> f "read_into %s already closed: EOF" t.description); Lwt.return (Ok `Eof))
+        else read_into t.fd buf
+      let read t =
+        if t.closed
+        then (Log.info (fun f -> f "read %s already closed: EOF" t.description); Lwt.return (Ok `Eof))
+        else read t.fd
+      let writev t bufs =
+        if t.closed (* || t.shutdown *)
+        then (Log.info (fun f -> f "writev %s already closed: EPIPE" t.description); Lwt.return (Error (`Msg "EPIPE")))
+        else writev t.fd bufs
       let write t buf = writev t [ buf ]
 
       let close t =
@@ -880,9 +889,18 @@ module Sockets = struct
                 | Ok () -> return ()))
         else Lwt.return_unit
 
-      let read_into t buf = read_into t.fd buf
-      let read t = read t.fd
-      let writev t bufs = writev t.fd bufs
+      let read_into t buf =
+        if t.closed
+        then (Log.info (fun f -> f "read_into %s already closed: EOF" t.description); Lwt.return (Ok `Eof))
+        else read_into t.fd buf
+      let read t =
+        if t.closed
+        then (Log.info (fun f -> f "read %s already closed: EOF" t.description); Lwt.return (Ok `Eof))
+        else read t.fd
+      let writev t bufs =
+        if t.closed (* || t.shutdown *)
+        then (Log.info (fun f -> f "writev %s already closed: EPIPE" t.description); Lwt.return (Error (`Msg "EPIPE")))
+        else writev t.fd bufs
       let write t buf = writev t [ buf ]
 
       let close t =


### PR DESCRIPTION
The segfault looks like this:
```
Thread 3 Crashed:
0   com.docker.vpnkit             	       0x10231b8b8 camlLuv__Helpers__set_reference_inner_1334 + 40
1   com.docker.vpnkit             	       0x10231b8b8 camlLuv__Helpers__set_reference_inner_1334 + 40
2   com.docker.vpnkit             	       0x1029c1108 caml_callback_exn + 24 (callback.c:111) [inlined]
3   com.docker.vpnkit             	       0x1029c1108 caml_callback + 44 (callback.c:165)
4   com.docker.vpnkit             	       0x102980aa0 luv_async_trampoline + 44 (helpers.c:64)
5   com.docker.vpnkit             	       0x102986a98 uv__async_io + 308 (async.c:163)
6   com.docker.vpnkit             	       0x102996be8 uv__io_poll + 992
7   com.docker.vpnkit             	       0x102986ec4 uv_run + 372 (core.c:389)
8   com.docker.vpnkit             	       0x10297cdd4 luv_stub_blocking_1_uv_run + 104 (c_generated_functions.c:1800)
9   com.docker.vpnkit             	       0x1029cc4e8 caml_c_call + 28
10  com.docker.vpnkit             	       0x1029c0e60 caml_callback_exn + 44 (callback.c:111)
11  com.docker.vpnkit             	       0x1029984a8 caml_thread_start + 112 (st_stubs.c:548)
12  libsystem_pthread.dylib       	       0x180a7d06c _pthread_start + 148
13  libsystem_pthread.dylib       	       0x180a77e2c thread_start + 8
```

I reproduced this by `docker pull`ing an image, and using Control+C. The proxy is interrupted and closes the stream, while there is still a background read/write loop in progress. The assumption was that read after close would return a harmless error, but this isn't guaranteed by luv. Therefore we catch this case and return an error ourselves.

Signed-off-by: David Scott <dave@recoil.org>