### PR TITLE
go: avoid possible overflow of the Write window

### DIFF
--- a/go/pkg/libproxy/multiplexed.go
+++ b/go/pkg/libproxy/multiplexed.go
@@ -138,10 +138,14 @@ func (c *channel) Write(p []byte) (int, error) {
 			return written, io.EOF
 		}
 		if c.write.size() > 0 {
+			// Some window space is available
 			toWrite := c.write.size()
 			if toWrite > len(p) {
 				toWrite = len(p)
 			}
+			// Advance the window before dropping the lock in case another Write() appears and sees the same available space
+			c.write.current = c.write.current + uint64(toWrite)
+
 			// Don't block holding the metadata mutex.
 			// Note this would allow concurrent calls to Write on the same channel
 			// to conflict, but we regard that as user error.
@@ -166,7 +170,6 @@ func (c *channel) Write(p []byte) (int, error) {
 			if err3 != nil {
 				return written, err3
 			}
-			c.write.current = c.write.current + uint64(toWrite)
 			p = p[toWrite:]
 			written = written + toWrite
 			continue


### PR DESCRIPTION
The Write window is used to keep track of how much buffer space is free in the remote to avoid one connection blocking the rest. Previously we checked the window and decided how much to write, then dropped the metadata mutex before performing the write. In theory another Write call on the same connection could see that buffer size is free, send too much and block the connection.

Therefore Write should take ownership of the space by bumping the `current` window before dropping the lock.