### PR TITLE
multiplexer: don't fail if Close() is called concurrently to Read(), Write()

### DIFF
--- a/go/pkg/libproxy/multiplexed_test.go
+++ b/go/pkg/libproxy/multiplexed_test.go
@@ -583,7 +583,7 @@ func writeAndBlock(t *testing.T, local, remote Multiplexer) chan error {
 	if err := server.SetWriteDeadline(time.Now().Add(1 * time.Second)); err != nil {
 		t.Fatal(err)
 	}
-	done := make(chan error, 1)
+	done := make(chan error)
 	go func() {
 		buf, _ := genRandomBuffer(1024)
 		for {
@@ -594,10 +594,10 @@ func writeAndBlock(t *testing.T, local, remote Multiplexer) chan error {
 			}
 		}
 		if err := client.Close(); err != nil {
-			t.Fatal(err)
+			done <- err
 		}
 		if err := server.Close(); err != nil {
-			t.Fatal(err)
+			done <- err
 		}
 		close(done)
 	}()


### PR DESCRIPTION
It's legal for a single `net.Conn` to be shared between goroutines, for example calling `Close()` on `<- ctx.Done()` while calls are blocked in `Read` and `Write`.

The multiplexer does not impose an ordering in `send`: each concurrent call simply competes for the `writeMutex`.

Therefore sequences we considered invalid are actually possible:
- `Close(id)` then `Window(id)`
- `Close(id)` then `Write(id)`
- `Close(id)` then `Shutdown(id)`

Previously we detected these invalid sequences and shutdown the whole multiplexer. The effect would be to completely disable port forwarding.

Instead we drop these out-of-order packets and log (just in case it's interesting). There is a very small risk that an old out-of-order packet could be mixed up with a new packet if the channel ID is reused, but we have a space of 2**32 of those so re-use is unlikely.

