### PR TITLE
Correctly return NOERROR even if host resolver returned empty list

### DIFF
--- a/src/hostnet/hostnet_dns.ml
+++ b/src/hostnet/hostnet_dns.ml
@@ -446,10 +446,11 @@ struct
             | _, Host ->
               D.resolve question
               >>= function
-              | [] ->
-                Lwt.return (Ok (Some (marshal nxdomain)))
-              | answers ->
+              | Ok answers ->
                 Lwt.return (Ok (marshal_reply answers))
+              (* Currently return all errors as NXDOMAIN *)
+              | Error _ ->
+                Lwt.return (Ok (Some (marshal nxdomain)))
       end
     | _ ->
       Lwt.return (Error (`Msg "DNS packet had multiple questions"))

--- a/src/hostnet/sig.ml
+++ b/src/hostnet/sig.ml
@@ -130,7 +130,7 @@ module type FILES = sig
 end
 
 module type DNS = sig
-  val resolve: Dns.Packet.question -> Dns.Packet.rr list Lwt.t
+  val resolve: Dns.Packet.question -> (Dns.Packet.rr list, unit) result Lwt.t
   (** Given a question, find associated resource records *)
 end
 


### PR DESCRIPTION
Fixes #509 and https://github.com/moby/moby/issues/47628.

1. `Dns.resolve` now returns  `(rr list, unit) result` to distinguish between `[]` resulting from NOERROR or NXDOMAIN.
    - Currently only returns NXDOMAIN on any kind of error.
    - `Dns.getaddrinfo` returns `(rr list, Msg) result` with no error handling just like current behavior
2. `Make.answer` returns answers (including `[]`) if there is no error, otherwise NXDOMAIN is returned.
3. Added NOERROR and NXDOMAIN test cases.