### PR TITLE
Fix(DNS): Handle EAI_NODATA as success (empty address list) in getaddrinfo

### DIFF
--- a/src/hostnet/host.ml
+++ b/src/hostnet/host.ml
@@ -1267,6 +1267,10 @@ module Dns = struct
   let getaddrinfo node family =
     Luv_lwt.in_luv (fun return ->
         Luv.DNS.getaddrinfo ~family ~node () (function
+          | Error `EAI_NODATA ->
+              (* Special handling for EAI_NODATA: Treat as success (host exists, but no address data) and
+                 Return an empty list. See https://github.com/moby/moby/issues/47628 for more context. *)
+              return (Ok [])
           | Error err -> return (Error (`Msg (Luv.Error.strerror err)))
           | Ok x ->
               let ips =


### PR DESCRIPTION
This pull request addresses a long-standing issue where DNS lookups within containers, especially those running in rootless Docker-in-Docker (DIND) environments using VPNKit, would fail with an `NXDOMAIN` error. 

This often occurred even when valid IP addresses were present in the DNS response, or for specific record types like SRV records.

#### Problem:

*   **DNS Lookup Errors in Rootless DIND**
    *   Related Issue: moby/moby#47628
    *   When running containers in `dind-rootless` mode, DNS lookups would fail with `NXDOMAIN`.
    *   This was particularly evident when the upstream DNS server stripped out IPv6 addresses. For example, commands like `apk add` in `alpine` containers would fail due to these DNS errors.
    *   This behavior was reproduced across multiple dind images.

*   **NXDOMAIN for SRV Records**
    *   The VPNKit DNS server was specifically observed to return `NXDOMAIN` for SRV record queries, unlike `slirp4netns` which handled them correctly (https://github.com/moby/vpnkit/issues/509).

The core of the issue stemmed from VPNKit treating the `EAI_NODATA` error code from `getaddrinfo` as a fatal failure. `EAI_NODATA` indicates that the name exists, but there are no addresses of the requested type (e.g., no AAAA records if IPv6 is filtered out, or no SRV records for a specific query).

#### Solution:

This pull request modifies VPNKit's DNS handling to **interpret `EAI_NODATA` as a successful result, specifically as an empty address list**. By doing so, DNS lookups can complete successfully even when an upstream DNS server returns an empty list for a particular query type.

#### Expected Outcome:

*   DNS lookups within `rootless DIND` containers using VPNKit will now work as expected, even when upstream DNS servers strip IPv6 addresses.
*   VPNKit-based SRV record lookups will no longer return `NXDOMAIN` when the name exists but no SRV records are found, allowing for proper resolution or indicating an empty SRV record list.
*   This change directly resolves the issues reported in moby/moby#47628 and moby/vpnkit#509.

#### Notes

* While Pull Request #645 aimed to fix the issue, it did not fully address the fundamental problem of how VPNKit handled EAI_NODATA error codes from getaddrinfo.

#### Acknowledgments

* Special thanks to @joanbm, who is explicitly listed as a co-author on this commit (the fullname and email address is retrieved from their own public repo). 
    *  See: https://github.com/moby/vpnkit/issues/509#issuecomment-2892480710

* A special thanks to Tomoya Kawaguchi (@yamoyamoto) for their invaluable help in debugging this issue. Tomoya added debug logs to narrow down the problem and confirmed that nslookup no longer returned NXDOMAIN within the Alpine images in the DIND environment.