### PR TITLE
Github action to build with dune package management

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: release
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  release-unix:
+    name: Release for ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-15-intel
+            name: x86_64-macos
+          - os: macos-15
+            name: aarch64-macos
+          - os: ubuntu-latest
+            name: x86_64-linux-gnu
+    steps:
+
+      - uses: actions/checkout@v4
+
+      - uses: ocaml-dune/setup-dune@v0
+
+      - name: Build the project
+        run: DUNE_CONFIG__PKG_BUILD_PROGRESS=enabled dune build @install --release --only-packages vpnkit
+
+      - run: echo OUT_NAME=vpnkit-${{ github.ref_name }}-${{ matrix.name }} >> $GITHUB_ENV
+
+      - name: Release a tarball of build outputs
+        run: |
+          mkdir -p "$OUT_NAME"
+          cp -rlf _build/install/default/* "$OUT_NAME"
+          tar czf "$OUT_NAME.tar.gz" "$OUT_NAME"
+
+      - name: Upload assets
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          artifacts: "*.tar.gz"

--- a/dune-workspace
+++ b/dune-workspace
@@ -1,0 +1,8 @@
+(lang dune 3.19)
+
+(repository
+ (name archive)
+ (url git+https://github.com/ocaml/opam-repository-archive))
+
+(lock_dir
+ (repositories upstream overlay archive))

--- a/dune.lock/alcotest.1.5.0.pkg
+++ b/dune.lock/alcotest.1.5.0.pkg
@@ -1,0 +1,19 @@
+(version 1.5.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs} @install))))))
+
+(depends
+ (all_platforms
+  (dune ocaml fmt astring cmdliner re stdlib-shims uutf ocaml-syntax-shims)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/alcotest/releases/download/1.5.0/alcotest-js-1.5.0.tbz)
+  (checksum
+   sha256=54281907e02d78995df246dc2e10ed182828294ad2059347a1e3a13354848f6c)))

--- a/dune.lock/angstrom.0.16.1.pkg
+++ b/dune.lock/angstrom.0.16.1.pkg
@@ -1,0 +1,17 @@
+(version 0.16.1)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune bigstringaf ocaml-syntax-shims)))
+
+(source
+ (fetch
+  (url https://github.com/inhabitedtype/angstrom/archive/0.16.1.tar.gz)
+  (checksum md5=a9e096b4b2b8e4e3bb17d472bbccaad0)))

--- a/dune.lock/arp.3.1.1.pkg
+++ b/dune.lock/arp.3.1.1.pkg
@@ -1,0 +1,28 @@
+(version 3.1.1)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml
+   dune
+   cstruct
+   ipaddr
+   macaddr
+   logs
+   mirage-time
+   lwt
+   duration
+   ethernet
+   fmt)))
+
+(source
+ (fetch
+  (url https://github.com/mirage/arp/releases/download/v3.1.1/arp-3.1.1.tbz)
+  (checksum
+   sha256=ea33c589e9deea300fb62bc2ba0b557cfdfeea4f40e600685b3a68c6868f06f1)))

--- a/dune.lock/astring.0.8.5.pkg
+++ b/dune.lock/astring.0.8.5.pkg
@@ -1,0 +1,15 @@
+(version 0.8.5)
+
+(build
+ (all_platforms
+  ((action (run ocaml pkg/pkg.ml build --pinned %{pkg-self:pinned})))))
+
+(depends
+ (all_platforms
+  (ocaml ocamlfind ocamlbuild topkg)))
+
+(source
+ (fetch
+  (url https://erratique.ch/software/astring/releases/astring-0.8.5.tbz)
+  (checksum
+   sha256=865692630c07c3ab87c66cdfc2734c0fdfc9c34a57f8e89ffec7c7d15e7a70fa)))

--- a/dune.lock/base-bytes.base.pkg
+++ b/dune.lock/base-bytes.base.pkg
@@ -1,0 +1,5 @@
+(version base)
+
+(depends
+ (all_platforms
+  (ocaml ocamlfind)))

--- a/dune.lock/base-threads.base.pkg
+++ b/dune.lock/base-threads.base.pkg
@@ -1,0 +1,1 @@
+(version base)

--- a/dune.lock/base-unix.base.pkg
+++ b/dune.lock/base-unix.base.pkg
@@ -1,0 +1,1 @@
+(version base)

--- a/dune.lock/base.v0.14.3.pkg
+++ b/dune.lock/base.v0.14.3.pkg
@@ -1,0 +1,28 @@
+(version v0.14.3)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when
+      (and_absorb_undefined_var (= %{arch} arm64) (= %{os} macos))
+      (patch fix-mpopcnt.patch))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml sexplib0 dune dune-configurator)))
+
+(source
+ (fetch
+  (url https://github.com/janestreet/base/archive/v0.14.3.tar.gz)
+  (checksum
+   sha256=e34dc0dd052a386c84f5f67e71a90720dff76e0edd01f431604404bee86ebe5a)))
+
+(extra_sources
+ (fix-mpopcnt.patch
+  (fetch
+   (url
+    https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/base/base-pr-184.diff)
+   (checksum
+    sha256=0fa6c87a379b3b35ffe3db3c8e1674dbc70cef91b5b457a35ed6d758a8f9ca80))))

--- a/dune.lock/base64.3.5.2.pkg
+++ b/dune.lock/base64.3.5.2.pkg
@@ -1,0 +1,19 @@
+(version 3.5.2)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-base64/releases/download/v3.5.2/base64-3.5.2.tbz)
+  (checksum
+   sha256=b3f5ce301aa72c7032ef90be2332d72ff3962922c00ee2aec6bcade187a2f59b)))

--- a/dune.lock/bigarray-compat.1.1.0.pkg
+++ b/dune.lock/bigarray-compat.1.1.0.pkg
@@ -1,0 +1,19 @@
+(version 1.1.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/bigarray-compat/releases/download/v1.1.0/bigarray-compat-1.1.0.tbz)
+  (checksum
+   sha256=434469a48d5c84e80d621b13d95eb067f8138c1650a1fd5ae6009a19b93718d5)))

--- a/dune.lock/bigstringaf.0.10.0.pkg
+++ b/dune.lock/bigstringaf.0.10.0.pkg
@@ -1,0 +1,17 @@
+(version 0.10.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs} @install))))))
+
+(depends
+ (all_platforms
+  (dune dune-configurator ocaml)))
+
+(source
+ (fetch
+  (url https://github.com/inhabitedtype/bigstringaf/archive/0.10.0.tar.gz)
+  (checksum md5=be0a44416840852777651150757a0a3b)))

--- a/dune.lock/camlp-streams.5.0.1.pkg
+++ b/dune.lock/camlp-streams.5.0.1.pkg
@@ -1,0 +1,17 @@
+(version 5.0.1)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs} @install))))))
+
+(depends
+ (all_platforms
+  (dune ocaml)))
+
+(source
+ (fetch
+  (url https://github.com/ocaml/camlp-streams/archive/v5.0.1.tar.gz)
+  (checksum md5=afc874b25f7a1f13e8f5cfc1182b51a7)))

--- a/dune.lock/charrua-client.1.5.0.pkg
+++ b/dune.lock/charrua-client.1.5.0.pkg
@@ -1,0 +1,35 @@
+(version 1.5.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (dune
+   ocaml
+   charrua
+   cstruct
+   ipaddr
+   macaddr
+   mirage-random
+   mirage-clock
+   mirage-time
+   mirage-net
+   duration
+   logs
+   fmt
+   ethernet
+   arp
+   tcpip
+   lwt)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/charrua/releases/download/v1.5.0/charrua-v1.5.0.tbz)
+  (checksum
+   sha256=4ce74a5e78402f3d645ddcb344aaa1348349a8d5a35b8b55112aff0cb84db8e1)))

--- a/dune.lock/charrua-server.1.5.0.pkg
+++ b/dune.lock/charrua-server.1.5.0.pkg
@@ -1,0 +1,29 @@
+(version 1.5.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml
+   dune
+   ppx_sexp_conv
+   menhir
+   charrua
+   cstruct
+   sexplib
+   ipaddr
+   macaddr
+   ipaddr-sexp
+   macaddr-sexp)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/charrua/releases/download/v1.5.0/charrua-v1.5.0.tbz)
+  (checksum
+   sha256=4ce74a5e78402f3d645ddcb344aaa1348349a8d5a35b8b55112aff0cb84db8e1)))

--- a/dune.lock/charrua.1.5.0.pkg
+++ b/dune.lock/charrua.1.5.0.pkg
@@ -1,0 +1,30 @@
+(version 1.5.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml
+   dune
+   ppx_sexp_conv
+   ppx_cstruct
+   cstruct
+   sexplib
+   ipaddr
+   macaddr
+   ipaddr-sexp
+   macaddr-sexp
+   ethernet
+   tcpip)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/charrua/releases/download/v1.5.0/charrua-v1.5.0.tbz)
+  (checksum
+   sha256=4ce74a5e78402f3d645ddcb344aaa1348349a8d5a35b8b55112aff0cb84db8e1)))

--- a/dune.lock/cmdliner.1.0.4.pkg
+++ b/dune.lock/cmdliner.1.0.4.pkg
@@ -1,0 +1,19 @@
+(version 1.0.4)
+
+(install
+ (all_platforms
+  (progn
+   (run %{make} install LIBDIR=%{pkg-self:lib} DOCDIR=%{pkg-self:doc})
+   (run %{make} install-doc LIBDIR=%{pkg-self:lib} DOCDIR=%{pkg-self:doc}))))
+
+(build
+ (all_platforms ((action (run %{make} all PREFIX=%{prefix})))))
+
+(depends
+ (all_platforms (ocaml)))
+
+(source
+ (fetch
+  (url http://erratique.ch/software/cmdliner/releases/cmdliner-1.0.4.tbz)
+  (checksum
+   sha256=5c2a93d44af8a38996a2c0f80fbd7970fe4751f104be470cafa069353fc004c0)))

--- a/dune.lock/cohttp-lwt.5.3.0.pkg
+++ b/dune.lock/cohttp-lwt.5.3.0.pkg
@@ -1,0 +1,19 @@
+(version 5.3.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune cohttp lwt sexplib0 ppx_sexp_conv logs uri)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-cohttp/releases/download/v5.3.0/cohttp-5.3.0.tbz)
+  (checksum
+   sha256=b3bd91c704e5ea510e924b83ab2ede1fc46a2cce448b0f8cef4883b9a16eeddd)))

--- a/dune.lock/cohttp.5.3.1.pkg
+++ b/dune.lock/cohttp.5.3.1.pkg
@@ -1,0 +1,19 @@
+(version 5.3.1)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune re uri uri-sexp sexplib0 ppx_sexp_conv stringext base64 jsonm)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-cohttp/releases/download/v5.3.1/cohttp-5.3.1.tbz)
+  (checksum
+   sha256=f5e273d3c2f29ff47bd7e16db23e1f3d6cd01a40be00208985bc434c88d4576b)))

--- a/dune.lock/conf-pkg-config.4.pkg
+++ b/dune.lock/conf-pkg-config.4.pkg
@@ -1,0 +1,87 @@
+(version 4)
+
+(build
+ (choice
+  ((((arch x86_64)
+     (os linux))
+    ((arch arm64)
+     (os linux)))
+   ((action
+     (run pkg-config --help))))
+  ((((arch x86_64)
+     (os macos))
+    ((arch arm64)
+     (os macos)))
+   ((action
+     (progn
+      (when
+       (and_absorb_undefined_var
+        true
+        (not
+         (and_absorb_undefined_var
+          true
+          (= %{os_distribution} homebrew))))
+       (run pkg-config --help))
+      (when
+       (or_absorb_undefined_var
+        false
+        (and_absorb_undefined_var
+         true
+         (= %{os_distribution} homebrew)))
+       (run pkgconf --version))))))))
+
+(depexts
+ ((pkg-config)
+  (or_absorb_undefined_var
+   (= %{os_family} debian)
+   (= %{os_family} ubuntu)))
+ ((pkgconf)
+  (= %{os_distribution} arch))
+ ((pkgconf-pkg-config)
+  (= %{os_family} fedora))
+ ((pkgconfig)
+  (and_absorb_undefined_var
+   (= %{os_distribution} centos)
+   (<= %{os_version} 7)))
+ ((pkgconf-pkg-config)
+  (= %{os_distribution} mageia))
+ ((pkgconfig)
+  (and_absorb_undefined_var
+   (= %{os_distribution} rhel)
+   (<= %{os_version} 7)))
+ ((pkgconfig)
+  (and_absorb_undefined_var
+   (= %{os_distribution} ol)
+   (<= %{os_version} 7)))
+ ((pkgconf)
+  (= %{os_distribution} alpine))
+ ((pkg-config)
+  (= %{os_distribution} nixos))
+ ((pkgconf)
+  (and_absorb_undefined_var
+   (= %{os} macos)
+   (= %{os_distribution} homebrew)))
+ ((pkgconfig)
+  (and_absorb_undefined_var
+   (= %{os} macos)
+   (= %{os_distribution} macports)))
+ ((pkgconf)
+  (= %{os} freebsd))
+ ((pkgconf-pkg-config)
+  (and_absorb_undefined_var
+   (= %{os_distribution} rhel)
+   (>= %{os_version} 8)))
+ ((pkgconf-pkg-config)
+  (and_absorb_undefined_var
+   (= %{os_distribution} centos)
+   (>= %{os_version} 8)))
+ ((pkgconf-pkg-config)
+  (and_absorb_undefined_var
+   (= %{os_distribution} ol)
+   (>= %{os_version} 8)))
+ ((system:pkgconf)
+  (and_absorb_undefined_var
+   (= %{os} win32)
+   (= %{os_distribution} cygwinports)))
+ ((pkgconf)
+  (= %{os_distribution} cygwin)))

--- a/dune.lock/cppo.1.8.0.pkg
+++ b/dune.lock/cppo.1.8.0.pkg
@@ -1,0 +1,17 @@
+(version 1.8.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs} @install))))))
+
+(depends
+ (all_platforms
+  (ocaml dune base-unix)))
+
+(source
+ (fetch
+  (url https://github.com/ocaml-community/cppo/archive/v1.8.0.tar.gz)
+  (checksum md5=a197cb393b84f6b30e0ff55080ac429b)))

--- a/dune.lock/csexp.1.5.2.pkg
+++ b/dune.lock/csexp.1.5.2.pkg
@@ -1,0 +1,19 @@
+(version 1.5.2)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs} @install))))))
+
+(depends
+ (all_platforms
+  (dune ocaml)))
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml-dune/csexp/releases/download/1.5.2/csexp-1.5.2.tbz)
+  (checksum
+   sha256=1a14dd04bb4379a41990248550628c77913a9c07f3c35c1370b6960e697787ff)))

--- a/dune.lock/cstruct-lwt.6.0.1.pkg
+++ b/dune.lock/cstruct-lwt.6.0.1.pkg
@@ -1,0 +1,19 @@
+(version 6.0.1)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml base-unix dune lwt cstruct)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-cstruct/releases/download/v6.0.1/cstruct-v6.0.1.tbz)
+  (checksum
+   sha256=4a67bb8f042753453c59eabf0e47865631253ba694091ce6062aac05d47a9bed)))

--- a/dune.lock/cstruct-sexp.6.0.1.pkg
+++ b/dune.lock/cstruct-sexp.6.0.1.pkg
@@ -1,0 +1,19 @@
+(version 6.0.1)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune sexplib cstruct)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-cstruct/releases/download/v6.0.1/cstruct-v6.0.1.tbz)
+  (checksum
+   sha256=4a67bb8f042753453c59eabf0e47865631253ba694091ce6062aac05d47a9bed)))

--- a/dune.lock/cstruct.6.0.1.pkg
+++ b/dune.lock/cstruct.6.0.1.pkg
@@ -1,0 +1,19 @@
+(version 6.0.1)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune bigarray-compat)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-cstruct/releases/download/v6.0.1/cstruct-v6.0.1.tbz)
+  (checksum
+   sha256=4a67bb8f042753453c59eabf0e47865631253ba694091ce6062aac05d47a9bed)))

--- a/dune.lock/ctypes.0.23.0.pkg
+++ b/dune.lock/ctypes.0.23.0.pkg
@@ -1,0 +1,34 @@
+(version 0.23.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run
+      dune
+      build
+      -p
+      %{pkg-self:name}
+      -j
+      %{jobs}
+      --promote-install-files=false
+      @install)
+     (run
+      dune
+      install
+      -p
+      %{pkg-self:name}
+      --create-install-files
+      %{pkg-self:name}))))))
+
+(depends
+ (all_platforms
+  (dune ocaml integers dune-configurator bigarray-compat)))
+
+(source
+ (fetch
+  (url
+   https://github.com/yallop/ocaml-ctypes/archive/refs/tags/0.23.0.tar.gz)
+  (checksum
+   sha256=cae47d815b27dd4c824a007f1145856044542fe2588d23a443ef4eefec360bf1)))

--- a/dune.lock/domain-name.0.5.0.pkg
+++ b/dune.lock/domain-name.0.5.0.pkg
@@ -1,0 +1,19 @@
+(version 0.5.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune)))
+
+(source
+ (fetch
+  (url
+   https://github.com/hannesm/domain-name/releases/download/v0.5.0/domain-name-0.5.0.tbz)
+  (checksum
+   sha256=9ec7ae2c22772c150b84cfa3f21d9bf25fae14a796f31e20df52d86f46499d89)))

--- a/dune.lock/dune-configurator.3.19.1.pkg
+++ b/dune.lock/dune-configurator.3.19.1.pkg
@@ -1,0 +1,21 @@
+(version 3.19.1)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run rm -rf vendor/csexp)
+     (run rm -rf vendor/pp)
+     (run dune build -p %{pkg-self:name} -j %{jobs} @install))))))
+
+(depends
+ (all_platforms
+  (dune ocaml base-unix csexp)))
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml/dune/releases/download/3.19.1/dune-3.19.1.tbz)
+  (checksum
+   sha256=a10386f980cda9417d1465466bed50dd2aef9c93b9d06a0f7feeedb0a1541158)))

--- a/dune.lock/duration.0.2.1.pkg
+++ b/dune.lock/duration.0.2.1.pkg
@@ -1,0 +1,19 @@
+(version 0.2.1)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune)))
+
+(source
+ (fetch
+  (url
+   https://github.com/hannesm/duration/releases/download/v0.2.1/duration-0.2.1.tbz)
+  (checksum
+   sha256=c738c1f38cfb99820c121cd3ddf819de4b2228f0d50eacbd1cc3ce99e7c71e2b)))

--- a/dune.lock/ethernet.3.0.0.pkg
+++ b/dune.lock/ethernet.3.0.0.pkg
@@ -1,0 +1,19 @@
+(version 3.0.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (dune ocaml cstruct ppx_cstruct mirage-net macaddr mirage-profile lwt logs)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ethernet/releases/download/v3.0.0/ethernet-v3.0.0.tbz)
+  (checksum
+   sha256=e95974f6363bd21e995a1c72ca03d09674c32ed2fbffada5aa82f096ee460929)))

--- a/dune.lock/ezjsonm.1.3.0.pkg
+++ b/dune.lock/ezjsonm.1.3.0.pkg
@@ -1,0 +1,19 @@
+(version 1.3.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune jsonm uutf sexplib0 hex)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ezjsonm/releases/download/v1.3.0/ezjsonm-1.3.0.tbz)
+  (checksum
+   sha256=08633e0f0e767a8ae81935ca7e74f1693b85a79c4502d568eedff5170f0cd77b)))

--- a/dune.lock/fd-send-recv.2.0.3.pkg
+++ b/dune.lock/fd-send-recv.2.0.3.pkg
@@ -1,0 +1,15 @@
+(version 2.0.3)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml dune)))
+
+(source
+ (fetch
+  (url
+   https://github.com/xapi-project/ocaml-fd-send-recv/releases/download/v2.0.3/fd-send-recv-2.0.3.tbz)
+  (checksum
+   sha256=34970f254a14885daaabb98f5410160530aa6e994747ad1eab99ec4f61dc9934)))

--- a/dune.lock/fmt.0.9.0.pkg
+++ b/dune.lock/fmt.0.9.0.pkg
@@ -1,0 +1,25 @@
+(version 0.9.0)
+
+(build
+ (all_platforms
+  ((action
+    (run
+     ocaml
+     pkg/pkg.ml
+     build
+     --dev-pkg
+     %{pkg-self:dev}
+     --with-base-unix
+     %{pkg:base-unix:installed}
+     --with-cmdliner
+     %{pkg:cmdliner:installed})))))
+
+(depends
+ (all_platforms
+  (ocaml ocamlfind ocamlbuild topkg base-unix cmdliner)))
+
+(source
+ (fetch
+  (url https://erratique.ch/software/fmt/releases/fmt-0.9.0.tbz)
+  (checksum
+   sha512=66cf4b8bb92232a091dfda5e94d1c178486a358cdc34b1eec516d48ea5acb6209c0dfcb416f0c516c50ddbddb3c94549a45e4a6d5c5fd1c81d3374dec823a83b)))

--- a/dune.lock/functoria-runtime.3.1.2.pkg
+++ b/dune.lock/functoria-runtime.3.1.2.pkg
@@ -1,0 +1,19 @@
+(version 3.1.2)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune cmdliner)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/functoria/releases/download/v3.1.2/functoria-3.1.2.tbz)
+  (checksum
+   sha256=847a5e59afca3874c056f3130f51ca5fe73e24a4f166cb2a30e90967dc7c00fa)))

--- a/dune.lock/hex.1.5.0.pkg
+++ b/dune.lock/hex.1.5.0.pkg
@@ -1,0 +1,19 @@
+(version 1.5.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune cstruct)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-hex/releases/download/v1.5.0/hex-1.5.0.tbz)
+  (checksum
+   sha256=2e67eeca1b03049307a30831b5cd694bcb2d3e7f2a6b4fb597fbdb647351b4dc)))

--- a/dune.lock/hvsock.3.0.0.pkg
+++ b/dune.lock/hvsock.3.0.0.pkg
@@ -1,0 +1,47 @@
+(version 3.0.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml
+   base-bytes
+   base-threads
+   base-unix
+   lwt
+   logs
+   fmt
+   cmdliner
+   sha
+   uri
+   base64
+   uuidm
+   uutf
+   mirage-flow
+   mirage-flow-combinators
+   mirage-time
+   cstruct
+   duration
+   dune)))
+
+(depexts
+ ((linux-headers)
+  (= %{os_distribution} alpine))
+ ((linux-libc-dev)
+  (= %{os_family} debian))
+ ((kernel-headers)
+  (= %{os_family} fedora))
+ ((kernel-headers)
+  (= %{os_distribution} rhel)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-hvsock/releases/download/3.0.0/hvsock-3.0.0.tbz)
+  (checksum
+   sha256=46d179976f153a7723890ba78fbcfee60e70b3cc9cc3574eb4bb8a682525e4e2)))

--- a/dune.lock/integers.0.7.0.pkg
+++ b/dune.lock/integers.0.7.0.pkg
@@ -1,0 +1,18 @@
+(version 0.7.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune stdlib-shims)))
+
+(source
+ (fetch
+  (url https://github.com/yallop/ocaml-integers/archive/0.7.0.tar.gz)
+  (checksum
+   sha256=8bb517fa9a1818246eb8c4ce34ee1489fbebb4b92defa3a25d13cab8d23ec685)))

--- a/dune.lock/io-page-unix.2.3.0.pkg
+++ b/dune.lock/io-page-unix.2.3.0.pkg
@@ -1,0 +1,19 @@
+(version 2.3.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune io-page cstruct)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/io-page/releases/download/v2.3.0/io-page-v2.3.0.tbz)
+  (checksum
+   sha256=9605a8a03e53bc12682212c371bc477f2a44ed829725ae38cc3005e2f83da2c3)))

--- a/dune.lock/io-page.2.3.0.pkg
+++ b/dune.lock/io-page.2.3.0.pkg
@@ -1,0 +1,19 @@
+(version 2.3.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune dune-configurator cstruct bigarray-compat)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/io-page/releases/download/v2.3.0/io-page-v2.3.0.tbz)
+  (checksum
+   sha256=9605a8a03e53bc12682212c371bc477f2a44ed829725ae38cc3005e2f83da2c3)))

--- a/dune.lock/ipaddr-sexp.5.6.0.pkg
+++ b/dune.lock/ipaddr-sexp.5.6.0.pkg
@@ -1,0 +1,19 @@
+(version 5.6.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune ipaddr ppx_sexp_conv sexplib0)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz)
+  (checksum
+   sha256=9e30433fdb4ca437a6aa8ffb447baca5eba7615fb88e7b0cd8a4b416c3208133)))

--- a/dune.lock/ipaddr.5.6.0.pkg
+++ b/dune.lock/ipaddr.5.6.0.pkg
@@ -1,0 +1,19 @@
+(version 5.6.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune macaddr domain-name)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz)
+  (checksum
+   sha256=9e30433fdb4ca437a6aa8ffb447baca5eba7615fb88e7b0cd8a4b416c3208133)))

--- a/dune.lock/jane-street-headers.v0.14.0.pkg
+++ b/dune.lock/jane-street-headers.v0.14.0.pkg
@@ -1,0 +1,15 @@
+(version v0.14.0)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml dune)))
+
+(source
+ (fetch
+  (url
+   https://ocaml.janestreet.com/ocaml-core/v0.14/files/jane-street-headers-v0.14.0.tar.gz)
+  (checksum
+   sha256=47bb7a4132eda6d489860f6a99a93b30af5247316827e46311c0c701c9ea1e09)))

--- a/dune.lock/jsonm.1.0.2.pkg
+++ b/dune.lock/jsonm.1.0.2.pkg
@@ -1,0 +1,15 @@
+(version 1.0.2)
+
+(build
+ (all_platforms
+  ((action (run ocaml pkg/pkg.ml build --dev-pkg %{pkg-self:dev})))))
+
+(depends
+ (all_platforms
+  (ocaml ocamlfind ocamlbuild topkg uutf)))
+
+(source
+ (fetch
+  (url https://erratique.ch/software/jsonm/releases/jsonm-1.0.2.tbz)
+  (checksum
+   sha512=0072f5c31080202ed1cb996a8530d72c882723f26b597f784441033f59338ba8c0cbabf901794d5b1ae749a54af4d7ebf7b47987db43488c7f6ac7fe191a042f)))

--- a/dune.lock/jst-config.v0.14.1.pkg
+++ b/dune.lock/jst-config.v0.14.1.pkg
@@ -1,0 +1,15 @@
+(version v0.14.1)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml base ppx_assert stdio dune dune-configurator)))
+
+(source
+ (fetch
+  (url
+   https://github.com/janestreet/jst-config/archive/refs/tags/v0.14.1.tar.gz)
+  (checksum
+   sha256=a4cab8a69c62d440de8b59f75e56ce2bbaac2448c4b123e07b8b17b629d0b271)))

--- a/dune.lock/lock.dune
+++ b/dune.lock/lock.dune
@@ -1,0 +1,38 @@
+(lang package 0.1)
+
+(dependency_hash 9948b6124a8e5d483a61f8d55544e36e)
+
+(ocaml ocaml-base-compiler)
+
+(repositories
+ (complete true)
+ (used
+  ((source
+    https://github.com/ocaml/opam-repository.git#e4e631bfa1de346c5c18d3bb460fd03366bcb0e6))
+  ((source
+    https://github.com/ocaml-dune/opam-overlays.git#2a9543286ff0e0656058fee5c0da7abc16b8717d))
+  ((source
+    https://github.com/ocaml/opam-repository-archive#bd3b5632af52a549ce9a9edccc835554ee365bb3))))
+
+(expanded_solver_variable_bindings
+ (variable_values
+  (with-doc false)
+  (with-dev-setup false)
+  (post true)
+  (opam-version 2.2.0))
+ (unset_variables
+  with-test
+  sys-ocaml-libc
+  enable-ocaml-beta-repository
+  dev
+  build))
+
+(solved_for_platforms
+ ((arch x86_64)
+  (os linux))
+ ((arch arm64)
+  (os linux))
+ ((arch x86_64)
+  (os macos))
+ ((arch arm64)
+  (os macos)))

--- a/dune.lock/logs.0.7.0.pkg
+++ b/dune.lock/logs.0.7.0.pkg
@@ -1,0 +1,31 @@
+(version 0.7.0)
+
+(build
+ (all_platforms
+  ((action
+    (run
+     ocaml
+     pkg/pkg.ml
+     build
+     --pinned
+     %{pkg-self:pinned}
+     --with-js_of_ocaml
+     %{pkg:js_of_ocaml:installed}
+     --with-fmt
+     %{pkg:fmt:installed}
+     --with-cmdliner
+     %{pkg:cmdliner:installed}
+     --with-lwt
+     %{pkg:lwt:installed}
+     --with-base-threads
+     %{pkg:base-threads:installed})))))
+
+(depends
+ (all_platforms
+  (ocaml ocamlfind ocamlbuild topkg fmt cmdliner lwt base-threads)))
+
+(source
+ (fetch
+  (url https://erratique.ch/software/logs/releases/logs-0.7.0.tbz)
+  (checksum
+   sha256=86f4a02807eb1a297aae44977d9f61e419c31458a5d7b23c6f55575e8e69d5ca)))

--- a/dune.lock/lru.0.3.1.pkg
+++ b/dune.lock/lru.0.3.1.pkg
@@ -1,0 +1,18 @@
+(version 0.3.1)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune psq)))
+
+(source
+ (fetch
+  (url https://github.com/pqwy/lru/releases/download/v0.3.1/lru-0.3.1.tbz)
+  (checksum
+   sha256=6cbe23d27a7d5b244f869c0b88140d47f70f413a6462ef35c0009325d4b236fd)))

--- a/dune.lock/luv.0.5.14.pkg
+++ b/dune.lock/luv.0.5.14.pkg
@@ -1,0 +1,15 @@
+(version 0.5.14)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (base-unix ctypes dune integers ocaml)))
+
+(source
+ (fetch
+  (url
+   https://github.com/aantron/luv/releases/download/0.5.14/luv-0.5.14.tar.gz)
+  (checksum
+   sha256=8e01b4a50c8876cdd98d8e245c0687c4dc4d883aed161ad9c5ace1fb1fdaae99)))

--- a/dune.lock/luv_unix.0.5.1.pkg
+++ b/dune.lock/luv_unix.0.5.1.pkg
@@ -1,0 +1,15 @@
+(version 0.5.1)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (base-unix ctypes dune luv ocaml)))
+
+(source
+ (fetch
+  (url
+   https://github.com/aantron/luv/releases/download/0.5.12/luv-0.5.12.tar.gz)
+  (checksum
+   sha256=769f6a08862a49d44e20043e270ef7177bcc7bb8679037bc06065622634c56c0)))

--- a/dune.lock/lwt-dllist.1.1.0.pkg
+++ b/dune.lock/lwt-dllist.1.1.0.pkg
@@ -1,0 +1,19 @@
+(version 1.1.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/lwt-dllist/releases/download/v1.1.0/lwt-dllist-1.1.0.tbz)
+  (checksum
+   sha256=b0200651e37eaa24f027177bc01e266db43da48aa18146973d1d18336c325d69)))

--- a/dune.lock/lwt.5.9.1.pkg
+++ b/dune.lock/lwt.5.9.1.pkg
@@ -1,0 +1,27 @@
+(version 5.9.1)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run
+      dune
+      exec
+      -p
+      %{pkg-self:name}
+      src/unix/config/discover.exe
+      --
+      --save
+      --use-libev
+      %{pkg:conf-libev:installed})
+     (run dune build -p %{pkg-self:name} -j %{jobs} @install))))))
+
+(depends
+ (all_platforms
+  (dune ocaml cppo dune-configurator ocplib-endian base-threads base-unix)))
+
+(source
+ (fetch
+  (url https://github.com/ocsigen/lwt/archive/refs/tags/5.9.1.tar.gz)
+  (checksum md5=18742da8b8fe3618e3fa700b7a884fe7)))

--- a/dune.lock/macaddr-cstruct.5.6.0.pkg
+++ b/dune.lock/macaddr-cstruct.5.6.0.pkg
@@ -1,0 +1,19 @@
+(version 5.6.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune macaddr cstruct)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz)
+  (checksum
+   sha256=9e30433fdb4ca437a6aa8ffb447baca5eba7615fb88e7b0cd8a4b416c3208133)))

--- a/dune.lock/macaddr-sexp.5.6.0.pkg
+++ b/dune.lock/macaddr-sexp.5.6.0.pkg
@@ -1,0 +1,19 @@
+(version 5.6.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune macaddr ppx_sexp_conv sexplib0)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz)
+  (checksum
+   sha256=9e30433fdb4ca437a6aa8ffb447baca5eba7615fb88e7b0cd8a4b416c3208133)))

--- a/dune.lock/macaddr.5.6.0.pkg
+++ b/dune.lock/macaddr.5.6.0.pkg
@@ -1,0 +1,19 @@
+(version 5.6.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz)
+  (checksum
+   sha256=9e30433fdb4ca437a6aa8ffb447baca5eba7615fb88e7b0cd8a4b416c3208133)))

--- a/dune.lock/menhir.20250912.pkg
+++ b/dune.lock/menhir.20250912.pkg
@@ -1,0 +1,14 @@
+(version 20250912)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml dune menhirLib menhirSdk menhirCST)))
+
+(source
+ (fetch
+  (url
+   https://gitlab.inria.fr/fpottier/menhir/-/archive/20250912/archive.tar.gz)
+  (checksum md5=b8f83df02226419f99e49f1b637dcb11)))

--- a/dune.lock/menhirCST.20250912.pkg
+++ b/dune.lock/menhirCST.20250912.pkg
@@ -1,0 +1,14 @@
+(version 20250912)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml dune)))
+
+(source
+ (fetch
+  (url
+   https://gitlab.inria.fr/fpottier/menhir/-/archive/20250912/archive.tar.gz)
+  (checksum md5=b8f83df02226419f99e49f1b637dcb11)))

--- a/dune.lock/menhirLib.20250912.pkg
+++ b/dune.lock/menhirLib.20250912.pkg
@@ -1,0 +1,14 @@
+(version 20250912)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml dune)))
+
+(source
+ (fetch
+  (url
+   https://gitlab.inria.fr/fpottier/menhir/-/archive/20250912/archive.tar.gz)
+  (checksum md5=b8f83df02226419f99e49f1b637dcb11)))

--- a/dune.lock/menhirSdk.20250912.pkg
+++ b/dune.lock/menhirSdk.20250912.pkg
@@ -1,0 +1,14 @@
+(version 20250912)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml dune)))
+
+(source
+ (fetch
+  (url
+   https://gitlab.inria.fr/fpottier/menhir/-/archive/20250912/archive.tar.gz)
+  (checksum md5=b8f83df02226419f99e49f1b637dcb11)))

--- a/dune.lock/metrics.0.5.0.pkg
+++ b/dune.lock/metrics.0.5.0.pkg
@@ -1,0 +1,19 @@
+(version 0.5.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune fmt)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/metrics/releases/download/v0.5.0/metrics-0.5.0.tbz)
+  (checksum
+   sha256=df356380909d06461bcd097ef6063ca9f3c51365f476a797c03664b53c05715d)))

--- a/dune.lock/mirage-channel.4.1.0.pkg
+++ b/dune.lock/mirage-channel.4.1.0.pkg
@@ -1,0 +1,19 @@
+(version 4.1.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune mirage-flow lwt cstruct logs)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/mirage-channel/releases/download/v4.1.0/mirage-channel-4.1.0.tbz)
+  (checksum
+   sha256=b0176851d4ddf5978d7072b420118178e6030ea50b33b1185fe3f3d9fda72100)))

--- a/dune.lock/mirage-clock-unix.4.2.0.pkg
+++ b/dune.lock/mirage-clock-unix.4.2.0.pkg
@@ -1,0 +1,19 @@
+(version 4.2.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune dune-configurator mirage-clock)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/mirage-clock/releases/download/v4.2.0/mirage-clock-4.2.0.tbz)
+  (checksum
+   sha256=fa17d15d5be23c79ba741f5f7cb88ed7112de16a4410cea81c71b98086889847)))

--- a/dune.lock/mirage-clock.4.2.0.pkg
+++ b/dune.lock/mirage-clock.4.2.0.pkg
@@ -1,0 +1,19 @@
+(version 4.2.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/mirage-clock/releases/download/v4.2.0/mirage-clock-4.2.0.tbz)
+  (checksum
+   sha256=fa17d15d5be23c79ba741f5f7cb88ed7112de16a4410cea81c71b98086889847)))

--- a/dune.lock/mirage-entropy.0.5.1.pkg
+++ b/dune.lock/mirage-entropy.0.5.1.pkg
@@ -1,0 +1,19 @@
+(version 0.5.1)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (conf-pkg-config dune ocaml cstruct mirage-runtime lwt)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/mirage-entropy/releases/download/v0.5.1/mirage-entropy-v0.5.1.tbz)
+  (checksum
+   sha256=612b2c17f18a56ed5cacc35006be6869016c26668eeaf301fd068b6467755d40)))

--- a/dune.lock/mirage-flow-combinators.3.0.0.pkg
+++ b/dune.lock/mirage-flow-combinators.3.0.0.pkg
@@ -1,0 +1,19 @@
+(version 3.0.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune fmt lwt logs cstruct mirage-clock mirage-flow)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/mirage-flow/releases/download/v3.0.0/mirage-flow-v3.0.0.tbz)
+  (checksum
+   sha256=d70bda6c85ec2747bed88bc4d95f269d2810503b92913f0807be5291696138fc)))

--- a/dune.lock/mirage-flow.3.0.0.pkg
+++ b/dune.lock/mirage-flow.3.0.0.pkg
@@ -1,0 +1,19 @@
+(version 3.0.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune cstruct fmt lwt)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/mirage-flow/releases/download/v3.0.0/mirage-flow-v3.0.0.tbz)
+  (checksum
+   sha256=d70bda6c85ec2747bed88bc4d95f269d2810503b92913f0807be5291696138fc)))

--- a/dune.lock/mirage-kv.5.0.0.pkg
+++ b/dune.lock/mirage-kv.5.0.0.pkg
@@ -1,0 +1,19 @@
+(version 5.0.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune fmt lwt)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/mirage-kv/releases/download/v5.0.0/mirage-kv-5.0.0.tbz)
+  (checksum
+   sha256=1036d74392461017ca8d9e32ccf94a5be6e03a056fa9ee551d4a7f49f6385462)))

--- a/dune.lock/mirage-net.4.0.0.pkg
+++ b/dune.lock/mirage-net.4.0.0.pkg
@@ -1,0 +1,19 @@
+(version 4.0.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune fmt macaddr cstruct lwt)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/mirage-net/releases/download/v4.0.0/mirage-net-v4.0.0.tbz)
+  (checksum
+   sha256=668effd187b81a0ab32450870c15dbb89ff911397ff338a8951807e250e194ce)))

--- a/dune.lock/mirage-profile.0.9.1.pkg
+++ b/dune.lock/mirage-profile.0.9.1.pkg
@@ -1,0 +1,15 @@
+(version 0.9.1)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml dune cstruct ppx_cstruct ocplib-endian lwt)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/mirage-profile/releases/download/v0.9.1/mirage-profile-v0.9.1.tbz)
+  (checksum
+   sha256=2bb6cf03c73c6f45dedc34365c9131b8bdda62390b04d26eb76793a6422a0352)))

--- a/dune.lock/mirage-random-stdlib.0.1.0.pkg
+++ b/dune.lock/mirage-random-stdlib.0.1.0.pkg
@@ -1,0 +1,19 @@
+(version 0.1.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (dune cstruct ocaml lwt mirage-random mirage-entropy)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/mirage-random-stdlib/releases/download/v0.1.0/mirage-random-stdlib-v0.1.0.tbz)
+  (checksum
+   sha256=51783442c9b97711715ce62a15bcbefd3b01ae32c737f998eede395bc2dbfda3)))

--- a/dune.lock/mirage-random.3.0.0.pkg
+++ b/dune.lock/mirage-random.3.0.0.pkg
@@ -1,0 +1,19 @@
+(version 3.0.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (dune cstruct ocaml)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/mirage-random/releases/download/v3.0.0/mirage-random-v3.0.0.tbz)
+  (checksum
+   sha256=49fe3f281d6430cc1723ecabe47fc9b8e9b29d83cd5f0964f5d000fa014066cf)))

--- a/dune.lock/mirage-runtime.3.10.8.pkg
+++ b/dune.lock/mirage-runtime.3.10.8.pkg
@@ -1,0 +1,19 @@
+(version 3.10.8)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune ipaddr functoria-runtime fmt logs lwt)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/mirage/releases/download/v3.10.8/mirage-v3.10.8.tbz)
+  (checksum
+   sha256=135d86ca74e68ddb61d4ef304d43fb951a10b7cbc488bf3d638fca4294016fb4)))

--- a/dune.lock/mirage-stack.4.0.0.pkg
+++ b/dune.lock/mirage-stack.4.0.0.pkg
@@ -1,0 +1,19 @@
+(version 4.0.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune tcpip)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/mirage-stack/releases/download/v4.0.0/mirage-stack-v4.0.0.tbz)
+  (checksum
+   sha256=abbd33190bd3e4a4eabcbdfb6d98d20fc4aed0fef628251eb327d625c23cccfc)))

--- a/dune.lock/mirage-time.3.0.0.pkg
+++ b/dune.lock/mirage-time.3.0.0.pkg
@@ -1,0 +1,19 @@
+(version 3.0.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune lwt)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/mirage-time/releases/download/v3.0.0/mirage-time-v3.0.0.tbz)
+  (checksum
+   sha256=0d40949b58e2c7e8b762ccc8ce066345046233c8c95d0e3d17a242ff289cbd7c)))

--- a/dune.lock/mirage-vnetif.0.5.0.pkg
+++ b/dune.lock/mirage-vnetif.0.5.0.pkg
@@ -1,0 +1,31 @@
+(version 0.5.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml
+   dune
+   lwt
+   mirage-time
+   mirage-clock
+   mirage-net
+   cstruct
+   ipaddr
+   macaddr
+   mirage-profile
+   duration
+   logs
+   result)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/mirage-vnetif/releases/download/v0.5.0/mirage-vnetif-v0.5.0.tbz)
+  (checksum
+   sha256=b85460222a780c9b99151b40a00cf57c29bd865baa63d702f997891d8ae3f832)))

--- a/dune.lock/num.1.6.pkg
+++ b/dune.lock/num.1.6.pkg
@@ -1,0 +1,31 @@
+(version 1.6)
+
+(build
+ (all_platforms
+  ((action
+    (run
+     %{make}
+     PROFILE=release
+     (when
+      (catch_undefined_var
+       (and_absorb_undefined_var
+        (not %{pkg:ocaml:preinstalled})
+        (< %{pkg:ocaml:version} 5.0.0~~))
+       false)
+      opam-legacy)
+     (when
+      (catch_undefined_var
+       (or_absorb_undefined_var
+        %{pkg:ocaml:preinstalled}
+        (>= %{pkg:ocaml:version} 5.0.0~~))
+       false)
+      opam-modern))))))
+
+(depends
+ (all_platforms (ocaml)))
+
+(source
+ (fetch
+  (url https://github.com/ocaml/num/archive/refs/tags/v1.6.tar.gz)
+  (checksum
+   sha256=b5cce325449aac746d5ca963d84688a627cca5b38d41e636cf71c68b60495b3e)))

--- a/dune.lock/ocaml-base-compiler.4.14.2.pkg
+++ b/dune.lock/ocaml-base-compiler.4.14.2.pkg
@@ -1,0 +1,117 @@
+(version 4.14.2)
+
+(install
+ (all_platforms
+  (withenv
+   ((= MSYS2_ARG_CONV_EXCL *))
+   (run %{make} install))))
+
+(build
+ (choice
+  ((((arch x86_64)
+     (os linux))
+    ((arch arm64)
+     (os linux)))
+   ((action
+     (withenv
+      ((= MSYS2_ARG_CONV_EXCL *))
+      (progn
+       (run
+        ./configure
+        (when
+         (catch_undefined_var
+          (and_absorb_undefined_var
+           %{pkg:system-msvc:installed}
+           %{pkg:arch-x86_64:installed})
+          false)
+         --host=x86_64-pc-windows)
+        (when
+         (catch_undefined_var
+          (and_absorb_undefined_var
+           (= %{os_distribution} cygwin)
+           %{pkg:system-mingw:installed}
+           %{pkg:arch-x86_64:installed})
+          false)
+         --host=x86_64-w64-mingw32)
+        (when
+         (catch_undefined_var
+          (and_absorb_undefined_var
+           %{pkg:system-msvc:installed}
+           %{pkg:arch-x86_32:installed})
+          false)
+         --host=i686-pc-windows)
+        (when
+         (catch_undefined_var
+          (and_absorb_undefined_var
+           (= %{os_distribution} cygwin)
+           %{pkg:system-mingw:installed}
+           %{pkg:arch-x86_32:installed})
+          false)
+         --host=i686-w64-mingw32)
+        --prefix=%{prefix}
+        --docdir=%{doc}/ocaml
+        -C)
+       (run %{make} -j%{jobs}))))))
+  ((((arch x86_64)
+     (os macos))
+    ((arch arm64)
+     (os macos)))
+   ((action
+     (withenv
+      ((= MSYS2_ARG_CONV_EXCL *))
+      (progn
+       (run
+        ./configure
+        (when
+         (catch_undefined_var
+          (and_absorb_undefined_var
+           %{pkg:system-msvc:installed}
+           %{pkg:arch-x86_64:installed})
+          false)
+         --host=x86_64-pc-windows)
+        (when
+         (catch_undefined_var
+          (and_absorb_undefined_var
+           (= %{os_distribution} cygwin)
+           %{pkg:system-mingw:installed}
+           %{pkg:arch-x86_64:installed})
+          false)
+         --host=x86_64-w64-mingw32)
+        (when
+         (catch_undefined_var
+          (and_absorb_undefined_var
+           %{pkg:system-msvc:installed}
+           %{pkg:arch-x86_32:installed})
+          false)
+         --host=i686-pc-windows)
+        (when
+         (catch_undefined_var
+          (and_absorb_undefined_var
+           (= %{os_distribution} cygwin)
+           %{pkg:system-mingw:installed}
+           %{pkg:arch-x86_32:installed})
+          false)
+         --host=i686-w64-mingw32)
+        --prefix=%{prefix}
+        --docdir=%{doc}/ocaml
+        -C
+        CC=cc
+        "ASPP=cc -c")
+       (run %{make} -j%{jobs}))))))))
+
+(source
+ (fetch
+  (url https://github.com/ocaml/ocaml/archive/4.14.2.tar.gz)
+  (checksum
+   sha256=c2d706432f93ba85bd3383fa451d74543c32a4e84a1afaf3e8ace18f7f097b43)))
+
+(exported_env
+ (= CAML_LD_LIBRARY_PATH "\%{lib}%/stublibs"))
+
+(extra_sources
+ (ocaml-base-compiler.install
+  (fetch
+   (url
+    https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install)
+   (checksum
+    sha256=79f2a1a5044a91350a0eb6ce12e261a72a2855c094c425cddf3860e58c486678))))

--- a/dune.lock/ocaml-compiler-libs.v0.12.4.pkg
+++ b/dune.lock/ocaml-compiler-libs.v0.12.4.pkg
@@ -1,0 +1,19 @@
+(version v0.12.4)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs} @install))))))
+
+(depends
+ (all_platforms
+  (dune ocaml)))
+
+(source
+ (fetch
+  (url
+   https://github.com/janestreet/ocaml-compiler-libs/releases/download/v0.12.4/ocaml-compiler-libs-v0.12.4.tbz)
+  (checksum
+   sha256=4ec9c9ec35cc45c18c7a143761154ef1d7663036a29297f80381f47981a07760)))

--- a/dune.lock/ocaml-config.2.pkg
+++ b/dune.lock/ocaml-config.2.pkg
@@ -1,0 +1,22 @@
+(version 2)
+
+(build
+ (all_platforms
+  ((action (substitute gen_ocaml_config.ml.in gen_ocaml_config.ml)))))
+
+(depends
+ (all_platforms (ocaml-base-compiler)))
+
+(extra_sources
+ (gen_ocaml_config.ml.in
+  (fetch
+   (url
+    https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-config/gen_ocaml_config.ml.in.2)
+   (checksum
+    sha256=22eb7c0211fc426028e444b272b97eac1e8287a49a512aebaa33c608652cfd29)))
+ (ocaml-config.install
+  (fetch
+   (url
+    https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-config/ocaml-config.install)
+   (checksum
+    sha256=6e4fd93f4cce6bad0ed3c08afd0248dbe7d7817109281de6294e5b5ef5597051))))

--- a/dune.lock/ocaml-syntax-shims.1.0.0.pkg
+++ b/dune.lock/ocaml-syntax-shims.1.0.0.pkg
@@ -1,0 +1,19 @@
+(version 1.0.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs} @install))))))
+
+(depends
+ (all_platforms
+  (dune ocaml)))
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml-ppx/ocaml-syntax-shims/releases/download/1.0.0/ocaml-syntax-shims-1.0.0.tbz)
+  (checksum
+   sha256=89b2e193e90a0c168b6ec5ddf6fef09033681bdcb64e11913c97440a2722e8c8)))

--- a/dune.lock/ocaml.4.14.2.pkg
+++ b/dune.lock/ocaml.4.14.2.pkg
@@ -1,0 +1,22 @@
+(version 4.14.2)
+
+(build
+ (all_platforms
+  ((action
+    (withenv
+     ((= CAML_LD_LIBRARY_PATH ""))
+     (run
+      ocaml
+      %{pkg:ocaml-config:share}/gen_ocaml_config.ml
+      %{pkg-self:version}
+      %{pkg-self:name}))))))
+
+(depends
+ (all_platforms
+  (ocaml-config ocaml-base-compiler)))
+
+(exported_env
+ (+= OCAMLTOP_INCLUDE_PATH "\%{toplevel}%")
+ (= CAML_LD_LIBRARY_PATH "\%{_:stubsdir}%")
+ (+= CAML_LD_LIBRARY_PATH "\%{lib}%/stublibs")
+ (= OCAML_TOPLEVEL_PATH "\%{toplevel}%"))

--- a/dune.lock/ocamlbuild.0.16.1+dune.pkg
+++ b/dune.lock/ocamlbuild.0.16.1+dune.pkg
@@ -1,0 +1,28 @@
+(version 0.16.1+dune)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (run
+      %{make}
+      -f
+      configure.make
+      all
+      OCAMLBUILD_PREFIX=%{prefix}
+      OCAMLBUILD_BINDIR=%{bin}
+      OCAMLBUILD_LIBDIR=%{lib}
+      OCAMLBUILD_MANDIR=%{man}
+      OCAML_NATIVE=%{pkg:ocaml:native}
+      OCAML_NATIVE_TOOLS=%{pkg:ocaml:native})
+     (run %{make} check-if-preinstalled all opam-install))))))
+
+(depends
+ (all_platforms (ocaml)))
+
+(source
+ (fetch
+  (url
+   https://github.com/gridbugs/ocamlbuild/archive/refs/tags/0.16.1+dune.tar.gz)
+  (checksum
+   sha512=9bf33e2e3cd70495c6ff5987f7e8c1c2fb3dccb02da490140726fed3b374489cb93d500f57bea32a1a71da1c9d3dd207e476109d1aaa759f54c3ef07d5b7ccd8)))

--- a/dune.lock/ocamlfind.1.9.8+dune.pkg
+++ b/dune.lock/ocamlfind.1.9.8+dune.pkg
@@ -1,0 +1,46 @@
+(version 1.9.8+dune)
+
+(install
+ (all_platforms
+  (progn
+   (run %{make} install)
+   (when
+    %{pkg:ocaml:preinstalled}
+    (run install -m 0755 ocaml-stub %{bin}/ocaml)))))
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (run
+      ./configure
+      -bindir
+      %{bin}
+      -sitelib
+      %{lib}
+      -mandir
+      %{man}
+      -config
+      %{lib}/findlib.conf
+      -with-relative-paths-at
+      %{prefix}
+      -no-custom
+      (when
+       (catch_undefined_var
+        (and_absorb_undefined_var
+         (not %{pkg:ocaml:preinstalled})
+         (>= %{pkg:ocaml:version} 4.02.0))
+        false)
+       -no-camlp4)
+      (when (catch_undefined_var %{pkg:ocaml:preinstalled} false) -no-topfind))
+     (run %{make} all)
+     (when %{pkg:ocaml:native} (run %{make} opt)))))))
+
+(depends
+ (all_platforms (ocaml)))
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml/ocamlfind/archive/refs/tags/findlib-1.9.8.tar.gz)
+  (checksum md5=ca770e5806032a96131b670f6e07f146)))

--- a/dune.lock/ocplib-endian.1.2.pkg
+++ b/dune.lock/ocplib-endian.1.2.pkg
@@ -1,0 +1,15 @@
+(version 1.2)
+
+(build
+ (all_platforms
+  ((action (run dune build -p %{pkg-self:name} -j %{jobs} @install)))))
+
+(depends
+ (all_platforms
+  (base-bytes ocaml cppo dune)))
+
+(source
+ (fetch
+  (url
+   https://github.com/OCamlPro/ocplib-endian/archive/refs/tags/1.2.tar.gz)
+  (checksum md5=8d5492eeb7c6815ade72a7415ea30949)))

--- a/dune.lock/octavius.1.2.2.pkg
+++ b/dune.lock/octavius.1.2.2.pkg
@@ -1,0 +1,18 @@
+(version 1.2.2)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs} @install))))))
+
+(depends
+ (all_platforms
+  (dune ocaml)))
+
+(source
+ (fetch
+  (url https://github.com/ocaml-doc/octavius/archive/v1.2.2.tar.gz)
+  (checksum
+   sha256=eac9104ce0316b69da9c44b9c477700fe0b52a888c89ce4bdf1d2b782a73e0ad)))

--- a/dune.lock/ounit.2.2.7.pkg
+++ b/dune.lock/ounit.2.2.7.pkg
@@ -1,0 +1,16 @@
+(version 2.2.7)
+
+(install
+ (all_platforms
+  (run %{make} install-ounit version=%{pkg-self:version})))
+
+(depends
+ (all_platforms
+  (ocamlfind ounit2)))
+
+(source
+ (fetch
+  (url
+   https://github.com/gildor478/ounit/releases/download/v2.2.7/ounit-2.2.7.tbz)
+  (checksum
+   sha256=90f6e63bd1240a51d8b9b2f722059bd79ce00b5276bdd6238b8f5c613c0e7388)))

--- a/dune.lock/ounit2.2.2.7.pkg
+++ b/dune.lock/ounit2.2.2.7.pkg
@@ -1,0 +1,16 @@
+(version 2.2.7)
+
+(build
+ (all_platforms
+  ((action (run dune build -p %{pkg-self:name} -j %{jobs} @install)))))
+
+(depends
+ (all_platforms
+  (dune ocaml base-unix seq stdlib-shims)))
+
+(source
+ (fetch
+  (url
+   https://github.com/gildor478/ounit/releases/download/v2.2.7/ounit-2.2.7.tbz)
+  (checksum
+   sha256=90f6e63bd1240a51d8b9b2f722059bd79ce00b5276bdd6238b8f5c613c0e7388)))

--- a/dune.lock/parsexp.v0.14.2.pkg
+++ b/dune.lock/parsexp.v0.14.2.pkg
@@ -1,0 +1,15 @@
+(version v0.14.2)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml base sexplib0 dune)))
+
+(source
+ (fetch
+  (url
+   https://github.com/janestreet/parsexp/archive/refs/tags/v0.14.2.tar.gz)
+  (checksum
+   sha256=f6e17e4e08dcdce08a6372485a381dcdb3fda0f71b4506d7be982b87b5a1f230)))

--- a/dune.lock/pcap-format.0.6.0.pkg
+++ b/dune.lock/pcap-format.0.6.0.pkg
@@ -1,0 +1,19 @@
+(version 0.6.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune cstruct ppx_cstruct)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-pcap/releases/download/v0.6.0/pcap-format-0.6.0.tbz)
+  (checksum
+   sha256=2d48f2f179ba56c9ccab51472b398983bba8ae44efedc393b282f09ad34791a6)))

--- a/dune.lock/ppx_assert.v0.14.0.pkg
+++ b/dune.lock/ppx_assert.v0.14.0.pkg
@@ -1,0 +1,15 @@
+(version v0.14.0)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml base ppx_cold ppx_compare ppx_here ppx_sexp_conv dune ppxlib)))
+
+(source
+ (fetch
+  (url
+   https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_assert-v0.14.0.tar.gz)
+  (checksum
+   sha256=25f45fbeadc6ac4823b2f7959b279a66a77abe21e10beb7319ab60f125c959d0)))

--- a/dune.lock/ppx_base.v0.14.0.pkg
+++ b/dune.lock/ppx_base.v0.14.0.pkg
@@ -1,0 +1,23 @@
+(version v0.14.0)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml
+   ppx_cold
+   ppx_compare
+   ppx_enumerate
+   ppx_hash
+   ppx_js_style
+   ppx_sexp_conv
+   dune
+   ppxlib)))
+
+(source
+ (fetch
+  (url
+   https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_base-v0.14.0.tar.gz)
+  (checksum
+   sha256=26ca13a9638b27b862c94886b8b25d0e1c83d5f7663cf0d545538214ab1bea2c)))

--- a/dune.lock/ppx_cold.v0.14.0.pkg
+++ b/dune.lock/ppx_cold.v0.14.0.pkg
@@ -1,0 +1,15 @@
+(version v0.14.0)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml base dune ppxlib)))
+
+(source
+ (fetch
+  (url
+   https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_cold-v0.14.0.tar.gz)
+  (checksum
+   sha256=c21aafd332719c28630de7fa9d0acd1250bac1b1609457bbad2ae578e1774dd5)))

--- a/dune.lock/ppx_compare.v0.14.0.pkg
+++ b/dune.lock/ppx_compare.v0.14.0.pkg
@@ -1,0 +1,15 @@
+(version v0.14.0)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml base dune ppxlib)))
+
+(source
+ (fetch
+  (url
+   https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_compare-v0.14.0.tar.gz)
+  (checksum
+   sha256=b7de8451acb6bcd0917b476c8bf2546bc4d45eb9c14a47fa71d19214b4501d57)))

--- a/dune.lock/ppx_cstruct.6.0.1.pkg
+++ b/dune.lock/ppx_cstruct.6.0.1.pkg
@@ -1,0 +1,19 @@
+(version 6.0.1)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune cstruct ppxlib sexplib stdlib-shims)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-cstruct/releases/download/v6.0.1/cstruct-v6.0.1.tbz)
+  (checksum
+   sha256=4a67bb8f042753453c59eabf0e47865631253ba694091ce6062aac05d47a9bed)))

--- a/dune.lock/ppx_derivers.1.2.1.pkg
+++ b/dune.lock/ppx_derivers.1.2.1.pkg
@@ -1,0 +1,14 @@
+(version 1.2.1)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml dune)))
+
+(source
+ (fetch
+  (url https://github.com/ocaml-ppx/ppx_derivers/archive/1.2.1.tar.gz)
+  (checksum
+   sha256=b6595ee187dea792b31fc54a0e1524ab1e48bc6068d3066c45215a138cc73b95)))

--- a/dune.lock/ppx_enumerate.v0.14.0.pkg
+++ b/dune.lock/ppx_enumerate.v0.14.0.pkg
@@ -1,0 +1,15 @@
+(version v0.14.0)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml base dune ppxlib)))
+
+(source
+ (fetch
+  (url
+   https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_enumerate-v0.14.0.tar.gz)
+  (checksum
+   sha256=e86bf7c661d9db3771e82764a301a4fd75c302cf19e695a4e5d242fc9cd346c6)))

--- a/dune.lock/ppx_hash.v0.14.0.pkg
+++ b/dune.lock/ppx_hash.v0.14.0.pkg
@@ -1,0 +1,15 @@
+(version v0.14.0)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml base ppx_compare ppx_sexp_conv dune ppxlib)))
+
+(source
+ (fetch
+  (url
+   https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_hash-v0.14.0.tar.gz)
+  (checksum
+   sha256=16e9447252e0bd3e5463b6dcc7acd9b74f3faf142566f557220ab507777b9c74)))

--- a/dune.lock/ppx_here.v0.14.0.pkg
+++ b/dune.lock/ppx_here.v0.14.0.pkg
@@ -1,0 +1,15 @@
+(version v0.14.0)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml base dune ppxlib)))
+
+(source
+ (fetch
+  (url
+   https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_here-v0.14.0.tar.gz)
+  (checksum
+   sha256=72fe20f7cfae3744a1a726bd973f0e25d07905a065f3eb41946623e36523842c)))

--- a/dune.lock/ppx_inline_test.v0.14.1.pkg
+++ b/dune.lock/ppx_inline_test.v0.14.1.pkg
@@ -1,0 +1,14 @@
+(version v0.14.1)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml base time_now dune ppxlib)))
+
+(source
+ (fetch
+  (url https://github.com/janestreet/ppx_inline_test/archive/v0.14.1.tar.gz)
+  (checksum
+   sha256=d7e5c1b92e5ae1e9076979852c80cb192af443ff90e2fb11b5561df032aafb63)))

--- a/dune.lock/ppx_js_style.v0.14.1.pkg
+++ b/dune.lock/ppx_js_style.v0.14.1.pkg
@@ -1,0 +1,15 @@
+(version v0.14.1)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml base dune octavius ppxlib)))
+
+(source
+ (fetch
+  (url
+   https://github.com/janestreet/ppx_js_style/archive/refs/tags/v0.14.1.tar.gz)
+  (checksum
+   sha256=3c5e1db934c3695315e00e27fd2df1f32efcb5c8f1c88b046b64b8548ccc04db)))

--- a/dune.lock/ppx_optcomp.v0.14.3.pkg
+++ b/dune.lock/ppx_optcomp.v0.14.3.pkg
@@ -1,0 +1,14 @@
+(version v0.14.3)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml base stdio dune ppxlib)))
+
+(source
+ (fetch
+  (url https://github.com/janestreet/ppx_optcomp/archive/v0.14.3.tar.gz)
+  (checksum
+   sha256=3601a4fc1e67b90735985015d12b12168bfacffd529ed17253b1fd512f80bf2f)))

--- a/dune.lock/ppx_sexp_conv.v0.14.3.pkg
+++ b/dune.lock/ppx_sexp_conv.v0.14.3.pkg
@@ -1,0 +1,14 @@
+(version v0.14.3)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml base sexplib0 dune ppxlib)))
+
+(source
+ (fetch
+  (url https://github.com/janestreet/ppx_sexp_conv/archive/v0.14.3.tar.gz)
+  (checksum
+   sha256=2fc1f46e14016c93b0ba89a2af263e36a51957a53608751361f07ad3349c7639)))

--- a/dune.lock/ppxlib.0.25.1.pkg
+++ b/dune.lock/ppxlib.0.25.1.pkg
@@ -1,0 +1,19 @@
+(version 0.25.1)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs} @install))))))
+
+(depends
+ (all_platforms
+  (dune ocaml ocaml-compiler-libs ppx_derivers sexplib0 stdlib-shims)))
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml-ppx/ppxlib/releases/download/0.25.1/ppxlib-0.25.1.tbz)
+  (checksum
+   sha256=a51b3868029e62ff14a0f2bd8d278dacfc0c3fc5b22d484a296be90c53e4ffd7)))

--- a/dune.lock/protocol-9p.2.0.2.pkg
+++ b/dune.lock/protocol-9p.2.0.2.pkg
@@ -1,0 +1,33 @@
+(version 2.0.2)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml
+   dune
+   base-bytes
+   cstruct
+   cstruct-sexp
+   sexplib
+   rresult
+   mirage-flow
+   mirage-channel
+   lwt
+   astring
+   fmt
+   logs
+   win-error
+   ppx_sexp_conv)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-9p/releases/download/2.0.2/protocol-9p-2.0.2.tbz)
+  (checksum
+   sha256=a4c0585e81f5c57c879560318016aeb022163044f2c7ae086af3dfcbbe1b8164)))

--- a/dune.lock/psq.0.2.1.pkg
+++ b/dune.lock/psq.0.2.1.pkg
@@ -1,0 +1,18 @@
+(version 0.2.1)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune seq)))
+
+(source
+ (fetch
+  (url https://github.com/pqwy/psq/releases/download/v0.2.1/psq-0.2.1.tbz)
+  (checksum
+   sha256=42005f533eabe74b1799ee32b8905654cd66a22bed4af2bd266b28d8462cd344)))

--- a/dune.lock/randomconv.0.1.3.pkg
+++ b/dune.lock/randomconv.0.1.3.pkg
@@ -1,0 +1,19 @@
+(version 0.1.3)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune cstruct)))
+
+(source
+ (fetch
+  (url
+   https://github.com/hannesm/randomconv/releases/download/v0.1.3/randomconv-v0.1.3.tbz)
+  (checksum
+   sha256=9b286aaac68fe3e5f69ed34115153ce74c613270a534b04642bae35934c863c7)))

--- a/dune.lock/re.1.12.0.pkg
+++ b/dune.lock/re.1.12.0.pkg
@@ -1,0 +1,19 @@
+(version 1.12.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune seq)))
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml/ocaml-re/releases/download/1.12.0/re-1.12.0.tbz)
+  (checksum
+   sha256=a01f2bf22f72c2f4ababd8d3e7635e35c1bf6bc5a41ad6d5a007454ddabad1d4)))

--- a/dune.lock/result.1.5.pkg
+++ b/dune.lock/result.1.5.pkg
@@ -1,0 +1,15 @@
+(version 1.5)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml dune)))
+
+(source
+ (fetch
+  (url
+   https://github.com/janestreet/result/releases/download/1.5/result-1.5.tbz)
+  (checksum
+   sha256=7c3a5e238558f4c1a4f5acca816bc705a0e12f68dc0005c61ddbf2e6cab8ee32)))

--- a/dune.lock/rresult.0.7.0.pkg
+++ b/dune.lock/rresult.0.7.0.pkg
@@ -1,0 +1,15 @@
+(version 0.7.0)
+
+(build
+ (all_platforms
+  ((action (run ocaml pkg/pkg.ml build --dev-pkg %{pkg-self:dev})))))
+
+(depends
+ (all_platforms
+  (ocaml ocamlfind ocamlbuild topkg)))
+
+(source
+ (fetch
+  (url https://erratique.ch/software/rresult/releases/rresult-0.7.0.tbz)
+  (checksum
+   sha512=f1bb631c986996388e9686d49d5ae4d8aaf14034f6865c62a88fb58c48ce19ad2eb785327d69ca27c032f835984e0bd2efd969b415438628a31f3e84ec4551d3)))

--- a/dune.lock/seq.base.pkg
+++ b/dune.lock/seq.base.pkg
@@ -1,0 +1,18 @@
+(version base)
+
+(depends
+ (all_platforms (ocaml)))
+
+(extra_sources
+ (META.seq
+  (fetch
+   (url
+    https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/seq/META.seq)
+   (checksum
+    sha256=e95062b4d0519ef8335c02f7d0f1952d11b814c7ab7e6d566a206116162fa2be)))
+ (seq.install
+  (fetch
+   (url
+    https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/seq/seq.install)
+   (checksum
+    sha256=fff926c2c4d5a82b6c94c60c4c35eb06e3d39975893ebe6b1f0e6557cbe34904))))

--- a/dune.lock/sexplib.v0.14.0.pkg
+++ b/dune.lock/sexplib.v0.14.0.pkg
@@ -1,0 +1,15 @@
+(version v0.14.0)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml parsexp sexplib0 dune num)))
+
+(source
+ (fetch
+  (url
+   https://ocaml.janestreet.com/ocaml-core/v0.14/files/sexplib-v0.14.0.tar.gz)
+  (checksum
+   sha256=a2d2c5fdab67b37f06a5ae190de18ba4488d02894f09fd866d4e66e60cb3348b)))

--- a/dune.lock/sexplib0.v0.14.0.pkg
+++ b/dune.lock/sexplib0.v0.14.0.pkg
@@ -1,0 +1,15 @@
+(version v0.14.0)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml dune)))
+
+(source
+ (fetch
+  (url
+   https://ocaml.janestreet.com/ocaml-core/v0.14/files/sexplib0-v0.14.0.tar.gz)
+  (checksum
+   sha256=6fab188a1ad5e1a9ada53de95981c3cfb500ffe412c9cb5a2079ef1d3260b929)))

--- a/dune.lock/sha.1.15.4.pkg
+++ b/dune.lock/sha.1.15.4.pkg
@@ -1,0 +1,34 @@
+(version 1.15.4)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run
+      dune
+      build
+      -p
+      %{pkg-self:name}
+      -j
+      %{jobs}
+      --promote-install-files=false
+      @install)
+     (run
+      dune
+      install
+      -p
+      %{pkg-self:name}
+      --create-install-files
+      %{pkg-self:name}))))))
+
+(depends
+ (all_platforms
+  (dune ocaml stdlib-shims)))
+
+(source
+ (fetch
+  (url
+   https://github.com/djs55/ocaml-sha/releases/download/v1.15.4/sha-1.15.4.tbz)
+  (checksum
+   sha256=6de5b12139b1999ce9df4cc78a5a31886c2a547c9d448bf2853f8b53bcf1f1b1)))

--- a/dune.lock/stdio.v0.14.0.pkg
+++ b/dune.lock/stdio.v0.14.0.pkg
@@ -1,0 +1,15 @@
+(version v0.14.0)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml base dune)))
+
+(source
+ (fetch
+  (url
+   https://ocaml.janestreet.com/ocaml-core/v0.14/files/stdio-v0.14.0.tar.gz)
+  (checksum
+   sha256=14ccd6a8b8a6fb4c906903a380644a6b7f2d7d081424a3408ac2e37c558645c2)))

--- a/dune.lock/stdlib-shims.0.3.0.pkg
+++ b/dune.lock/stdlib-shims.0.3.0.pkg
@@ -1,0 +1,15 @@
+(version 0.3.0)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (dune ocaml)))
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml/stdlib-shims/releases/download/0.3.0/stdlib-shims-0.3.0.tbz)
+  (checksum
+   sha256=babf72d3917b86f707885f0c5528e36c63fccb698f4b46cf2bab5c7ccdd6d84a)))

--- a/dune.lock/stringext.1.6.0.pkg
+++ b/dune.lock/stringext.1.6.0.pkg
@@ -1,0 +1,19 @@
+(version 1.6.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune)))
+
+(source
+ (fetch
+  (url
+   https://github.com/rgrinberg/stringext/releases/download/1.6.0/stringext-1.6.0.tbz)
+  (checksum
+   sha256=db41f5d52e9eab17615f110b899dfeb27dd7e7f89cd35ae43827c5119db206ea)))

--- a/dune.lock/tar.2.0.1.pkg
+++ b/dune.lock/tar.2.0.1.pkg
@@ -1,0 +1,34 @@
+(version 2.0.1)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run
+      dune
+      build
+      -p
+      %{pkg-self:name}
+      -j
+      %{jobs}
+      --promote-install-files=false
+      @install)
+     (run
+      dune
+      install
+      -p
+      %{pkg-self:name}
+      --create-install-files
+      %{pkg-self:name}))))))
+
+(depends
+ (all_platforms
+  (dune camlp-streams ocaml ppx_cstruct cstruct re)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-tar/releases/download/v2.0.1/tar-mirage-2.0.1.tbz)
+  (checksum
+   sha256=e9565fb43dab9e944d1860f9a3b5c681df72211b859c66ee1d7085cafc13ee9b)))

--- a/dune.lock/tcpip.7.1.2.pkg
+++ b/dune.lock/tcpip.7.1.2.pkg
@@ -1,0 +1,43 @@
+(version 7.1.2)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (conf-pkg-config
+   dune
+   ocaml
+   cstruct
+   cstruct-lwt
+   ppx_cstruct
+   mirage-net
+   mirage-clock
+   mirage-random
+   mirage-time
+   ipaddr
+   macaddr
+   macaddr-cstruct
+   mirage-profile
+   fmt
+   lwt
+   lwt-dllist
+   logs
+   duration
+   randomconv
+   ethernet
+   arp
+   mirage-flow
+   lru
+   metrics)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/mirage-tcpip/releases/download/v7.1.2/tcpip-7.1.2.tbz)
+  (checksum
+   sha256=96b6aeafa35f143f7275d1becb6d639472adf3680b8180416de765b6581c466d)))

--- a/dune.lock/time_now.v0.14.0.pkg
+++ b/dune.lock/time_now.v0.14.0.pkg
@@ -1,0 +1,15 @@
+(version v0.14.0)
+
+(build
+ (all_platforms ((action (run dune build -p %{pkg-self:name} -j %{jobs})))))
+
+(depends
+ (all_platforms
+  (ocaml base jane-street-headers jst-config ppx_base ppx_optcomp dune)))
+
+(source
+ (fetch
+  (url
+   https://ocaml.janestreet.com/ocaml-core/v0.14/files/time_now-v0.14.0.tar.gz)
+  (checksum
+   sha256=1033819ee471bba975edaa4a0e555eff7c7379a153d3a52d75affc46b8147642)))

--- a/dune.lock/topkg.1.1.1.pkg
+++ b/dune.lock/topkg.1.1.1.pkg
@@ -1,0 +1,23 @@
+(version 1.1.1)
+
+(build
+ (all_platforms
+  ((action
+    (run
+     ocaml
+     pkg/pkg.ml
+     build
+     --pkg-name
+     %{pkg-self:name}
+     --dev-pkg
+     %{pkg-self:dev})))))
+
+(depends
+ (all_platforms
+  (ocaml ocamlfind ocamlbuild)))
+
+(source
+ (fetch
+  (url https://erratique.ch/software/topkg/releases/topkg-1.1.1.tbz)
+  (checksum
+   sha512=c36c549a362ddf5b7fe3f6ff91c79b7ab531c43633bb9737576370bcbd69db7e1625d247c278a869b503d45a175e9753231ccf595e5bfa4e3b7e2602ac3d3b42)))

--- a/dune.lock/uri-sexp.4.4.0.pkg
+++ b/dune.lock/uri-sexp.4.4.0.pkg
@@ -1,0 +1,19 @@
+(version 4.4.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (uri dune ppx_sexp_conv sexplib0)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-uri/releases/download/v4.4.0/uri-4.4.0.tbz)
+  (checksum
+   sha256=cdabaf6ef5cd2161e59cc7b74c6e4a68ecb80a9f4e96002e338e1b6bf17adec4)))

--- a/dune.lock/uri.4.4.0.pkg
+++ b/dune.lock/uri.4.4.0.pkg
@@ -1,0 +1,19 @@
+(version 4.4.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml dune stringext angstrom)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-uri/releases/download/v4.4.0/uri-4.4.0.tbz)
+  (checksum
+   sha256=cdabaf6ef5cd2161e59cc7b74c6e4a68ecb80a9f4e96002e338e1b6bf17adec4)))

--- a/dune.lock/uuidm.0.9.7.pkg
+++ b/dune.lock/uuidm.0.9.7.pkg
@@ -1,0 +1,23 @@
+(version 0.9.7)
+
+(build
+ (all_platforms
+  ((action
+    (run
+     ocaml
+     pkg/pkg.ml
+     build
+     --pinned
+     %{pkg-self:pinned}
+     --with-cmdliner
+     %{pkg:cmdliner:installed})))))
+
+(depends
+ (all_platforms
+  (ocaml ocamlfind ocamlbuild topkg cmdliner)))
+
+(source
+ (fetch
+  (url https://erratique.ch/software/uuidm/releases/uuidm-0.9.7.tbz)
+  (checksum
+   sha256=2817b2034ac8b2f9f251f4ae903dd1a2d8ed48bfa6f758b3307325dbe1587dc7)))

--- a/dune.lock/uutf.1.0.3.pkg
+++ b/dune.lock/uutf.1.0.3.pkg
@@ -1,0 +1,23 @@
+(version 1.0.3)
+
+(build
+ (all_platforms
+  ((action
+    (run
+     ocaml
+     pkg/pkg.ml
+     build
+     --dev-pkg
+     %{pkg-self:dev}
+     --with-cmdliner
+     %{pkg:cmdliner:installed})))))
+
+(depends
+ (all_platforms
+  (ocaml ocamlfind ocamlbuild topkg cmdliner)))
+
+(source
+ (fetch
+  (url https://erratique.ch/software/uutf/releases/uutf-1.0.3.tbz)
+  (checksum
+   sha512=50cc4486021da46fb08156e9daec0d57b4ca469b07309c508d5a9a41e9dbcf1f32dec2ed7be027326544453dcaf9c2534919395fd826dc7768efc6cc4bfcc9f8)))

--- a/dune.lock/win-error.1.0.pkg
+++ b/dune.lock/win-error.1.0.pkg
@@ -1,0 +1,19 @@
+(version 1.0)
+
+(build
+ (all_platforms
+  ((action
+    (progn
+     (when %{pkg-self:dev} (run dune subst))
+     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
+
+(depends
+ (all_platforms
+  (ocaml base-bytes base-unix dune)))
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-win-error/releases/download/1.0/win-error-1.0.tbz)
+  (checksum
+   sha256=c00aecc776b1cd6ac2d2aa442e2355ae6a44e4760f3ba1fc7117dc1e2231a400)))

--- a/src/dns_test/dune
+++ b/src/dns_test/dune
@@ -1,6 +1,6 @@
 (test
   (name       test)
-  (libraries  dns oUnit pcap-format bigarray bigarray-compat lwt)
+  (libraries  dns ounit pcap-format bigarray bigarray-compat lwt)
   (deps       (glob_files *.pcap) (glob_files *.zone))
   (preprocess (pps ppx_cstruct)))
 

--- a/vpnkit.opam
+++ b/vpnkit.opam
@@ -67,6 +67,7 @@ depends: [
   "mirage-random-stdlib"
   "re" {>= "1.9.0"}
   "ppx_inline_test"
+  "cohttp" {< "6"}
 ]
 synopsis: "VPN-friendly networking devices for HyperKit"
 description: """


### PR DESCRIPTION
This adds a dune lockdir to the project and a github action where pushing a tag causes a vpn binary distribution to be built for linux and macos, and released to the github "releases" page.

Also fixes a few minor issues which prevented the project from building with the locked versions of dependencies.