### PR TITLE
Fix bin-image workflow JSON parsing error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,8 @@ version: 2
 jobs:
   build:
     macos:
-      xcode: "14.0.0"
+      xcode: "14.3.1"
+    resource_class: m4pro.medium
     environment:
       OPAMYES: "1"
       OPAMJOBS: "2"

--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -26,7 +26,7 @@ env:
   REPO_SLUG: moby/vpnkit-bin
 jobs:
   build:
-    uses: crazy-max/.github/.github/workflows/bake-distribute-mp.yml@d9a10e2737504a6e253f96e344cef684b0e00cb5
+    uses: crazy-max/.github/.github/workflows/bake-distribute-mp.yml@387d336cac5f20cba622a6b9a866a80ea4c2c575
     with:
       target: bin-image
       push: ${{ github.event_name != 'pull_request' && github.repository == 'moby/vpnkit' }}


### PR DESCRIPTION
## Summary
- Updates the `crazy-max/.github` reusable workflow from commit `d9a10e2` to `387d336` (latest)
- Updates CircleCI configuration to use Xcode 14.3.1 with `m4pro.medium` resource class
- Fixes both GitHub Actions and CircleCI build failures observed in PR #654

## Problem 1: GitHub Actions JSON Parsing Error

The bin-image workflow was failing with:
```
SyntaxError: Bad control character in string literal in JSON at position 13871
```

This occurred because the older version of the workflow used `actions/github-script@v7` which embedded GitHub event payloads (containing PR body text with newlines and other control characters) directly into a JavaScript template literal containing JSON. When `JSON.parse()` tried to parse this, it encountered unescaped control characters and failed.

## Problem 2: CircleCI Resource Class Incompatibility

The CircleCI build was failing with:
```
Job was rejected because resource class m4pro.medium, image xcode:14.0.0 is not a valid resource class
```

Xcode 14.0.0 is not compatible with the new default `m4pro.medium` resource class. CircleCI changed the default macOS resource class for free plans on November 10, 2025, and Xcode 14.0.0 only supports older M1/M2 resource classes which are being deprecated in February 2026.

## Solution

### GitHub Actions Fix
The newer version of the `crazy-max/.github` workflow uses `actions/github-script@v8` which properly handles JSON serialization, preventing control character parsing errors.

### CircleCI Fix
Updated to use Xcode 14.3.1 (latest Xcode 14.x version) with explicit `resource_class: m4pro.medium` specification. This combination is supported per CircleCI's compatibility matrix and ensures long-term compatibility.

## Testing
This should fix the build failures observed in PR #654: https://github.com/moby/vpnkit/actions/runs/20041297769/job/57478620313

🤖 Generated with [Claude Code](https://claude.com/claude-code)