### PR TITLE
Use `public_name` to install public binary

### DIFF
--- a/dune
+++ b/dune
@@ -17,11 +17,6 @@
  (action (run %{gen} -out %{target} -in %{deps})))
 
 (rule
- (target vpnkit.exe)
- (deps src/bin/main.exe)
- (action (copy %{deps} %{target})))
-
-(rule
  (target vpnkit.tgz)
  (deps    vpnkit.exe (:gen ./scripts/mac_package.exe))
  (action  (run %{gen} -out %{target} -in %{deps})))

--- a/src/bin/dune
+++ b/src/bin/dune
@@ -1,5 +1,6 @@
 (executable
  (name main)
+ (public_name vpnkit)
  (libraries cmdliner ofs logs.fmt hostnet hvsock hvsock.lwt
    fd-send-recv duration mirage-clock-unix mirage-random
    fs9p mirage-random-stdlib)
@@ -21,9 +22,3 @@
   (chdir
    %{workspace_root}
    (run make src/bin/version.ml))))
-
-(install
- (section bin)
- (package vpnkit)
- (files
-  (main.exe as vpnkit)))


### PR DESCRIPTION
The dune files build `main` and then rename it to `vpnkit` and install it. This what `public_name` does, thus this PR removes the copy logic and the install customization and adds a `public_name` stanza instead.