### PR TITLE
Ignore large build folders in Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 Dockerfile*
+/_opam/
+/_build/


### PR DESCRIPTION
On my system `docker build` uploads about 2GB of data from Dune's `_build` and OPAM's `_opam` folder which takes a long time and isn't needed as the Docker image builds the code from scratch. These folders typically contain all dependencies and compilers so they can get pretty big.

This PR excludes them so it only takes a few seconds to start building the container.

cc @djs55