### PR TITLE
ci: declare contents: read on tests-in-docker workflow

### DIFF
--- a/.github/workflows/tests-in-docker.yml
+++ b/.github/workflows/tests-in-docker.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Single-job workflow that does `actions/checkout` then `docker build --file Dockerfile.test` to run integration tests in a container. No git push, no GitHub API write.

`bin-image.yml` in this repo already declares workflow-level `permissions: contents: read`; this brings `tests-in-docker.yml` in line.