### PR TITLE
Fix library name of oUnit

### DIFF
--- a/src/dns_test/dune
+++ b/src/dns_test/dune
@@ -1,6 +1,6 @@
 (test
   (name       test)
-  (libraries  dns oUnit pcap-format bigarray bigarray-compat lwt)
+  (libraries  dns ounit2 pcap-format bigarray bigarray-compat lwt)
   (deps       (glob_files *.pcap) (glob_files *.zone))
   (preprocess (pps ppx_cstruct)))
 


### PR DESCRIPTION
When [running tests](https://github.com/tarides/moby-vpnkit/actions/runs/26166909233/job/76973483427) the tests fail because of the fact that some reshuffling happened in OUnit and the library name changed:

```
  + dune runtest
  File "src/dns_test/dune", line 3, characters 18-23:
  3 |   (libraries  dns oUnit pcap-format bigarray bigarray-compat lwt)
                        ^^^^^
  Error: Library "oUnit" not found.
  -> required by _build/default/src/dns_test/test.exe
  -> required by alias src/dns_test/runtest in src/dns_test/dune:7
```

This PR updates it to use `ounit2` which seems to pass the tests (with no changes to the dependency definitions).