### PR TITLE
Register dependency on `vpnkit` accurately

### DIFF
--- a/dune
+++ b/dune
@@ -10,7 +10,7 @@
 
 (rule
  (target vpnkit.tgz)
- (deps    vpnkit.exe (:gen ./scripts/mac_package.exe))
+ (deps    %{bin:vpnkit} (:gen ./scripts/mac_package.exe))
  (action  (run %{gen} -out %{target} -in %{deps})))
 
 (rule


### PR DESCRIPTION
Since #660 was merged by @djs55 we can depend on `vpnkit` no matter where in the tree it is and without the somewhat odd `.exe` prefix.