### PR TITLE
Simplify Makefile by moving OCaml build instructions to Dune

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,18 @@
 build: vpnkit.exe
 
+.PHONY: vpnkit.exe
 vpnkit.exe:
 	opam exec -- dune build --profile release
 
+.PHONY: ocaml
 ocaml:
 	ocaml -version || opam init --compiler=4.14.0
 	opam pin add vpnkit . -n
 
+.PHONY: depends
 depends:
 	opam install --deps-only -t vpnkit
 
+.PHONY: test
 test:
 	opam exec -- dune build @runtest @e2e

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,4 @@ depends:
 	opam install --deps-only -t vpnkit
 
 test:
-	opam exec -- dune test
-	opam exec -- dune build @e2e
-
-%: %.in
-	@echo "  GEN     " $@
-	@sed -e "s/@COMMIT@/$$(git rev-parse HEAD)/" $< >$@.tmp
-	@mv $@.tmp $@
+	opam exec -- dune build @runtest @e2e

--- a/src/bin/dune
+++ b/src/bin/dune
@@ -16,9 +16,7 @@
   (run config/discover.exe -ocamlc "\%{OCAMLC}")))
 
 (rule
- (targets version.ml)
- (deps version.ml.in ../../Makefile)
- (action
-  (chdir
-   %{workspace_root}
-   (run make src/bin/version.ml))))
+  (target version.ml)
+  (action
+    (with-stdout-to %{target}
+                    (system "git rev-parse HEAD | xargs printf 'let git = \"%s\"'"))))

--- a/src/bin/version.ml.in
+++ b/src/bin/version.ml.in
@@ -1,1 +1,0 @@
-let git = "@COMMIT@"


### PR DESCRIPTION
Different approaches to this are possible, e.g. taking the `sed` call and putting it into the `dune` file but for simplicity I thought it would be easiest to just generate the 1-line file directly as the `@@COMMIT@@` bit is only used once and the `.in` rule only existed for one file.

Somewhat annoyingly this still requires shell tools, but at least there's no `make build` -> `dune` -> `make` chain anymore and we can avoid a build-time dependency on `sed` and `make`.

Also cleans up the `Makefile` by making sure the targets are marked as `PHONY`, thus `touch test && make test` does not break the `test` target.

cc @djs55