### PR TITLE
Remove detour through scratch image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,5 @@ RUN opam depext vpnkit -y
 
 RUN opam install vpnkit -y
 
-FROM scratch AS binary
-COPY --from=build /home/opam/.opam/4.14/bin/vpnkit /vpnkit
-
 FROM alpine:latest
-COPY --from=binary /vpnkit /vpnkit
+COPY --from=build /home/opam/.opam/4.14/bin/vpnkit /vpnkit


### PR DESCRIPTION
While testing by running `docker build` to make sure things continue to work I noticed that the code is built on an older Alpine Linux version, then put in a `scratch` image and then immediately pulled out into the latest Alpine Linux image.

There didn't seem to be much point in doing that unless the `binary` layer is used somehow else by e.g exporting the layer but I haven't seen any place where this might happen. So I tried to removed that indirection. It continues to work fine and saves a few seconds in building and a small bit of storage.

cc @djs55.