### PR TITLE
Move non-OCaml rules out of Dune file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,9 @@ _opam/
 *~
 COMMIT
 OSS-LICENSES
-vpnkit.exe
 vpnkit.tgz
 opam/licenses/dependency.slirp
 src/hostnet_test/_tests/
 .merlin
+deps.csv
+licenses.json

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,21 @@ depends:
 .PHONY: test
 test:
 	opam exec -- dune build @runtest @e2e
+
+deps.csv:
+	opam list \
+		--installed \
+		--required-by=vpnkit \
+		--recursive \
+		--columns name,package,license: \
+		--separator=, \
+		--nobuild \
+		--color=never \
+		> $@
+
+licenses.json: deps.csv
+	opam exec -- dune exec ./scripts/licenses.exe -- -out $@ -in $?
+
+vpnkit.tgz:
+	opam exec -- dune build --profile release @install
+	opam exec -- dune exec ./scripts/mac_package.exe -- -out $@ -in _build/install/default/bin/vpnkit

--- a/dune
+++ b/dune
@@ -1,19 +1,4 @@
 (rule
- (target deps.csv)
- (deps vpnkit.opam)
- (action (with-outputs-to %{target} (run opam list --installed --required-by=vpnkit --recursive --columns name,package,license: --separator=, --nobuild --color=never))))
-
-(rule
- (target licenses.json)
- (deps deps.csv (:gen ./scripts/licenses.exe))
- (action (run %{gen} -out %{target} -in %{deps})))
-
-(rule
- (target vpnkit.tgz)
- (deps    %{bin:vpnkit} (:gen ./scripts/mac_package.exe))
- (action  (run %{gen} -out %{target} -in %{deps})))
-
-(rule
  (alias e2e)
  (deps src/hostnet_test/main.exe
    go/test_inputs/open_dedicated_connection.bin


### PR DESCRIPTION
This PR moves rules that are not building OCaml code out of the `dune` file.

The main reason to do this is due to Dune's default build target is `@all`. Running `dune build` is running all targets in the `dune` file - this means that running `dune build` it will create `deps.csv` and `licenses.json` and `vpnkit.tgz` (realistically it will fail, because the licenses script has a hardcoded mapping of versions to licenses and OPAM currently installs other versions).

The other issue is that Dune targets will be created in `_build/default/...` and not in the source tree (where one would expect `make vpnkit.tgz` to appear), thus users might think that nothing at all has happened.

The existing `.gitignore` file for example assumes that `vpnkit.tgz` is created in the source tree, which wasn't the case before but is the case now. I assume some previous build configuration created the tarballs in this place and a Dune port changed this.

The advantage of moving the targets into the Makefile is that `dune build` does not depend on `opam` anymore (for creating `deps.csv`) yet these files still can get created and do get created in the location the caller would expect them to. Crucially, this also allows `setup-dune` to build the project as it doesn't have a dependency on `opam`. At the moment building with `setup-dune` fails as it calls `dune build` which is equivalent to `dune build @all` which then attempts to  build the `deps.json` file using `opam`. My idea of customizing the target for setup-dune has been mostly rejected: https://github.com/ocaml-dune/setup-dune/issues/31

An alternative solution is to reconfigure the default target to be `@install` but this is confusing for users expecting the default behavior of `dune build` and requires users that wish to have `deps.csv`, `licenses.json` or `vpnkit.tgz`  to fish out the generated targets out of `_build/default/...`. Thus I believe the suggestion in this PR is the better solution.

cc @djs55