### PR TITLE
Update to newer Docker base image to have access to newer software versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM ocaml/opam:alpine-3.19-ocaml-4.14 AS build
-RUN opam update
+FROM ocaml/opam:alpine-3.23-ocaml-4.14 AS build
+RUN sudo ln -sf /usr/bin/opam-2.5 /usr/bin/opam && \
+  opam init --reinit -ni
+RUN opam repo add archive git+https://github.com/ocaml/opam-repository-archive --all
 
 ADD . /home/opam/vpnkit
 RUN opam pin add vpnkit /home/opam/vpnkit --kind=path -n
-RUN opam depext vpnkit -y
-
 RUN opam install vpnkit -y
 
 FROM alpine:latest

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,18 +1,17 @@
-FROM ocaml/opam:alpine-3.19-ocaml-4.14 AS build
-RUN opam update
+FROM ocaml/opam:alpine-3.23-ocaml-4.14 AS build
+RUN sudo ln -sf /usr/bin/opam-2.5 /usr/bin/opam && \
+  opam init --reinit -ni
+RUN opam repo add archive git+https://github.com/ocaml/opam-repository-archive --all
 
 ADD . /home/opam/vpnkit
 RUN sudo chown opam:opam -R vpnkit
 WORKDIR /home/opam/vpnkit
 RUN opam pin add vpnkit /home/opam/vpnkit --kind=path -n
-RUN opam depext vpnkit -y
 
 RUN opam install vpnkit -y -t
 
-# unit tests
-RUN opam exec -- dune runtest
-# integration tests
-RUN opam exec -- dune build @e2e
+# unit tests & integration tests
+RUN opam exec -- dune build @runtest @e2e
 
 # we're not interested in the intermediate artifacts
 FROM scratch


### PR DESCRIPTION
The Dockerfile used `opam:alpine-3.19-ocaml` as a build image, which was created before the opam-repo archival and the `opam update` didn't do anything as it would only consult the local checkout of opam-repository (`/home/opam/opam-repository`), which did not update anything.

This means that e.g. the archived versions of packages are still available and packages are stuck at old versions (e.g. Dune 3.16 released in June 2024).

This PR 

  * updates the image to a newer version of Alpine Linux (3.19 is EOL and while it can be made work, might as well switch to a currently supported version since the only change required is the version in the `FROM` line)
  * Uses opam 2.5, since the image supports it, might as well. This incorporates `depext` directly, so the separate call was removed
  * Adds the archive repo to include the archived versions of the dependencies
  * Updates both the regular `Dockerfile` which generates an executable as well as the `Dockerfile.test` which generates a build log. The build log now contains both unit and E2E test results as we're running `dune build` only once (`dune build` creates a new `_build/log` on every run, so `dune build @e2e` would overwrite the log of `dune runtest`).

This should make the setup in the Docker container a bit more futureproof with never versions of software as well as being closer to the set up people need to develop locally (especially the archive repository).

cc @djs55