### PR TITLE
Update discovery to optionally allow dynamic builds

### DIFF
--- a/src/bin/config/discover.ml
+++ b/src/bin/config/discover.ml
@@ -8,10 +8,18 @@ let os_type () =
     line
   | x -> x
 
+let static_build () =
+  (* if DYNAMIC is set (to anything) its not a static build *)
+  match Unix.getenv "DYNAMIC" with
+  | _ -> false
+  | exception Not_found -> true
+
 let flags () =
   match os_type () with
-  | "Linux" ->
-    [ "-ccopt"; "-static" ]
+  | "Linux" -> (
+    match static_build () with
+    | true -> [ "-ccopt"; "-static" ]
+    | false -> [])
   | _ ->
     []
 

--- a/src/bin/dune
+++ b/src/bin/dune
@@ -9,11 +9,17 @@
   (:include flags.sexp))
  (preprocess no_preprocessing))
 
+(env
+  (dynamic
+    ;; set DYNAMIC to some value when building in dynamic profile
+    (env-vars
+      (DYNAMIC 1))))
+
 (rule
  (targets flags.sexp)
- (deps config/discover.exe)
+ (deps (env_var DYNAMIC))
  (action
-  (run config/discover.exe -ocamlc "\%{OCAMLC}")))
+  (run config/discover.exe)))
 
 (rule
   (target version.ml)


### PR DESCRIPTION
This is a small clean-up of the `discover.exe` mechanism which generates build flags.

  - Adds a new Dune profile `dynamic` which disables the `-ccopt static`. This makes it easier to build on platforms without a static configuration (my Fedora Linux complains that there's no static `-lm` for example but is plenty happy to build a dynamic executable). The default is still to build a static executable, so nothing changes unless the user specifically requests `--profile dynamic` from Dune.
  - Removes the `OCAMLC` variable. The program didn't use it.

cc @djs55