### PR TITLE
Update set-up instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ocaml/opam:alpine-3.23-ocaml-4.14 AS build
 RUN sudo ln -sf /usr/bin/opam-2.5 /usr/bin/opam && \
   opam init --reinit -ni
-RUN opam repo add archive git+https://github.com/ocaml/opam-repository-archive --all
+RUN opam repo add archive-without-constraint git+https://github.com/tarides/moby-vpnkit-opam-repository-archive#remove-dune-upper-constraint --all
 
 ADD . /home/opam/vpnkit
 RUN opam pin add vpnkit /home/opam/vpnkit --kind=path -n

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,17 @@ build: vpnkit.exe
 
 .PHONY: vpnkit.exe
 vpnkit.exe:
-	opam exec -- dune build --profile release
+	opam exec -- dune build --profile release @install
 
 .PHONY: ocaml
 ocaml:
-	ocaml -version || opam init --compiler=4.14.0
-	opam pin add vpnkit . -n
+	opam switch create ./ ocaml-base-compiler.4.14.3 --no-install
+	opam repo add archive git+https://github.com/ocaml/opam-repository-archive
+	opam pin add vpnkit . --kind=path --no-action
 
 .PHONY: depends
 depends:
-	opam install --deps-only -t vpnkit
+	opam install vpnkit --deps-only --with-test
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ vpnkit.exe:
 .PHONY: ocaml
 ocaml:
 	opam switch create ./ ocaml-base-compiler.4.14.3 --no-install
-	opam repo add archive git+https://github.com/ocaml/opam-repository-archive
+	opam repo add archive-without-constraint git+https://github.com/tarides/moby-vpnkit-opam-repository-archive#remove-dune-upper-constraint
 	opam pin add vpnkit . --kind=path --no-action
 
 .PHONY: depends

--- a/README.md
+++ b/README.md
@@ -20,12 +20,9 @@ Building on Unix (including Mac)
 First install `wget`, `opam`, `pkg-config`, and `dylibbundler` using your
 package manager of choice.
 
-If you are an existing `opam` user then you can either build against your existing `opam`
-package universe, or the custom universe contained in this repo. To use the custom universe,
-ensure that you unset your `OPAMROOT` environment variable:
-```
-unset OPAMROOT
-```
+If you are an existing `opam` user then you can either build against your
+existing `opam` package universe, or the custom universe contained in this
+repo.
 
 To set up the OCaml build environment, type:
 ```
@@ -40,7 +37,16 @@ To build:
 make
 ```
 
-When the build succeeds the `vpnkit.exe` binary should be available in the current directory.
+When the build succeeds the `vpnkit` binary should be available in
+`_build/install/default/bin/vpnkit`.
+
+Alternatively you can run it with Dune:
+
+```
+dune exec vpnkit
+```
+
+which will automatically build and execute `vpnkit`.
 
 Building on Windows
 -------------------

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 2.0)
+(lang dune 3.23)
 (name vpnkit)

--- a/dune-workspace
+++ b/dune-workspace
@@ -1,4 +1,4 @@
-(lang dune 3.19)
+(lang dune 3.23)
 
 (repository
  (name archive-without-constraint)
@@ -6,3 +6,5 @@
 
 (lock_dir
  (repositories upstream overlay archive-without-constraint))
+
+(pkg disabled)

--- a/vpnkit.opam
+++ b/vpnkit.opam
@@ -25,7 +25,7 @@ build: [
 
 depends: [
   "ocaml" {>="4.08.0"}
-  "dune" {>= "3.19"}
+  "dune" {>= "3.23"}
   "alcotest" {with-test}
   "ounit" {with-test}
   "tar" {>= "1.0.1"}


### PR DESCRIPTION
This PR updates the Makefile instructions to use a local opam switch (and updates the compiler to the most recent 4.14 version).

- No need to deal with `OPAMROOT` anymore
- Added the archive repository, so creating an opam switch will find a solution that compiles
- Updated the instructions in the README

Closes #652

cc @djs55