### PR TITLE
Add instructions for usage with Dune package management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-VPN-friendly networking devices for [HyperKit](https://github.com/moby/hyperkit)
-===============================
+# VPN-friendly networking devices for [HyperKit](https://github.com/moby/hyperkit)
 
 [![Build Status (OSX)](https://circleci.com/gh/moby/vpnkit.png)](https://circleci.com/gh/moby/vpnkit)
 
@@ -14,11 +13,12 @@ VPNKit is a set of tools and services for helping [HyperKit](https://github.com/
 VMs interoperate with host VPN configurations.
 
 
-Building on Unix (including Mac)
---------------------------------
+## Building on Unix (including Mac)
 
 First install `wget`, `opam`, `pkg-config`, and `dylibbundler` using your
 package manager of choice.
+
+### Building with opam
 
 If you are an existing `opam` user then you can either build against your
 existing `opam` package universe, or the custom universe contained in this
@@ -40,16 +40,29 @@ make
 When the build succeeds the `vpnkit` binary should be available in
 `_build/install/default/bin/vpnkit`.
 
-Alternatively you can run it with Dune:
+### Building with Dune
+
+Alternatively you can use Dune package management to download and install the
+dependencies automatically:
 
 ```
-dune exec vpnkit
+dune build --pkg=enabled
 ```
 
-which will automatically build and execute `vpnkit`.
+When the build succeeds the `vpnkit` binary should be available in
+`_build/install/default/bin/vpnkit`.
 
-Building on Windows
--------------------
+You can also automatically build and execute the `vpnkit` binary:
+
+```
+dune exec --pkg=enabled vpnkit
+```
+
+If you want to enable Dune package management by default (and avoid having to
+specify `--pkg=enabled`) you can edit the `dune-workspace` and remove the `(pkg
+disabled)` line.
+
+## Building on Windows
 
 First install the [OCaml environment with Cygwin](https://fdopen.github.io/opam-repository-mingw/installation/).
 Note that although the Cygwin tools are needed for the build scripts, Cygwin itself will not
@@ -65,8 +78,7 @@ The first build will take a little longer as it will build all the package depen
 
 When the build succeeds the `vpnkit.exe` binary should be available in the current directory.
 
-Running with hyperkit
----------------------
+## Running with hyperkit
 
 First ask `vpnkit` to listen for ethernet connections on a local Unix domain socket:
 ```
@@ -76,8 +88,7 @@ Next ask [com.docker.hyperkit](https://github.com/moby/hyperkit) to connect a NI
 socket by adding a command-line option like `-s 2:0,virtio-vpnkit,path=/tmp/ethernet`. Note:
 you may need to change the slot `2:0` to a free slot in your VM configuration.
 
-Why is this needed?
--------------------
+## Why is this needed?
 
 Running a VM usually involves modifying the network configuration on the host, for example
 by activating Ethernet bridges, new routing table entries, DNS and firewall/NAT configurations.
@@ -94,16 +105,14 @@ VPNKit operates by reconstructing Ethernet traffic from the VM and translating i
 relevant socket API calls on OSX or Windows. This allows the host application to generate
 traffic without requiring low-level Ethernet bridging support.
 
-Design
-------
+## Design
 
 - [Using vpnkit as a default gateway](docs/ethernet.md): describes the flow of ethernet traffic to/from the VM
 - [Port forwarding](docs/ports.md): describes how ports are forwarded from the host into the VM
 - [Experimental transparent HTTP proxy](docs/transparent-http-proxy.md): describes the
   experimental support for transparent HTTP(S) proxying
 
-Licensing
----------
+## Licensing
 
 VPNKit is licensed under the Apache License, Version 2.0. See
 [LICENSE](https://github.com/moby/vpnkit/blob/master/LICENSE) for the full

--- a/dune.lock/alcotest.1.5.0.pkg
+++ b/dune.lock/alcotest.1.5.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/alcotest/releases/download/1.5.0/alcotest-js-1.5.0.tbz)
   (checksum
-   sha256=54281907e02d78995df246dc2e10ed182828294ad2059347a1e3a13354848f6c)))
+   sha512=1aea91de40795ec4f6603d510107e4b663c1a94bd223f162ad231316d8595e9e098cabbe28a46bdcb588942f3d103d8377373d533bcc7413ba3868a577469b45)))

--- a/dune.lock/angstrom.0.16.1.pkg
+++ b/dune.lock/angstrom.0.16.1.pkg
@@ -14,4 +14,5 @@
 (source
  (fetch
   (url https://github.com/inhabitedtype/angstrom/archive/0.16.1.tar.gz)
-  (checksum md5=a9e096b4b2b8e4e3bb17d472bbccaad0)))
+  (checksum
+   sha256=143536fb4d049574c539b9990840615e078ed3dd94e1d24888293f68349a100b)))

--- a/dune.lock/arp.3.1.1.pkg
+++ b/dune.lock/arp.3.1.1.pkg
@@ -25,4 +25,4 @@
  (fetch
   (url https://github.com/mirage/arp/releases/download/v3.1.1/arp-3.1.1.tbz)
   (checksum
-   sha256=ea33c589e9deea300fb62bc2ba0b557cfdfeea4f40e600685b3a68c6868f06f1)))
+   sha512=5824ea057094d6035cac4235f0dd984af9d56fb9ec9aa621af3bc24674c97df328cd77efb749743f295f94c040e39d9b1caf68a13253393685dfae02fce6e869)))

--- a/dune.lock/base.v0.14.4.pkg
+++ b/dune.lock/base.v0.14.4.pkg
@@ -10,4 +10,5 @@
 (source
  (fetch
   (url https://github.com/janestreet/base/archive/refs/tags/v0.14.4.tar.gz)
-  (checksum md5=89c571906217b5513682123b74327522)))
+  (checksum
+   sha512=d8fdc0de663797b73b65f1753e4e46f3de58dc63a9bbac10d128f84a208da16d231500906796dbc1ac6d6566f4eb4007ff7c02200b4617cc8dd475c10446cdb6)))

--- a/dune.lock/base64.3.5.2.pkg
+++ b/dune.lock/base64.3.5.2.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/ocaml-base64/releases/download/v3.5.2/base64-3.5.2.tbz)
   (checksum
-   sha256=b3f5ce301aa72c7032ef90be2332d72ff3962922c00ee2aec6bcade187a2f59b)))
+   sha512=82148a1fefec9493aaeac032c8d46b9548369d7fd90a57865e009a32c8a0eef950f0f8dbb52b74bb46880a590a0b49f2daa7ab4857233734aee8e383f5a164ec)))

--- a/dune.lock/bigarray-compat.1.1.0.pkg
+++ b/dune.lock/bigarray-compat.1.1.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/bigarray-compat/releases/download/v1.1.0/bigarray-compat-1.1.0.tbz)
   (checksum
-   sha256=434469a48d5c84e80d621b13d95eb067f8138c1650a1fd5ae6009a19b93718d5)))
+   sha512=7be283fd957ee168ce1e62835d22114da405e4b7da9619b4f2030a832d45ca210a0c8f1d1c57c92e224f3512308a8a0f0923b94f44b6f582acbe0e7728d179d4)))

--- a/dune.lock/camlp-streams.5.0.1.pkg
+++ b/dune.lock/camlp-streams.5.0.1.pkg
@@ -14,4 +14,5 @@
 (source
  (fetch
   (url https://github.com/ocaml/camlp-streams/archive/v5.0.1.tar.gz)
-  (checksum md5=afc874b25f7a1f13e8f5cfc1182b51a7)))
+  (checksum
+   sha512=2efa8dd4a636217c8d49bac1e4e7e5558fc2f45cfea66514140a59fd99dd08d61fb9f1e17804997ff648b71b13820a5d4a1eb70fed9d848aa2abd6e41f853c86)))

--- a/dune.lock/charrua-client.1.5.0.pkg
+++ b/dune.lock/charrua-client.1.5.0.pkg
@@ -32,4 +32,4 @@
   (url
    https://github.com/mirage/charrua/releases/download/v1.5.0/charrua-v1.5.0.tbz)
   (checksum
-   sha256=4ce74a5e78402f3d645ddcb344aaa1348349a8d5a35b8b55112aff0cb84db8e1)))
+   sha512=ac6960de516642793b928224c95da997042d2907829496843481894b38804e3b465b5f9703bd8c02e5202059847ee5c16db6975c630b462448db511b39f34f87)))

--- a/dune.lock/charrua-server.1.5.0.pkg
+++ b/dune.lock/charrua-server.1.5.0.pkg
@@ -26,4 +26,4 @@
   (url
    https://github.com/mirage/charrua/releases/download/v1.5.0/charrua-v1.5.0.tbz)
   (checksum
-   sha256=4ce74a5e78402f3d645ddcb344aaa1348349a8d5a35b8b55112aff0cb84db8e1)))
+   sha512=ac6960de516642793b928224c95da997042d2907829496843481894b38804e3b465b5f9703bd8c02e5202059847ee5c16db6975c630b462448db511b39f34f87)))

--- a/dune.lock/charrua.1.5.0.pkg
+++ b/dune.lock/charrua.1.5.0.pkg
@@ -27,4 +27,4 @@
   (url
    https://github.com/mirage/charrua/releases/download/v1.5.0/charrua-v1.5.0.tbz)
   (checksum
-   sha256=4ce74a5e78402f3d645ddcb344aaa1348349a8d5a35b8b55112aff0cb84db8e1)))
+   sha512=ac6960de516642793b928224c95da997042d2907829496843481894b38804e3b465b5f9703bd8c02e5202059847ee5c16db6975c630b462448db511b39f34f87)))

--- a/dune.lock/cohttp-lwt.5.3.0.pkg
+++ b/dune.lock/cohttp-lwt.5.3.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/ocaml-cohttp/releases/download/v5.3.0/cohttp-5.3.0.tbz)
   (checksum
-   sha256=b3bd91c704e5ea510e924b83ab2ede1fc46a2cce448b0f8cef4883b9a16eeddd)))
+   sha512=529930d9b1f38737d91f47cb94f8bae381df87ea941cb8e75ee798354763bdf5091f4f3be31d0ba14b9944dc68203a3d98e235c38c66e7e176a114be9ff4acf3)))

--- a/dune.lock/cohttp.5.3.1.pkg
+++ b/dune.lock/cohttp.5.3.1.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/ocaml-cohttp/releases/download/v5.3.1/cohttp-5.3.1.tbz)
   (checksum
-   sha256=f5e273d3c2f29ff47bd7e16db23e1f3d6cd01a40be00208985bc434c88d4576b)))
+   sha512=26580405fc33cd7e05b2c91732df97da9ba609d7392e5779be601aa65e34f1991d2b0ae2870ac29e57567f583dc0e13e61d3c4a74c7ac21012453acb33a37ae3)))

--- a/dune.lock/conf-pkg-config.4.pkg
+++ b/dune.lock/conf-pkg-config.4.pkg
@@ -15,19 +15,11 @@
    ((action
      (progn
       (when
-       (and_absorb_undefined_var
-        true
-        (not
-         (and_absorb_undefined_var
-          true
-          (= %{os_distribution} homebrew))))
+       (not
+        (= %{os_distribution} homebrew))
        (run pkg-config --help))
       (when
-       (or_absorb_undefined_var
-        false
-        (and_absorb_undefined_var
-         true
-         (= %{os_distribution} homebrew)))
+       (= %{os_distribution} homebrew)
        (run pkgconf --version))))))))
 
 (depexts

--- a/dune.lock/cppo.1.8.0.pkg
+++ b/dune.lock/cppo.1.8.0.pkg
@@ -14,4 +14,5 @@
 (source
  (fetch
   (url https://github.com/ocaml-community/cppo/archive/v1.8.0.tar.gz)
-  (checksum md5=a197cb393b84f6b30e0ff55080ac429b)))
+  (checksum
+   sha512=3840725b767a0300bdc48f11d26d798bdcae0a764ed6798df3a08dfc8cc76fe124b14a19d47c9b5ea8e229d68b0311510afce77c0e4d9131fbda5116dc2689a2)))

--- a/dune.lock/csexp.1.5.2.pkg
+++ b/dune.lock/csexp.1.5.2.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/ocaml-dune/csexp/releases/download/1.5.2/csexp-1.5.2.tbz)
   (checksum
-   sha256=1a14dd04bb4379a41990248550628c77913a9c07f3c35c1370b6960e697787ff)))
+   sha512=be281018bcfc20d4db14894ef51c4b836d6338d2fdfe22e63d46f405f8dea7349e16f1c0ecd65f73d4c85a2a80e618cdbb8c9dafcbb9f229f04f1adca5b1973c)))

--- a/dune.lock/cstruct-lwt.6.0.1.pkg
+++ b/dune.lock/cstruct-lwt.6.0.1.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/ocaml-cstruct/releases/download/v6.0.1/cstruct-v6.0.1.tbz)
   (checksum
-   sha256=4a67bb8f042753453c59eabf0e47865631253ba694091ce6062aac05d47a9bed)))
+   sha512=3eeeb6ae0fd3b625cf1d308498f0a1e6951d16566561f3362fdf74e7158d92d8f6c6d9fa968ff15f8c19a1886dce99d0ef17b44dbb37b97cc68c9b088fdc2248)))

--- a/dune.lock/cstruct-sexp.6.0.1.pkg
+++ b/dune.lock/cstruct-sexp.6.0.1.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/ocaml-cstruct/releases/download/v6.0.1/cstruct-v6.0.1.tbz)
   (checksum
-   sha256=4a67bb8f042753453c59eabf0e47865631253ba694091ce6062aac05d47a9bed)))
+   sha512=3eeeb6ae0fd3b625cf1d308498f0a1e6951d16566561f3362fdf74e7158d92d8f6c6d9fa968ff15f8c19a1886dce99d0ef17b44dbb37b97cc68c9b088fdc2248)))

--- a/dune.lock/cstruct.6.0.1.pkg
+++ b/dune.lock/cstruct.6.0.1.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/ocaml-cstruct/releases/download/v6.0.1/cstruct-v6.0.1.tbz)
   (checksum
-   sha256=4a67bb8f042753453c59eabf0e47865631253ba694091ce6062aac05d47a9bed)))
+   sha512=3eeeb6ae0fd3b625cf1d308498f0a1e6951d16566561f3362fdf74e7158d92d8f6c6d9fa968ff15f8c19a1886dce99d0ef17b44dbb37b97cc68c9b088fdc2248)))

--- a/dune.lock/domain-name.0.5.0.pkg
+++ b/dune.lock/domain-name.0.5.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/hannesm/domain-name/releases/download/v0.5.0/domain-name-0.5.0.tbz)
   (checksum
-   sha256=9ec7ae2c22772c150b84cfa3f21d9bf25fae14a796f31e20df52d86f46499d89)))
+   sha512=923acab434ebb197f44075711030fd1b7f61783e20cc6f74387ce0acf1bc5f48eb8a8a5e29d3440e7c249ab00673e250ddfdc7e53d71c5a1613f1dbb557c0ae1)))

--- a/dune.lock/dune-configurator.3.23.1.pkg
+++ b/dune.lock/dune-configurator.3.23.1.pkg
@@ -1,4 +1,4 @@
-(version 3.22.2)
+(version 3.23.1)
 
 (build
  (all_platforms
@@ -14,6 +14,6 @@
 (source
  (fetch
   (url
-   https://github.com/ocaml/dune/releases/download/3.22.2/dune-3.22.2.tbz)
+   https://github.com/ocaml/dune/releases/download/3.23.1/dune-3.23.1.tbz)
   (checksum
-   sha256=c2ccf8bc6b17afa47c450297357496303aa7c8680e329b79d98c68e35013a118)))
+   sha512=e5566bedc651292ae54d47ba1cdbcfff48962012c1436d0f9ece49a71aa10a674affc092058b0edee56ab2a2405c545b78fde1c472c0b4704c8f58570a2f46cd)))

--- a/dune.lock/duration.0.2.1.pkg
+++ b/dune.lock/duration.0.2.1.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/hannesm/duration/releases/download/v0.2.1/duration-0.2.1.tbz)
   (checksum
-   sha256=c738c1f38cfb99820c121cd3ddf819de4b2228f0d50eacbd1cc3ce99e7c71e2b)))
+   sha512=0de9e15c7d6188872ddd9994f08616c4a1822e4ac92724efa2c312fbb2fc44cd7cbe4b36bcf66a8451d510c1fc95de481760afbcacb8f83e183262595dcf5f0c)))

--- a/dune.lock/ethernet.3.0.0.pkg
+++ b/dune.lock/ethernet.3.0.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/ethernet/releases/download/v3.0.0/ethernet-v3.0.0.tbz)
   (checksum
-   sha256=e95974f6363bd21e995a1c72ca03d09674c32ed2fbffada5aa82f096ee460929)))
+   sha512=171d061b16f2e00b9caa3dfc1cd9b5b358d380e892281ac5c137dc2a3119c3fa288ea927dcb4e9efbcf4850f6857ed0d4b754f56dbb248c1c6150779e57d24e4)))

--- a/dune.lock/ezjsonm.1.3.0.pkg
+++ b/dune.lock/ezjsonm.1.3.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/ezjsonm/releases/download/v1.3.0/ezjsonm-1.3.0.tbz)
   (checksum
-   sha256=08633e0f0e767a8ae81935ca7e74f1693b85a79c4502d568eedff5170f0cd77b)))
+   sha512=b731036384115603af9187464695418d27b7cf6f763c8dbc0812db62a7657cac1b6019d3b205b1c95ae81b7dab0bd4037390d977ee8c122bef29a9ddef771e18)))

--- a/dune.lock/fd-send-recv.2.0.3.pkg
+++ b/dune.lock/fd-send-recv.2.0.3.pkg
@@ -12,4 +12,4 @@
   (url
    https://github.com/xapi-project/ocaml-fd-send-recv/releases/download/v2.0.3/fd-send-recv-2.0.3.tbz)
   (checksum
-   sha256=34970f254a14885daaabb98f5410160530aa6e994747ad1eab99ec4f61dc9934)))
+   sha512=c50d836212d9b0e05ffa9fe83dc208929b7aab3c88340f0d7ea7a13bec802bdb15d4279c9dc146bb0b6b59d9baf7db7802d57cd35f3ecda6c2ee053c6b3c69c7)))

--- a/dune.lock/functoria-runtime.3.1.2.pkg
+++ b/dune.lock/functoria-runtime.3.1.2.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/functoria/releases/download/v3.1.2/functoria-3.1.2.tbz)
   (checksum
-   sha256=847a5e59afca3874c056f3130f51ca5fe73e24a4f166cb2a30e90967dc7c00fa)))
+   sha512=b25dd0c66bf689b6c850210e1882f4711372a22b6df9c7487c0fb3e0d52c1cbb0160adec4873c94f87022e06322e87e565afebf974d02d1bdfad6b6e6594147c)))

--- a/dune.lock/hex.1.5.0.pkg
+++ b/dune.lock/hex.1.5.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/ocaml-hex/releases/download/v1.5.0/hex-1.5.0.tbz)
   (checksum
-   sha256=2e67eeca1b03049307a30831b5cd694bcb2d3e7f2a6b4fb597fbdb647351b4dc)))
+   sha512=baa09b47a90f0a54ad2becfb272f0674219e4fc0c03559deff26aaf13ccd59258b31bf98e56c44a5a8fa03437e3eba2bf5f0cd76e52d184d26cfb1170c490462)))

--- a/dune.lock/hvsock.3.0.0.pkg
+++ b/dune.lock/hvsock.3.0.0.pkg
@@ -44,4 +44,4 @@
   (url
    https://github.com/mirage/ocaml-hvsock/releases/download/3.0.0/hvsock-3.0.0.tbz)
   (checksum
-   sha256=46d179976f153a7723890ba78fbcfee60e70b3cc9cc3574eb4bb8a682525e4e2)))
+   sha512=f38d53ba07ed77d39c1e92864506ebc7daab0321c8fc2709660c7a55bb43de82af56571d827cbc03443c1b5ccb3a898f6a2163d32d9c5c52b5f4e36507b56969)))

--- a/dune.lock/io-page-unix.2.3.0.pkg
+++ b/dune.lock/io-page-unix.2.3.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/io-page/releases/download/v2.3.0/io-page-v2.3.0.tbz)
   (checksum
-   sha256=9605a8a03e53bc12682212c371bc477f2a44ed829725ae38cc3005e2f83da2c3)))
+   sha512=ce1775bff151d62bb85405a13fe75f912c11b09cbc0a6dd81dd27b3f4c767f0b9c4d3e7383d494eb5c130311482ea69877c45b71b91153177562ffc47de4da2f)))

--- a/dune.lock/io-page.2.3.0.pkg
+++ b/dune.lock/io-page.2.3.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/io-page/releases/download/v2.3.0/io-page-v2.3.0.tbz)
   (checksum
-   sha256=9605a8a03e53bc12682212c371bc477f2a44ed829725ae38cc3005e2f83da2c3)))
+   sha512=ce1775bff151d62bb85405a13fe75f912c11b09cbc0a6dd81dd27b3f4c767f0b9c4d3e7383d494eb5c130311482ea69877c45b71b91153177562ffc47de4da2f)))

--- a/dune.lock/ipaddr-sexp.5.6.0.pkg
+++ b/dune.lock/ipaddr-sexp.5.6.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz)
   (checksum
-   sha256=9e30433fdb4ca437a6aa8ffb447baca5eba7615fb88e7b0cd8a4b416c3208133)))
+   sha512=66a3bedfd91dacd6c1de9ba35abac3ef2ad3c2c8543f7b4e2a0cc6283a8d42138b48d02e904df0232ee9f320920e889bddbbda9a5148c5c6b72fd0164e0c6a34)))

--- a/dune.lock/ipaddr.5.6.0.pkg
+++ b/dune.lock/ipaddr.5.6.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz)
   (checksum
-   sha256=9e30433fdb4ca437a6aa8ffb447baca5eba7615fb88e7b0cd8a4b416c3208133)))
+   sha512=66a3bedfd91dacd6c1de9ba35abac3ef2ad3c2c8543f7b4e2a0cc6283a8d42138b48d02e904df0232ee9f320920e889bddbbda9a5148c5c6b72fd0164e0c6a34)))

--- a/dune.lock/lock.dune
+++ b/dune.lock/lock.dune
@@ -1,6 +1,6 @@
 (lang package 0.1)
 
-(dependency_hash e47ae79ace6670bd5310bc4285f485ae)
+(dependency_hash 0beb7a4d10b274d10397c1f3b97fb4c2)
 
 (ocaml ocaml-base-compiler)
 
@@ -8,7 +8,7 @@
  (complete true)
  (used
   ((source
-    https://github.com/ocaml/opam-repository.git#9d78ee2aeafa6aabaf5c2c6be25f9ab1182af709))
+    https://github.com/ocaml/opam-repository.git#523a31fe2826592f852851d82b1ced7de1db2a98))
   ((source
     https://github.com/ocaml-dune/opam-overlays.git#2a9543286ff0e0656058fee5c0da7abc16b8717d))
   ((source

--- a/dune.lock/logs.0.7.0.pkg
+++ b/dune.lock/logs.0.7.0.pkg
@@ -10,7 +10,7 @@
      --pinned
      %{pkg-self:pinned}
      --with-js_of_ocaml
-     %{pkg:js_of_ocaml:installed}
+     false
      --with-fmt
      %{pkg:fmt:installed}
      --with-cmdliner

--- a/dune.lock/lru.0.3.1.pkg
+++ b/dune.lock/lru.0.3.1.pkg
@@ -15,4 +15,4 @@
  (fetch
   (url https://github.com/pqwy/lru/releases/download/v0.3.1/lru-0.3.1.tbz)
   (checksum
-   sha256=6cbe23d27a7d5b244f869c0b88140d47f70f413a6462ef35c0009325d4b236fd)))
+   sha512=81144e258d6e488d4677ade91132401b6f8871c72aadf2f1c190c4dee918c71c5df10c4e690c5bf1ab0f364d87989d44aec3695310a3477f6473eb17c1261734)))

--- a/dune.lock/lwt-dllist.1.1.0.pkg
+++ b/dune.lock/lwt-dllist.1.1.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/lwt-dllist/releases/download/v1.1.0/lwt-dllist-1.1.0.tbz)
   (checksum
-   sha256=b0200651e37eaa24f027177bc01e266db43da48aa18146973d1d18336c325d69)))
+   sha512=0a34795203d1d6601285b631ac5016beece436ffe49eb2896fdf730913b66b0dc6192fdad6bd3d5cc3ad22a19627a9d6198189597ecd520af44b0b3db5e81f00)))

--- a/dune.lock/lwt.5.9.1.pkg
+++ b/dune.lock/lwt.5.9.1.pkg
@@ -14,7 +14,7 @@
       --
       --save
       --use-libev
-      %{pkg:conf-libev:installed})
+      false)
      (run dune build -p %{pkg-self:name} -j %{jobs} @install))))))
 
 (depends
@@ -24,4 +24,5 @@
 (source
  (fetch
   (url https://github.com/ocsigen/lwt/archive/refs/tags/5.9.1.tar.gz)
-  (checksum md5=18742da8b8fe3618e3fa700b7a884fe7)))
+  (checksum
+   sha512=1c51fdb4d0856c89e2df08a1c0095ef28ebd0f613b07b03d0f66501ca5486515562071291e6d0932e57587ed0c9362c8b92c5c9eddb4d2bb2f5e129986b484a7)))

--- a/dune.lock/macaddr-cstruct.5.6.0.pkg
+++ b/dune.lock/macaddr-cstruct.5.6.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz)
   (checksum
-   sha256=9e30433fdb4ca437a6aa8ffb447baca5eba7615fb88e7b0cd8a4b416c3208133)))
+   sha512=66a3bedfd91dacd6c1de9ba35abac3ef2ad3c2c8543f7b4e2a0cc6283a8d42138b48d02e904df0232ee9f320920e889bddbbda9a5148c5c6b72fd0164e0c6a34)))

--- a/dune.lock/macaddr-sexp.5.6.0.pkg
+++ b/dune.lock/macaddr-sexp.5.6.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz)
   (checksum
-   sha256=9e30433fdb4ca437a6aa8ffb447baca5eba7615fb88e7b0cd8a4b416c3208133)))
+   sha512=66a3bedfd91dacd6c1de9ba35abac3ef2ad3c2c8543f7b4e2a0cc6283a8d42138b48d02e904df0232ee9f320920e889bddbbda9a5148c5c6b72fd0164e0c6a34)))

--- a/dune.lock/macaddr.5.6.0.pkg
+++ b/dune.lock/macaddr.5.6.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz)
   (checksum
-   sha256=9e30433fdb4ca437a6aa8ffb447baca5eba7615fb88e7b0cd8a4b416c3208133)))
+   sha512=66a3bedfd91dacd6c1de9ba35abac3ef2ad3c2c8543f7b4e2a0cc6283a8d42138b48d02e904df0232ee9f320920e889bddbbda9a5148c5c6b72fd0164e0c6a34)))

--- a/dune.lock/menhir.20260209.pkg
+++ b/dune.lock/menhir.20260209.pkg
@@ -11,4 +11,5 @@
  (fetch
   (url
    https://gitlab.inria.fr/fpottier/menhir/-/archive/20260209/archive.tar.gz)
-  (checksum md5=e993231085db95ab011ffe0cd606d9dd)))
+  (checksum
+   sha512=aafad186f328ae8dd4cc69af0f30c1a0b208cf5148a7a94c150099be03838503c5ec12918de26cd7f794b5a72f114bc1bae8d81058bd0ea10372a3b06818687e)))

--- a/dune.lock/menhirCST.20260209.pkg
+++ b/dune.lock/menhirCST.20260209.pkg
@@ -11,4 +11,5 @@
  (fetch
   (url
    https://gitlab.inria.fr/fpottier/menhir/-/archive/20260209/archive.tar.gz)
-  (checksum md5=e993231085db95ab011ffe0cd606d9dd)))
+  (checksum
+   sha512=aafad186f328ae8dd4cc69af0f30c1a0b208cf5148a7a94c150099be03838503c5ec12918de26cd7f794b5a72f114bc1bae8d81058bd0ea10372a3b06818687e)))

--- a/dune.lock/menhirGLR.20260209.pkg
+++ b/dune.lock/menhirGLR.20260209.pkg
@@ -11,4 +11,5 @@
  (fetch
   (url
    https://gitlab.inria.fr/fpottier/menhir/-/archive/20260209/archive.tar.gz)
-  (checksum md5=e993231085db95ab011ffe0cd606d9dd)))
+  (checksum
+   sha512=aafad186f328ae8dd4cc69af0f30c1a0b208cf5148a7a94c150099be03838503c5ec12918de26cd7f794b5a72f114bc1bae8d81058bd0ea10372a3b06818687e)))

--- a/dune.lock/menhirLib.20260209.pkg
+++ b/dune.lock/menhirLib.20260209.pkg
@@ -11,4 +11,5 @@
  (fetch
   (url
    https://gitlab.inria.fr/fpottier/menhir/-/archive/20260209/archive.tar.gz)
-  (checksum md5=e993231085db95ab011ffe0cd606d9dd)))
+  (checksum
+   sha512=aafad186f328ae8dd4cc69af0f30c1a0b208cf5148a7a94c150099be03838503c5ec12918de26cd7f794b5a72f114bc1bae8d81058bd0ea10372a3b06818687e)))

--- a/dune.lock/menhirSdk.20260209.pkg
+++ b/dune.lock/menhirSdk.20260209.pkg
@@ -11,4 +11,5 @@
  (fetch
   (url
    https://gitlab.inria.fr/fpottier/menhir/-/archive/20260209/archive.tar.gz)
-  (checksum md5=e993231085db95ab011ffe0cd606d9dd)))
+  (checksum
+   sha512=aafad186f328ae8dd4cc69af0f30c1a0b208cf5148a7a94c150099be03838503c5ec12918de26cd7f794b5a72f114bc1bae8d81058bd0ea10372a3b06818687e)))

--- a/dune.lock/metrics.0.5.0.pkg
+++ b/dune.lock/metrics.0.5.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/metrics/releases/download/v0.5.0/metrics-0.5.0.tbz)
   (checksum
-   sha256=df356380909d06461bcd097ef6063ca9f3c51365f476a797c03664b53c05715d)))
+   sha512=06e0aef8ba7a09a350cbf7219822c01047afcc9cd2870ca153040e1232d2b8560882ae6823e7797f061fa0b34da750d88365c8817cd025715b2e891320d77c19)))

--- a/dune.lock/mirage-channel.4.1.0.pkg
+++ b/dune.lock/mirage-channel.4.1.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/mirage-channel/releases/download/v4.1.0/mirage-channel-4.1.0.tbz)
   (checksum
-   sha256=b0176851d4ddf5978d7072b420118178e6030ea50b33b1185fe3f3d9fda72100)))
+   sha512=d6e085cc7c61387fa651757704dd0c76d2fee728725e06174ea8a1c47e63b13217d3683094939a3862fe2f23f18f74dfcdbe4577ba0e9e45609c15d1539edd10)))

--- a/dune.lock/mirage-clock-unix.4.2.0.pkg
+++ b/dune.lock/mirage-clock-unix.4.2.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/mirage-clock/releases/download/v4.2.0/mirage-clock-4.2.0.tbz)
   (checksum
-   sha256=fa17d15d5be23c79ba741f5f7cb88ed7112de16a4410cea81c71b98086889847)))
+   sha512=05a359dc8400d4ca200ff255dbd030acd33d2c4acb5020838f772c02cdb5f243f3dbafbc43a8cd51e6b5923a140f84c9e7ea25b2c0fa277bb68b996190d36e3b)))

--- a/dune.lock/mirage-clock.4.2.0.pkg
+++ b/dune.lock/mirage-clock.4.2.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/mirage-clock/releases/download/v4.2.0/mirage-clock-4.2.0.tbz)
   (checksum
-   sha256=fa17d15d5be23c79ba741f5f7cb88ed7112de16a4410cea81c71b98086889847)))
+   sha512=05a359dc8400d4ca200ff255dbd030acd33d2c4acb5020838f772c02cdb5f243f3dbafbc43a8cd51e6b5923a140f84c9e7ea25b2c0fa277bb68b996190d36e3b)))

--- a/dune.lock/mirage-entropy.0.5.1.pkg
+++ b/dune.lock/mirage-entropy.0.5.1.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/mirage-entropy/releases/download/v0.5.1/mirage-entropy-v0.5.1.tbz)
   (checksum
-   sha256=612b2c17f18a56ed5cacc35006be6869016c26668eeaf301fd068b6467755d40)))
+   sha512=194624c9084664b41fbac88c45542a862762e8c0eaec7aa8af2e9fed4b8a5dbaf91303676f279defb4f57eaf74d9e11550d0233a471ef61e0b9f278287ecb031)))

--- a/dune.lock/mirage-flow-combinators.3.0.0.pkg
+++ b/dune.lock/mirage-flow-combinators.3.0.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/mirage-flow/releases/download/v3.0.0/mirage-flow-v3.0.0.tbz)
   (checksum
-   sha256=d70bda6c85ec2747bed88bc4d95f269d2810503b92913f0807be5291696138fc)))
+   sha512=2aeb397799621bc0ea2485b68058949c99b3da8d454939d594a9b2d39ef47aa2c16489f06adfa2dea3b34fd15e60a23abc6b8e214dfbc8b7da2e958de7c36b57)))

--- a/dune.lock/mirage-flow.3.0.0.pkg
+++ b/dune.lock/mirage-flow.3.0.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/mirage-flow/releases/download/v3.0.0/mirage-flow-v3.0.0.tbz)
   (checksum
-   sha256=d70bda6c85ec2747bed88bc4d95f269d2810503b92913f0807be5291696138fc)))
+   sha512=2aeb397799621bc0ea2485b68058949c99b3da8d454939d594a9b2d39ef47aa2c16489f06adfa2dea3b34fd15e60a23abc6b8e214dfbc8b7da2e958de7c36b57)))

--- a/dune.lock/mirage-kv.5.0.0.pkg
+++ b/dune.lock/mirage-kv.5.0.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/mirage-kv/releases/download/v5.0.0/mirage-kv-5.0.0.tbz)
   (checksum
-   sha256=1036d74392461017ca8d9e32ccf94a5be6e03a056fa9ee551d4a7f49f6385462)))
+   sha512=f5acef8f8deedf5489e66fe5a088b468e1e691287f67563081564e3d66ad20c542dd600b3a0b118bc3d3d76bd91656ecb1fa31e9645fe9f6b224280a0876d939)))

--- a/dune.lock/mirage-net.4.0.0.pkg
+++ b/dune.lock/mirage-net.4.0.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/mirage-net/releases/download/v4.0.0/mirage-net-v4.0.0.tbz)
   (checksum
-   sha256=668effd187b81a0ab32450870c15dbb89ff911397ff338a8951807e250e194ce)))
+   sha512=52064dc704ebd0d305fd234b6d89fc313d5a80016d8875ef93212a1962ad8b1f332f7b0338244afbb2d2f207a28d476e7d7639be9dc607d95145afee7fccc483)))

--- a/dune.lock/mirage-profile.0.9.1.pkg
+++ b/dune.lock/mirage-profile.0.9.1.pkg
@@ -12,4 +12,4 @@
   (url
    https://github.com/mirage/mirage-profile/releases/download/v0.9.1/mirage-profile-v0.9.1.tbz)
   (checksum
-   sha256=2bb6cf03c73c6f45dedc34365c9131b8bdda62390b04d26eb76793a6422a0352)))
+   sha512=23cc4a2a62f5cc05b48d626bd6c8171a442fd46490da6810b1c507fcd7661c7fcd901d8328cddf687af4144136bf0d34b63f8484e32550077ab63d23e6eaea2b)))

--- a/dune.lock/mirage-random-stdlib.0.1.0.pkg
+++ b/dune.lock/mirage-random-stdlib.0.1.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/mirage-random-stdlib/releases/download/v0.1.0/mirage-random-stdlib-v0.1.0.tbz)
   (checksum
-   sha256=51783442c9b97711715ce62a15bcbefd3b01ae32c737f998eede395bc2dbfda3)))
+   sha512=979f4eabe61e97ceb84f6c0dddc03e2c46b404a8786fce3913feb2351369b8e755a1b737aa2d13db5abade72439186b04774ca892fe2b7f28b386fe6846d443a)))

--- a/dune.lock/mirage-random.3.0.0.pkg
+++ b/dune.lock/mirage-random.3.0.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/mirage-random/releases/download/v3.0.0/mirage-random-v3.0.0.tbz)
   (checksum
-   sha256=49fe3f281d6430cc1723ecabe47fc9b8e9b29d83cd5f0964f5d000fa014066cf)))
+   sha512=5d16855740e04f8efe5bcd5a7596ccffb5b927a616c5e6de4a5f5bd96e2f9f8f3b030d8b216156cac897d49a64b0f5bd7f89c30c787c3d9be63ab952c9984160)))

--- a/dune.lock/mirage-runtime.3.10.8.pkg
+++ b/dune.lock/mirage-runtime.3.10.8.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/mirage/releases/download/v3.10.8/mirage-v3.10.8.tbz)
   (checksum
-   sha256=135d86ca74e68ddb61d4ef304d43fb951a10b7cbc488bf3d638fca4294016fb4)))
+   sha512=beaaa4e238bd5d785f073e62c3ebaa71a1f0e7f7287be73106ba5c20f3b3bc6cfe6825700521ce39dfed92f12857296a9137673e89e112d1461df02df070a6ca)))

--- a/dune.lock/mirage-stack.4.0.0.pkg
+++ b/dune.lock/mirage-stack.4.0.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/mirage-stack/releases/download/v4.0.0/mirage-stack-v4.0.0.tbz)
   (checksum
-   sha256=abbd33190bd3e4a4eabcbdfb6d98d20fc4aed0fef628251eb327d625c23cccfc)))
+   sha512=83f121a22ce7a00aa2fc01d88603dafb6dd8d4cff0a2a9c6f73d8b1626aa43604ab797c793689190035289d2d00c77a60aa8d1b9f8fa66425dd19a08e7ccd518)))

--- a/dune.lock/mirage-time.3.0.0.pkg
+++ b/dune.lock/mirage-time.3.0.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/mirage-time/releases/download/v3.0.0/mirage-time-v3.0.0.tbz)
   (checksum
-   sha256=0d40949b58e2c7e8b762ccc8ce066345046233c8c95d0e3d17a242ff289cbd7c)))
+   sha512=066f9271c7871eb754cf9b3f8853f4861ce80d1cc31eb9a2384f3cd62441e15aa7636d19cc3bee6d56219fa5653b9f7da7d9b9d659fd1f7cd17326e7ba1715eb)))

--- a/dune.lock/mirage-vnetif.0.5.0.pkg
+++ b/dune.lock/mirage-vnetif.0.5.0.pkg
@@ -28,4 +28,4 @@
   (url
    https://github.com/mirage/mirage-vnetif/releases/download/v0.5.0/mirage-vnetif-v0.5.0.tbz)
   (checksum
-   sha256=b85460222a780c9b99151b40a00cf57c29bd865baa63d702f997891d8ae3f832)))
+   sha512=7889d12b35647868bea34ecd8fd1976411f2e74bc0b97b49e9b0eafca67ca2c37f2fd360afc3362d447f9b93445e888d52f4da484bece86ecb4075bb6e225491)))

--- a/dune.lock/num.1.6.pkg
+++ b/dune.lock/num.1.6.pkg
@@ -28,4 +28,4 @@
  (fetch
   (url https://github.com/ocaml/num/archive/refs/tags/v1.6.tar.gz)
   (checksum
-   sha256=b5cce325449aac746d5ca963d84688a627cca5b38d41e636cf71c68b60495b3e)))
+   sha512=5cb32dfa9a9f0ad375bfd89079e9b1422979f3c089f61ef2300ad9cc64fb1fc25ed1f86b0267eb017f12ae41a574a959df5bfa39ab22c2be2f1ac84c3c671bdf)))

--- a/dune.lock/ocaml-base-compiler.4.14.3.pkg
+++ b/dune.lock/ocaml-base-compiler.4.14.3.pkg
@@ -18,36 +18,10 @@
       (progn
        (run
         ./configure
-        (when
-         (catch_undefined_var
-          (and_absorb_undefined_var
-           %{pkg:system-msvc:installed}
-           %{pkg:arch-x86_64:installed})
-          false)
-         --host=x86_64-pc-windows)
-        (when
-         (catch_undefined_var
-          (and_absorb_undefined_var
-           (= %{os_distribution} cygwin)
-           %{pkg:system-mingw:installed}
-           %{pkg:arch-x86_64:installed})
-          false)
-         --host=x86_64-w64-mingw32)
-        (when
-         (catch_undefined_var
-          (and_absorb_undefined_var
-           %{pkg:system-msvc:installed}
-           %{pkg:arch-x86_32:installed})
-          false)
-         --host=i686-pc-windows)
-        (when
-         (catch_undefined_var
-          (and_absorb_undefined_var
-           (= %{os_distribution} cygwin)
-           %{pkg:system-mingw:installed}
-           %{pkg:arch-x86_32:installed})
-          false)
-         --host=i686-w64-mingw32)
+        (when false "")
+        (when false "")
+        (when false "")
+        (when false "")
         --prefix=%{prefix}
         --docdir=%{doc}/ocaml
         -C)
@@ -62,36 +36,10 @@
       (progn
        (run
         ./configure
-        (when
-         (catch_undefined_var
-          (and_absorb_undefined_var
-           %{pkg:system-msvc:installed}
-           %{pkg:arch-x86_64:installed})
-          false)
-         --host=x86_64-pc-windows)
-        (when
-         (catch_undefined_var
-          (and_absorb_undefined_var
-           (= %{os_distribution} cygwin)
-           %{pkg:system-mingw:installed}
-           %{pkg:arch-x86_64:installed})
-          false)
-         --host=x86_64-w64-mingw32)
-        (when
-         (catch_undefined_var
-          (and_absorb_undefined_var
-           %{pkg:system-msvc:installed}
-           %{pkg:arch-x86_32:installed})
-          false)
-         --host=i686-pc-windows)
-        (when
-         (catch_undefined_var
-          (and_absorb_undefined_var
-           (= %{os_distribution} cygwin)
-           %{pkg:system-mingw:installed}
-           %{pkg:arch-x86_32:installed})
-          false)
-         --host=i686-w64-mingw32)
+        (when false "")
+        (when false "")
+        (when false "")
+        (when false "")
         --prefix=%{prefix}
         --docdir=%{doc}/ocaml
         -C

--- a/dune.lock/ocaml-compiler-libs.v0.12.4.pkg
+++ b/dune.lock/ocaml-compiler-libs.v0.12.4.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/janestreet/ocaml-compiler-libs/releases/download/v0.12.4/ocaml-compiler-libs-v0.12.4.tbz)
   (checksum
-   sha256=4ec9c9ec35cc45c18c7a143761154ef1d7663036a29297f80381f47981a07760)))
+   sha512=978dba8dfa61f98fa24fda7a9c26c2e837081f37d1685fe636dc19cfc3278a940cf01a10293504b185c406706bc1008bc54313d50f023bcdea6d5ac6c0788b35)))

--- a/dune.lock/ocaml-syntax-shims.1.0.0.pkg
+++ b/dune.lock/ocaml-syntax-shims.1.0.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/ocaml-ppx/ocaml-syntax-shims/releases/download/1.0.0/ocaml-syntax-shims-1.0.0.tbz)
   (checksum
-   sha256=89b2e193e90a0c168b6ec5ddf6fef09033681bdcb64e11913c97440a2722e8c8)))
+   sha512=75c4c6b0bfa1267a8a49a82ba494d08cf0823fc8350863d6d3d4971528cb09e5a2a29e2981d04c75e76ad0f49360b05a432c9efeff9a4fbc1ec6b28960399852)))

--- a/dune.lock/ocamlfind.1.9.8+dune.pkg
+++ b/dune.lock/ocamlfind.1.9.8+dune.pkg
@@ -43,4 +43,5 @@
  (fetch
   (url
    https://github.com/ocaml/ocamlfind/archive/refs/tags/findlib-1.9.8.tar.gz)
-  (checksum md5=ca770e5806032a96131b670f6e07f146)))
+  (checksum
+   sha512=8967986de2ab4ec5993f437b0a4206742adf37aa7a292a3bba0a04438d78539b84d001191e60b2d5bde98a695b38cba2593b7051f7749adbdb964a0df3c4b661)))

--- a/dune.lock/ocplib-endian.1.2.pkg
+++ b/dune.lock/ocplib-endian.1.2.pkg
@@ -12,4 +12,5 @@
  (fetch
   (url
    https://github.com/OCamlPro/ocplib-endian/archive/refs/tags/1.2.tar.gz)
-  (checksum md5=8d5492eeb7c6815ade72a7415ea30949)))
+  (checksum
+   sha512=2e70be5f3d6e377485c60664a0e235c3b9b24a8d6b6a03895d092c6e40d53810bfe1f292ee69e5181ce6daa8a582bfe3d59f3af889f417134f658812be5b8b85)))

--- a/dune.lock/ounit.2.2.7.pkg
+++ b/dune.lock/ounit.2.2.7.pkg
@@ -13,4 +13,4 @@
   (url
    https://github.com/gildor478/ounit/releases/download/v2.2.7/ounit-2.2.7.tbz)
   (checksum
-   sha256=90f6e63bd1240a51d8b9b2f722059bd79ce00b5276bdd6238b8f5c613c0e7388)))
+   sha512=53463e5b1b5a40f424e19f5f6a86338a544079600d1fd121ffc1a6fcaa239630194018faf91ccf360ba40b1b2a8b01cf491935e014c68d2947f6e027a2f0a0f9)))

--- a/dune.lock/ounit2.2.2.7.pkg
+++ b/dune.lock/ounit2.2.2.7.pkg
@@ -13,4 +13,4 @@
   (url
    https://github.com/gildor478/ounit/releases/download/v2.2.7/ounit-2.2.7.tbz)
   (checksum
-   sha256=90f6e63bd1240a51d8b9b2f722059bd79ce00b5276bdd6238b8f5c613c0e7388)))
+   sha512=53463e5b1b5a40f424e19f5f6a86338a544079600d1fd121ffc1a6fcaa239630194018faf91ccf360ba40b1b2a8b01cf491935e014c68d2947f6e027a2f0a0f9)))

--- a/dune.lock/pcap-format.0.6.0.pkg
+++ b/dune.lock/pcap-format.0.6.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/ocaml-pcap/releases/download/v0.6.0/pcap-format-0.6.0.tbz)
   (checksum
-   sha256=2d48f2f179ba56c9ccab51472b398983bba8ae44efedc393b282f09ad34791a6)))
+   sha512=6c46b314b665eff3e46550e28a88f6de5370ed5299e88fa76f612330fa704bea5e436608e4f0eff489b444cc8b534e1f5710a0d92083469ec52f375d6435baf8)))

--- a/dune.lock/ppx_cstruct.6.0.1.pkg
+++ b/dune.lock/ppx_cstruct.6.0.1.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/ocaml-cstruct/releases/download/v6.0.1/cstruct-v6.0.1.tbz)
   (checksum
-   sha256=4a67bb8f042753453c59eabf0e47865631253ba694091ce6062aac05d47a9bed)))
+   sha512=3eeeb6ae0fd3b625cf1d308498f0a1e6951d16566561f3362fdf74e7158d92d8f6c6d9fa968ff15f8c19a1886dce99d0ef17b44dbb37b97cc68c9b088fdc2248)))

--- a/dune.lock/ppxlib.0.25.1.pkg
+++ b/dune.lock/ppxlib.0.25.1.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/ocaml-ppx/ppxlib/releases/download/0.25.1/ppxlib-0.25.1.tbz)
   (checksum
-   sha256=a51b3868029e62ff14a0f2bd8d278dacfc0c3fc5b22d484a296be90c53e4ffd7)))
+   sha512=6a6d9af49344e901cc9e6da7bcf38c2973705c8cee4cff1c64c0393e9ccc55a6abec1f58d5b56d0807939a3741bec722ee7bfc244f94619167a30438f182488a)))

--- a/dune.lock/protocol-9p.2.0.2.pkg
+++ b/dune.lock/protocol-9p.2.0.2.pkg
@@ -30,4 +30,4 @@
   (url
    https://github.com/mirage/ocaml-9p/releases/download/2.0.2/protocol-9p-2.0.2.tbz)
   (checksum
-   sha256=a4c0585e81f5c57c879560318016aeb022163044f2c7ae086af3dfcbbe1b8164)))
+   sha512=253bafb9a41d7e641d8f8c117de4a561f7b0a81dd7e54ab9ea322375818fe1e4d952bc7b4fdabc88cab30b2df082f0cf5c0764e5d63474c1ee43a8e3f591694e)))

--- a/dune.lock/psq.0.2.1.pkg
+++ b/dune.lock/psq.0.2.1.pkg
@@ -15,4 +15,4 @@
  (fetch
   (url https://github.com/pqwy/psq/releases/download/v0.2.1/psq-0.2.1.tbz)
   (checksum
-   sha256=42005f533eabe74b1799ee32b8905654cd66a22bed4af2bd266b28d8462cd344)))
+   sha512=8a8dfe20dc77e1cf38a7b1a7fc76f815c71a4ffe04627151b855feaba8f1ae742594739d1b7a45580b5b24a2cd99b58516f6b5c8d858aa314201f4a6422101ee)))

--- a/dune.lock/randomconv.0.1.3.pkg
+++ b/dune.lock/randomconv.0.1.3.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/hannesm/randomconv/releases/download/v0.1.3/randomconv-v0.1.3.tbz)
   (checksum
-   sha256=9b286aaac68fe3e5f69ed34115153ce74c613270a534b04642bae35934c863c7)))
+   sha512=f5186f7669a6b1b943442fdcfcdb37cf6c8199a1c644ed815f351f50428b9b7e1e5408ff4a0fcdfb093451b5237e48602af60f87a1b93e49897576c8aa2cd23f)))

--- a/dune.lock/re.1.12.0.pkg
+++ b/dune.lock/re.1.12.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/ocaml/ocaml-re/releases/download/1.12.0/re-1.12.0.tbz)
   (checksum
-   sha256=a01f2bf22f72c2f4ababd8d3e7635e35c1bf6bc5a41ad6d5a007454ddabad1d4)))
+   sha512=f0726826e1e677f7ecdf447d46d814a11d3844ec6e5c0527be8c73c7afdb08aacfca47ea764eda325bcd7064aff07c1d3441c935ee5a0fc99ede8707f81a451d)))

--- a/dune.lock/sha.1.15.4.pkg
+++ b/dune.lock/sha.1.15.4.pkg
@@ -31,4 +31,4 @@
   (url
    https://github.com/djs55/ocaml-sha/releases/download/v1.15.4/sha-1.15.4.tbz)
   (checksum
-   sha256=6de5b12139b1999ce9df4cc78a5a31886c2a547c9d448bf2853f8b53bcf1f1b1)))
+   sha512=dbb31b523ba0bace023bc1b0558a8f572a0ec20fb3f19f783935be755cd161e09aba352eda2bcf7c4e5ab838c7f874cfbfaed9debf0813df25d9dbe7b9314fdf)))

--- a/dune.lock/stdlib-shims.0.3.0.pkg
+++ b/dune.lock/stdlib-shims.0.3.0.pkg
@@ -12,4 +12,4 @@
   (url
    https://github.com/ocaml/stdlib-shims/releases/download/0.3.0/stdlib-shims-0.3.0.tbz)
   (checksum
-   sha256=babf72d3917b86f707885f0c5528e36c63fccb698f4b46cf2bab5c7ccdd6d84a)))
+   sha512=1151d7edc8923516e9a36995a3f8938d323aaade759ad349ed15d6d8501db61ffbe63277e97c4d86149cf371306ac23df0f581ec7e02611f58335126e1870980)))

--- a/dune.lock/stringext.1.6.0.pkg
+++ b/dune.lock/stringext.1.6.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/rgrinberg/stringext/releases/download/1.6.0/stringext-1.6.0.tbz)
   (checksum
-   sha256=db41f5d52e9eab17615f110b899dfeb27dd7e7f89cd35ae43827c5119db206ea)))
+   sha512=d8ebe40f42b598a9bd99f1ef4b00ba93458385a4accd121af66a0bf3b3f8d7135f576740adf1a43081dd409977c2219fd4bdbb5b3d1308890d301d553ed49900)))

--- a/dune.lock/tar.2.0.1.pkg
+++ b/dune.lock/tar.2.0.1.pkg
@@ -31,4 +31,4 @@
   (url
    https://github.com/mirage/ocaml-tar/releases/download/v2.0.1/tar-mirage-2.0.1.tbz)
   (checksum
-   sha256=e9565fb43dab9e944d1860f9a3b5c681df72211b859c66ee1d7085cafc13ee9b)))
+   sha512=e4486274b44e6b34540afc9893bc0f2b604ba01c576b01aeb0b494f30791a0c353d1809de62e2f0ae04de771a2391affb17b98b1fc6c0d2fc2e963741bc65a55)))

--- a/dune.lock/tcpip.7.1.2.pkg
+++ b/dune.lock/tcpip.7.1.2.pkg
@@ -40,4 +40,4 @@
   (url
    https://github.com/mirage/mirage-tcpip/releases/download/v7.1.2/tcpip-7.1.2.tbz)
   (checksum
-   sha256=96b6aeafa35f143f7275d1becb6d639472adf3680b8180416de765b6581c466d)))
+   sha512=3f873c986de5c58df72db2953c6b2a6319963dbbbd0781b55c2878fd1eaa081ebb7cecbee595db7cb3680a6f438904f98cb69ca17e70c7a6d2d1f61277e929bd)))

--- a/dune.lock/uri-sexp.4.4.0.pkg
+++ b/dune.lock/uri-sexp.4.4.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/ocaml-uri/releases/download/v4.4.0/uri-4.4.0.tbz)
   (checksum
-   sha256=cdabaf6ef5cd2161e59cc7b74c6e4a68ecb80a9f4e96002e338e1b6bf17adec4)))
+   sha512=88374143e0d8aaf6d40aa3cbd7593f9832e9c9727738c6e651498125150c83d5646e13b5737d5c3e81484dd041127f67f8acea13fdc0300ac4e46107559f8ae2)))

--- a/dune.lock/uri.4.4.0.pkg
+++ b/dune.lock/uri.4.4.0.pkg
@@ -16,4 +16,4 @@
   (url
    https://github.com/mirage/ocaml-uri/releases/download/v4.4.0/uri-4.4.0.tbz)
   (checksum
-   sha256=cdabaf6ef5cd2161e59cc7b74c6e4a68ecb80a9f4e96002e338e1b6bf17adec4)))
+   sha512=88374143e0d8aaf6d40aa3cbd7593f9832e9c9727738c6e651498125150c83d5646e13b5737d5c3e81484dd041127f67f8acea13fdc0300ac4e46107559f8ae2)))


### PR DESCRIPTION
Since we have a lock committed, its perfectly possible to directly use Dune package management without having to set up an OPAM switch.

This PR adds the instructions for the user on how to use it.

Also, in a separate commit, updates the lock dir, since the dependencies changed in #671 and I broke it. Will open a PR later on to make sure this doesn't happen in the future.

cc @djs55