### PR TITLE
Update archive repo to allow using Dune 3.23

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,7 +1,7 @@
 FROM ocaml/opam:alpine-3.23-ocaml-4.14 AS build
 RUN sudo ln -sf /usr/bin/opam-2.5 /usr/bin/opam && \
   opam init --reinit -ni
-RUN opam repo add archive git+https://github.com/ocaml/opam-repository-archive --all
+RUN opam repo add archive-without-constraint git+https://github.com/tarides/moby-vpnkit-opam-repository-archive#remove-dune-upper-constraint --all
 
 ADD . /home/opam/vpnkit
 RUN sudo chown opam:opam -R vpnkit
@@ -15,4 +15,4 @@ RUN opam exec -- dune build @runtest @e2e
 
 # we're not interested in the intermediate artifacts
 FROM scratch
-COPY --from=build /home/opam/vpnkit/_build/log /
+COPY --from=build /home/opam/vpnkit/_build/trace.csexp /


### PR DESCRIPTION
This also updates the log file reading since Dune writes information to a trace file nowadays and that is where the relevant information can be extracted from.

cc @djs55