### PR TITLE
Remove redundant `@runtest` addition

### DIFF
--- a/src/dns_test/dune
+++ b/src/dns_test/dune
@@ -3,7 +3,3 @@
   (libraries  dns ounit2 pcap-format bigarray bigarray-compat lwt)
   (deps       (glob_files *.pcap) (glob_files *.zone))
   (preprocess (pps ppx_cstruct)))
-
-(rule
- (alias  runtest)
- (action (run ./test.exe)))


### PR DESCRIPTION
The `test` stanza already adds the test to the `@runtest` alias, adding it twice runs it twice.

The second definition is lacking the dependencies thus the tests might fail (missing `.pcap` files) if ran in the wrong order (or sandboxing isolates the rules), so deleting it is the right thing to do.

cc @djs55