### PR TITLE
Make `rev-parse` safer by defining dependency on `.git` folder

### DIFF
--- a/dune
+++ b/dune
@@ -1,3 +1,5 @@
+(data_only_dirs .git)
+
 (rule
  (alias e2e)
  (deps src/hostnet_test/main.exe

--- a/src/bin/dune
+++ b/src/bin/dune
@@ -23,6 +23,9 @@
 
 (rule
   (target version.ml)
+  (deps
+    (glob_files_rec %{project_root}/.git/**)
+    (sandbox preserve_file_kind))
   (action
     (with-stdout-to %{target}
-                    (system "git rev-parse HEAD | xargs printf 'let git = \"%s\"'"))))
+                    (system "git -C %{project_root} rev-parse HEAD | xargs printf 'let git = \"%s\"'"))))


### PR DESCRIPTION
Running `rev-parse` is only possible when a `.git` folder exists (which is a problem at the moment), thus the rule needs to define a dependency on the `.git` folder. If not declared, this breaks the build if sandboxing is enabled as in https://github.com/ocaml/dune/issues/14723.

This change adds that dependency and makes sure to run `rev-parse` with the right path.

cc @djs55 