### PR TITLE
Add Github action to build and run tests with `dune pkg`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,11 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: ocaml-dune/setup-dune@v2
+        with:
+          workspace: dune-workspace.ci
 
       - name: Build the project
-        run: dune build @install --release --only-packages vpnkit --display=short
+        run: dune build --workspace=dune-workspace.ci @install --release --only-packages vpnkit --display=short
 
       - name: Release a tarball of build outputs
         run: |

--- a/.github/workflows/tests-with-dune-pkg.yaml
+++ b/.github/workflows/tests-with-dune-pkg.yaml
@@ -1,0 +1,24 @@
+name: test with dune pkg
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        runs-on: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+    - name: Check out sources
+      uses: actions/checkout@v6
+    - name: Install and test
+      uses: ocaml-dune/setup-dune@v2
+      with:
+        workspace: dune-workspace.ci

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Alternatively you can use Dune package management to download and install the
 dependencies automatically:
 
 ```
-dune build --pkg=enabled
+dune build --workspace=dune-workspace.ci
 ```
 
 When the build succeeds the `vpnkit` binary should be available in
@@ -55,12 +55,8 @@ When the build succeeds the `vpnkit` binary should be available in
 You can also automatically build and execute the `vpnkit` binary:
 
 ```
-dune exec --pkg=enabled vpnkit
+dune exec --workspace=dune-workspace.ci vpnkit
 ```
-
-If you want to enable Dune package management by default (and avoid having to
-specify `--pkg=enabled`) you can edit the `dune-workspace` and remove the `(pkg
-disabled)` line.
 
 ## Building on Windows
 

--- a/dune-workspace
+++ b/dune-workspace
@@ -1,10 +1,3 @@
 (lang dune 3.23)
 
-(repository
- (name archive-without-constraint)
- (url git+https://github.com/tarides/moby-vpnkit-opam-repository-archive#remove-dune-upper-constraint))
-
-(lock_dir
- (repositories upstream overlay archive-without-constraint))
-
 (pkg disabled)

--- a/dune-workspace.ci
+++ b/dune-workspace.ci
@@ -1,0 +1,11 @@
+(lang dune 3.23)
+
+(repository
+ (name archive-without-constraint)
+ (url git+https://github.com/tarides/moby-vpnkit-opam-repository-archive#remove-dune-upper-constraint))
+
+(lock_dir
+ (repositories upstream overlay archive-without-constraint))
+
+(pkg enabled)
+


### PR DESCRIPTION
This PR adds an action that uses `setup-dune` to build the source code and run the tests on ever push to `master` and on every PR. `setup-dune` does a good job caching the dune build cache, thus the CI runs with a warm cache only take a few seconds.

This also prevents the lockfile from getting outdated, as in such case the Github action will fail and the error message will state that the project dependencies declared in the OPAM file and the committed lock file don't match.

A successful run of the action can be seen in https://github.com/tarides/moby-vpnkit/pull/1 where it sets up the dependencies, builds the project and runs the tests successfully, both on Ubuntu and macOS.

This PR disables `dune pkg` by default and makes it an opt-in feature via `dune-workspace.ci`, to not interfere with potentially existing OPAM workflows.

The previous PRs, #674 and #675 fixed the build issues (mostly missing build dependencies) that were discovered preparing this PR.

cc @djs55