### PR TITLE
Add `dune-build-info` as a dependency to OPAM

### DIFF
--- a/vpnkit.opam
+++ b/vpnkit.opam
@@ -25,6 +25,7 @@ bug-reports: "https://github.com/moby/vpnkit/issues"
 depends: [
   "dune" {>= "3.23"}
   "ocaml" {>= "4.08.0"}
+  "dune-build-info"
   "alcotest" {with-test}
   "ounit" {with-test}
   "tar" {>= "1.0.1"}


### PR DESCRIPTION
#677 was missing a re-generated OPAM file (and thus missing the `dune-build-info` dependency), this PR adds it. It should fix the `dune pkg` test.

cc @djs55